### PR TITLE
Remove duplicate definitions in test_fault_handler.h

### DIFF
--- a/header-rewriter/tests/should_segfault/main.c
+++ b/header-rewriter/tests/should_segfault/main.c
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include <print_secret.h>
 #include <ia2.h>
+#define IA2_DEFINE_TEST_HANDLER
+#include "test_fault_handler.h"
 
 INIT_RUNTIME(1);
 INIT_COMPARTMENT(1);

--- a/header-rewriter/tests/trusted_direct/main.c
+++ b/header-rewriter/tests/trusted_direct/main.c
@@ -3,6 +3,8 @@
 #include <unistd.h>
 #include <ia2.h>
 #include "plugin.h"
+#define IA2_DEFINE_TEST_HANDLER
+#include "test_fault_handler.h"
 
 // This test checks that an untrusted library can call a trusted main binary. An
 // MPK violation is triggered from the untrusted library if no arguments are

--- a/header-rewriter/tests/trusted_indirect/main.c
+++ b/header-rewriter/tests/trusted_indirect/main.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include "rand_op.h"
 #include <ia2.h>
+#define IA2_DEFINE_TEST_HANDLER
+#include "test_fault_handler.h"
 
 /*
     This program tests that a trusted binary can receive and call function pointers from an

--- a/header-rewriter/tests/two_keys_minimal/main.c
+++ b/header-rewriter/tests/two_keys_minimal/main.c
@@ -2,6 +2,7 @@
 #include <unistd.h>
 #include <ia2.h>
 #include "plugin.h"
+#define IA2_DEFINE_TEST_HANDLER
 #include "test_fault_handler.h"
 
 // This test uses two protection keys

--- a/header-rewriter/tests/untrusted_indirect/main.c
+++ b/header-rewriter/tests/untrusted_indirect/main.c
@@ -2,6 +2,8 @@
 #include <stdint.h>
 #include "foo.h"
 #include "untrusted_indirect-original_fn_ptr_ia2.h"
+#define IA2_DEFINE_TEST_HANDLER
+#include "test_fault_handler.h"
 
 INIT_RUNTIME(1);
 INIT_COMPARTMENT(1);


### PR DESCRIPTION
We were previously (even before #119) defining the same variables multiple times in different shared objects in our testing framework. This worked out because we happened to include "test_fault_handler.h" in main.c in all tests that used it, so those definitions were being used. This wouldn't have worked with the variables defined in other shared objects because we currently don't support defining shared data from arbitrary compartments #113 .

This removes that issue by using `#ifdef`s to ensure that variables in test_fault_handler.h are only defined once. It also makes sure that functions are also defined once, though that was less of an issue. I added an explanation on how to use the test handler and modified the tests which required changes. This didn't fix any failing tests in #117, but I wanted to make sure our testing framework is sound before continuing to debug those.