### PR TITLE
Make names for manually defined direct call wrappers unique

### DIFF
--- a/header-rewriter/GenCallAsm.cpp
+++ b/header-rewriter/GenCallAsm.cpp
@@ -351,8 +351,14 @@ std::string emit_asm_wrapper(const CAbiSignature &sig, const std::string &name,
   } else if (as_macro) {
     // This is for IA2_DEFINE_WRAPPER
     add_asm_line(aw, ".text 1");
-    add_raw_line(aw, "\".global __ia2_\" #target \"\\n\"");
-    add_raw_line(aw, "\"__ia2_\" #target \":\\n\"");
+    add_asm_line(aw, llvm::formatv(".global __ia2_{0}_{1}_{2}",
+                                   asm_macro_expansion("target"),
+                                   asm_macro_expansion(caller_pkey),
+                                   asm_macro_expansion(target_pkey)));
+    add_asm_line(
+        aw, llvm::formatv("__ia2_{0}_{1}_{2}:", asm_macro_expansion("target"),
+                          asm_macro_expansion(caller_pkey),
+                          asm_macro_expansion(target_pkey)));
   } else {
     // This is for wrappers defined in the shims
     add_asm_line(aw, ".text");

--- a/header-rewriter/tests/global_fn_ptr/main.c
+++ b/header-rewriter/tests/global_fn_ptr/main.c
@@ -14,21 +14,21 @@ IA2_DEFINE_WRAPPER(mul, _ZTSPFjjjE, 1);
 
 // `sum` can't be set to __ia2_add since it's defined in asm so the compiler doesn't know it's a valid initializer
 //static WordFn sum = __ia2_add;
-static WordFn sum = IA2_WRAPPER(add);
-static HalfFn diff = IA2_WRAPPER(sub);
+static WordFn sum = IA2_WRAPPER(add, 1);
+static HalfFn diff = IA2_WRAPPER(sub, 1);
 // The following won't compile since the inner pointer is also type-specific
-//static HalfFn mul = {&__ia2_mul};
+//static HalfFn mul = {&__ia2_mul_0_1};
 
 Op operations[2] IA2_SHARED_DATA = {
     {
         { "add", 4 },
-        {&__ia2_add},
+        IA2_WRAPPER(add, 1),
         { "Adds two u32s", 14 },
         0,
     },
     {
         { "mul", 4 },
-        {&__ia2_mul},
+        IA2_WRAPPER(mul, 1),
         { "Multiply two u32s", 18 },
         0,
     },

--- a/header-rewriter/tests/simple1/main.c
+++ b/header-rewriter/tests/simple1/main.c
@@ -56,9 +56,9 @@ int main() {
   // These will be called from untrusted code but may access trusted compartment
   // 0
   IA2_DEFINE_WRAPPER(main_map, _ZTSPFiiE, 1);
-  simple_foreach_v1(s, IA2_WRAPPER_FN_SCOPE(main_map));
+  simple_foreach_v1(s, IA2_WRAPPER_FN_SCOPE(main_map, 1));
   simple_reset(s);
-  simple_foreach_v2(s, IA2_WRAPPER_FN_SCOPE(main_map));
+  simple_foreach_v2(s, IA2_WRAPPER_FN_SCOPE(main_map, 1));
   simple_destroy(s);
 
   // We need to check if exit_hook_fn is NULL since IA2_CALL always

--- a/header-rewriter/tests/untrusted_indirect/main.c
+++ b/header-rewriter/tests/untrusted_indirect/main.c
@@ -60,11 +60,11 @@ int main(int argc, char **argv) {
     printf("0x%lx\n", apply_callback(1, 2));
 
     IA2_DEFINE_WRAPPER(pick_rhs, _ZTSPFmmmE, 1);
-    register_callback(IA2_WRAPPER_FN_SCOPE(pick_rhs));
+    register_callback(IA2_WRAPPER_FN_SCOPE(pick_rhs, 1));
     printf("0x%lx\n", apply_callback(3, 4));
 
     IA2_DEFINE_WRAPPER(leak_secret_address, _ZTSPFmmmE, 1);
-    register_callback(IA2_WRAPPER_FN_SCOPE(leak_secret_address));
+    register_callback(IA2_WRAPPER_FN_SCOPE(leak_secret_address, 1));
     printf("TRUSTED: oops we leaked the address of the secret\n");
     apply_callback(5, 6);
 

--- a/include/ia2.h
+++ b/include/ia2.h
@@ -47,7 +47,7 @@ asm(".macro mov_mixed_pkru_eax pkey0, pkey1\n"
   __attribute__((used)) typeof(target) target;                                 \
   /* Create an identifier to get the wrapper's address with                    \
    * IA2_WRAPPER/IA2_WRAPPER_FN_SCOPE */                                       \
-  extern struct IA2_fnptr_##ty##_inner_t __ia2_##target;                       \
+  extern struct IA2_fnptr_##ty##_inner_t __ia2_##target##_0_##target_pkey;     \
   /* Create an identifier to get the wrapper's type with                       \
    * IA2_WRAPPER/IA2_WRAPPER_FN_SCOPE */                                       \
   extern struct IA2_fnptr_##ty __ia2_##target##_wrapper;
@@ -67,15 +67,15 @@ asm(".macro mov_mixed_pkru_eax pkey0, pkey1\n"
 // IA2_DEFINE_WRAPPER.
 //
 // This macro may only be used in the global scope.
-#define IA2_WRAPPER(target)                                                    \
-  { &__ia2_##target }
+#define IA2_WRAPPER(target, target_pkey)                                       \
+  { &__ia2_##target##_0_##target_pkey }
 
 // Expands to an opaque pointer expression for a wrapper defined by
 // IA2_DEFINE_WRAPPER.
 //
 // This macro may only be used inside functions.
-#define IA2_WRAPPER_FN_SCOPE(target)                                           \
-  (typeof(__ia2_##target##_wrapper)) { &__ia2_##target }
+#define IA2_WRAPPER_FN_SCOPE(target, target_pkey)                              \
+  (typeof(__ia2_##target##_wrapper)) { &__ia2_##target##_0_##target_pkey }
 
 // Defines a wrapper for the function `target` and expands to an opaque pointer
 // expression for the wrapper.
@@ -84,7 +84,7 @@ asm(".macro mov_mixed_pkru_eax pkey0, pkey1\n"
 #define IA2_DEFINE_WRAPPER_FN_SCOPE(target, ty, target_pkey)                   \
   ({                                                                           \
     IA2_DEFINE_WRAPPER(target, ty, target_pkey);                               \
-    IA2_WRAPPER_FN_SCOPE(target);                                              \
+    IA2_WRAPPER_FN_SCOPE(target, target_pkey);                                 \
   })
 
 // Defines a wrapper for the opaque pointer `target` and expands to a function


### PR DESCRIPTION
Closes #116. I ended up only having to modify the manually defined direct call
wrappers. Direct call wrappers in the shim libraries currently don't need to have the
pkeys appended, but this may be an issue when we start dealing with multiple shims
calling one library. This is a cherry-pick of changes @fw-immunant reviewed in #111.