### PR TITLE
Move pkey_mprotect out of phdr loop in dl_iterate_phdr callback

### DIFF
--- a/libia2/src/lib.rs
+++ b/libia2/src/lib.rs
@@ -160,7 +160,8 @@ pub unsafe extern "C" fn protect_pages(
             }
         }
     }
-
+// After calling `pkey_mprotect` on the first phdr, we can't access `info->dlpi_phdr`
+// anymore since it's in the first phdr itself.
     for (r, prot) in protected_ranges {
         pkey_mprotect(r.start, r.stop, prot, pkey);
     }


### PR DESCRIPTION
`dlsym` needs to access the first phdr so we have to move the `pkey_mprotect`s
after the phdr loop.