### PR TITLE
Factor out creation of clang::CodeGenerator

### DIFF
--- a/header-rewriter/CMakeLists.txt
+++ b/header-rewriter/CMakeLists.txt
@@ -12,6 +12,7 @@ add_definitions(${CLANG_DEFINITIONS} ${LLVM_DEFINITIONS})
 include_directories(${CLANG_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS})
 
 add_executable(ia2-header-rewriter
+    CreateCodeGenerator.cpp
     HeaderRewriter.cpp
     DetermineAbi.cpp
     GenCallAsm.cpp

--- a/header-rewriter/CreateCodeGenerator.cpp
+++ b/header-rewriter/CreateCodeGenerator.cpp
@@ -1,0 +1,20 @@
+#include "clang/AST/AST.h"
+#include "clang/Basic/CodeGenOptions.h"
+#include "clang/CodeGen/ModuleBuilder.h"
+#include "clang/Lex/HeaderSearchOptions.h"
+#include "clang/Lex/PreprocessorOptions.h"
+#include "llvm/IR/LLVMContext.h"
+
+clang::CodeGenerator *createCodeGenerator(clang::ASTContext &astContext) {
+  // Set up context in order to create a CodeGenerator, which will be used
+  // to query function ABI
+  clang::HeaderSearchOptions hso;
+  clang::PreprocessorOptions ppo;
+  clang::CodeGenOptions cgo;
+  llvm::LLVMContext llvmCtx;
+  clang::CodeGenerator *codeGenerator = CreateLLVMCodeGen(
+    astContext.getDiagnostics(), llvm::StringRef(), hso, ppo, cgo, llvmCtx);
+
+  codeGenerator->Initialize(astContext);
+  return codeGenerator;
+}

--- a/header-rewriter/CreateCodeGenerator.h
+++ b/header-rewriter/CreateCodeGenerator.h
@@ -1,0 +1,4 @@
+#include "clang/AST/AST.h"
+#include "clang/CodeGen/ModuleBuilder.h"
+
+clang::CodeGenerator *createCodeGenerator(clang::ASTContext &astContext);

--- a/header-rewriter/DetermineAbi.h
+++ b/header-rewriter/DetermineAbi.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "CAbi.h"
 #include "clang/AST/AST.h"
+#include "clang/CodeGen/ModuleBuilder.h"
 
-auto determineAbiForDecl(const clang::FunctionDecl &fnDecl) -> CAbiSignature;
+auto determineAbiForDecl(const clang::FunctionDecl &fnDecl, clang::CodeGen::CodeGenModule &cgm) -> CAbiSignature;


### PR DESCRIPTION
With the intent of addressing #75, which was to follow @rinon's [recommendation](https://github.com/immunant/IA2-Phase2/pull/34#discussion_r804087357).

Unfortunately, this doesn't seem to work:
```
Program received signal SIGSEGV, Segmentation fault.
0x00007fffef190491 in llvm::StructType::create(llvm::LLVMContext&) () from /usr/lib/libLLVM-13.so
(gdb) bt
#0  0x00007fffef190491 in llvm::StructType::create(llvm::LLVMContext&) () from /usr/lib/libLLVM-13.so
#1  0x00007ffff672cfdd in clang::CodeGen::CodeGenTypes::ConvertRecordDeclType(clang::RecordDecl const*) () from /usr/lib/libclang-cpp.so.13
#2  0x00007ffff672d426 in clang::CodeGen::CodeGenTypes::ConvertType(clang::QualType) () from /usr/lib/libclang-cpp.so.13
#3  0x00007ffff6783d16 in ?? () from /usr/lib/libclang-cpp.so.13
#4  0x00007ffff64d9e44 in clang::CodeGen::CodeGenTypes::arrangeLLVMFunctionInfo(clang::CanQual<clang::Type>, bool, bool, llvm::ArrayRef<clang::CanQual<clang::Type> >, clang::FunctionType::ExtInfo, llvm::ArrayRef<clang::FunctionType::ExtParameterInfo>, clang::CodeGen::RequiredArgs) () from /usr/lib/libclang-cpp.so.13
#5  0x00007ffff668de34 in clang::CodeGen::arrangeFreeFunctionType(clang::CodeGen::CodeGenModule&, clang::CanQual<clang::FunctionProtoType>) () from /usr/lib/libclang-cpp.so.13
#6  0x00005555555d4721 in cgFunctionInfo (cgm=..., fnDecl=...) at header-rewriter/DetermineAbi.cpp:175
#7  0x00005555555d47f4 in determineAbiForDecl (fnDecl=..., cgm=...) at header-rewriter/DetermineAbi.cpp:191
#8  0x0000555555596c5b in FnDecl::run (this=0x7fffffffd6a0, Result=...) at header-rewriter/HeaderRewriter.cpp:262
#9  0x00007ffff73881d7 in ?? () from /usr/lib/libclang-cpp.so.13
#10 0x00007ffff5d4e23c in ?? () from /usr/lib/libclang-cpp.so.13
#11 0x00007ffff5d4e35c in ?? () from /usr/lib/libclang-cpp.so.13
#12 0x00007ffff5d7cbaa in ?? () from /usr/lib/libclang-cpp.so.13
#13 0x00007ffff5d7ecf0 in ?? () from /usr/lib/libclang-cpp.so.13
#14 0x00007ffff5d4972f in clang::ast_matchers::MatchFinder::matchAST(clang::ASTContext&) () from /usr/lib/libclang-cpp.so.13
#15 0x00007ffff6dee1ab in ?? () from /usr/lib/libclang-cpp.so.13
#16 0x00007ffff572719a in clang::ParseAST(clang::Sema&, bool, bool) () from /usr/lib/libclang-cpp.so.13
#17 0x00007ffff6cb0f79 in clang::FrontendAction::Execute() () from /usr/lib/libclang-cpp.so.13
#18 0x00007ffff6c572cf in clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) () from /usr/lib/libclang-cpp.so.13
#19 0x00007ffff6e0d31b in clang::tooling::FrontendActionFactory::runInvocation(std::shared_ptr<clang::CompilerInvocation>, clang::FileManager*, std::shared_ptr<clang::PCHContainerOperations>, clang::DiagnosticConsumer*) ()
   from /usr/lib/libclang-cpp.so.13
#20 0x00007ffff6e03697 in clang::tooling::ToolInvocation::runInvocation(char const*, clang::driver::Compilation*, std::shared_ptr<clang::CompilerInvocation>, std::shared_ptr<clang::PCHContainerOperations>) () from /usr/lib/libclang-cpp.so.13
#21 0x00007ffff6e0c5f9 in clang::tooling::ToolInvocation::run() () from /usr/lib/libclang-cpp.so.13
#22 0x00007ffff6e0e1e6 in clang::tooling::ClangTool::run(clang::tooling::ToolAction*) () from /usr/lib/libclang-cpp.so.13
#23 0x00007ffff6dee0fd in clang::tooling::RefactoringTool::runAndSave(clang::tooling::FrontendActionFactory*) () from /usr/lib/libclang-cpp.so.13
#24 0x0000555555584667 in main (argc=5, argv=0x7fffffffddd8) at header-rewriter/HeaderRewriter.cpp:608
```

(For context, I observe a single call to `onStartOfTranslationUnit` and no calls to `onEndOfTranslationUnit` by the point at which this segfault occurs. I think the issue is in reusing a `clang::CodeGenerator` for multiple different `ASTContext`s (from multiple function declarations). I tried calling `codeGenerator->Initialize(...)` with the `ASTContext` of each `fn_decl` as an argument prior to each call to `determineAbiForDecl`, but that still crashed.

Any thoughts? The docs don't show any `Deinitialize`/`Reset`/etc. method that seems likely to be required, so I'm wondering if we're grasping for an API usage flow that just isn't supported.

Why do we expect this to be a bottleneck (@rinon)?