### PR TITLE
Remove the need to compile wrappers with `-I rewritten_header_dir`

### DIFF
--- a/header-rewriter/HeaderRewriter.cpp
+++ b/header-rewriter/HeaderRewriter.cpp
@@ -194,7 +194,6 @@ public:
         if (addHeaderImport(header_name, OutputHeader)) {
           return;
         }
-        WrapperOut << llvm::formatv("#include \"{0}\"\n", header_name);
         InitializedHeaders.push_back(header_ref);
       }
 
@@ -270,7 +269,7 @@ public:
 
       // Generate wrapper symbol definition, invoking call gates around call
       WrapperOut << llvm::formatv(
-          "{0}({1});\n"
+          "// {0}({1});\n"
           "asm(\n"
           "{2}\n"
           ");\n\n",
@@ -558,8 +557,7 @@ int main(int argc, const char **argv) {
     return EC.value();
   }
 
-  wrapper_out << "#define IA2_WRAPPER\n"
-              << "#include <ia2.h>\n"
+  wrapper_out << "#include <ia2.h>\n"
               << "#ifndef CALLER_PKEY\n"
               << "#error CALLER_PKEY must be defined to compile this file\n"
               << "#endif\n";

--- a/include/ia2.h
+++ b/include/ia2.h
@@ -8,11 +8,7 @@
 // Attribute for variables that can be accessed from any untrusted compartments.
 #define IA2_SHARED_DATA __attribute__((section("ia2_shared_data")))
 
-#ifdef IA2_WRAPPER
-#define IA2_WRAP_FUNCTION(name)
-#else
 #define IA2_WRAP_FUNCTION(name) __asm__(".symver " #name ",__ia2_" #name "@IA2")
-#endif
 
 #define XSTR(s) STR(s)
 #define STR(s) #s


### PR DESCRIPTION
This commit gets us most of the benefits in issue #90 but doesn't reformat the
wrappers as .S files because the stacks are still defined in the wrapper sources
on the main branch. After moving the stack definitions (PR #88) the wrappers can
be reformatted though it's only a slight benefit at that point since it'll
only remove the need to add `-I ia2_h_dir`.