### PR TITLE
Declare padding sections from inline asm in insecure mode

### DIFF
--- a/header-rewriter/tests/minimal/include/minimal.h
+++ b/header-rewriter/tests/minimal/include/minimal.h
@@ -3,7 +3,12 @@ RUN: cp %s %t.h
 RUN: ia2-header-rewriter %t.c %t.h -- -I%resource_dir
 RUN: cat %t.h | sed 's/^.*CHECK.*$//' | FileCheck %s
 RUN: %binary_dir/tests/minimal/minimal-main | diff %S/../Output/minimal.out -
+RUN: readelf -lW %binary_dir/tests/minimal/minimal-main | FileCheck --check-prefix=SEGMENTS %s
 */
+
+// Check that readelf shows exactly one executable segment
+// SEGMENTS-COUNT-1: LOAD{{.*}}R E
+// SEGMENTS-NOT:     LOAD{{.*}}R E
 
 #pragma once
 

--- a/header-rewriter/tests/two_keys_minimal/include/main/exported_fn.h
+++ b/header-rewriter/tests/two_keys_minimal/include/main/exported_fn.h
@@ -5,7 +5,14 @@ RUN: cat %t.h | sed 's/^.*CHECK.*$//' | FileCheck %s
 RUN: %binary_dir/tests/two_keys_minimal/two_keys_minimal-main plugin | diff %binary_dir/tests/two_keys_minimal/plugin.out -
 RUN: %binary_dir/tests/two_keys_minimal/two_keys_minimal-main main | diff %binary_dir/tests/two_keys_minimal/main.out -
 TODO: %binary_dir/tests/two_keys_minimal/two_keys_minimal-main clean_exit | diff %source_dir/tests/two_keys_minimal/Output/clean_exit.out -
+RUN: readelf -lW %binary_dir/tests/two_keys_minimal/two_keys_minimal-main | FileCheck --check-prefix=SEGMENTS %s
+RUN: readelf -lW %binary_dir/tests/two_keys_minimal/libtwo_keys_minimal-original.so | FileCheck --check-prefix=SEGMENTS %s
 */
+
+// Check that readelf shows exactly one executable segment
+// SEGMENTS-COUNT-1: LOAD{{.*}}R E
+// SEGMENTS-NOT:     LOAD{{.*}}R E
+
 #pragma once
 #include <stdint.h>
 #include <stdbool.h>

--- a/include/ia2.h
+++ b/include/ia2.h
@@ -20,7 +20,7 @@
 
 #define INIT_RUNTIME(n) _INIT_RUNTIME(n + 1)
 #ifdef LIBIA2_INSECURE
-#define INIT_COMPARTMENT(n)
+#define INIT_COMPARTMENT(n) DECLARE_PADDING_SECTIONS
 #define IA2_WRPKRU
 #else
 #define INIT_COMPARTMENT(n) _INIT_COMPARTMENT(n)
@@ -99,6 +99,12 @@
           "\n"                                                                 \
           ".previous");
 
+#define DECLARE_PADDING_SECTIONS                                               \
+  NEW_SECTION(".fini_padding");                                                \
+  NEW_SECTION(".rela.plt_padding");                                            \
+  NEW_SECTION(".eh_frame_padding");                                            \
+  NEW_SECTION(".bss_padding");
+
 // Ensure that all required pkeys are allocated.
 void ensure_pkeys_allocated(int *n_to_alloc) {
   if (*n_to_alloc != 0) {
@@ -114,14 +120,11 @@ void ensure_pkeys_allocated(int *n_to_alloc) {
 }
 
 // Initializes a compartment with protection key `n` when the ELF invoking this
-// macro is loaded. This must only be called once for each key. The copmartment
+// macro is loaded. This must only be called once for each key. The compartment
 // includes all segments in the ELF except the `ia2_shared_data` section, if one
 // exists.
 #define _INIT_COMPARTMENT(n)                                                   \
-  NEW_SECTION(".fini_padding");                                                \
-  NEW_SECTION(".rela.plt_padding");                                            \
-  NEW_SECTION(".eh_frame_padding");                                            \
-  NEW_SECTION(".bss_padding");                                                 \
+  DECLARE_PADDING_SECTIONS;                                                    \
   extern int ia2_n_pkeys_to_alloc;                                             \
   __attribute__((constructor)) static void init_pkey_ctor() {                  \
     ensure_pkeys_allocated(&ia2_n_pkeys_to_alloc);                             \


### PR DESCRIPTION
When the padding sections are defined in the linker script we use to pad and
page-align trusted compartments, their (and the corresponding segment's)
permission defaults to RWE. By defining padding sections in inline asm each
section inherits its segment's permission. We were previously not doing this
correctly in insecure mode, which meant that trusted binaries had more
executable segments than necessary. We may want to use executable segments
to minimize the number of comparisons at each call gate when implementing
dynamic compartment permissions for function pointers (#107).