### PR TITLE
Test with lld in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         build-type: [Release, Debug]
         compiler: [clang, gcc]
+        linker: [lld, bfd]
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -28,6 +29,7 @@ jobs:
           cmake ..                                                       \
             -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}                  \
             -DCMAKE_C_COMPILER=${{ matrix.compiler }}                    \
+            -DCMAKE_C_FLAGS="-fuse-ld=${{ matrix.linker }}"              \
             -DClang_DIR=$Clang_DIR                                       \
             -DLLVM_DIR=$LLVM_DIR                                         \
             -DLLVM_EXTERNAL_LIT=$HOME/.local/bin/lit                     \

--- a/cmake/define-test.cmake
+++ b/cmake/define-test.cmake
@@ -81,7 +81,7 @@ function(define_test)
         "-Werror=incompatible-pointer-types"
         "-fPIC"
         ${DEFINE_TEST_COMPILE_OPTS})
-    target_link_options(${MAIN} PRIVATE "-Wl,-z,now" "-Wl,-T${LINKER_SCRIPT}" "-Wl,--dynamic-list=${DYN_SYM}")
+    target_link_options(${MAIN} PRIVATE "-Wl,--export-dynamic" "-Wl,-z,now" "-Wl,-T${LINKER_SCRIPT}" "-Wl,--dynamic-list=${DYN_SYM}")
     target_include_directories(${MAIN} BEFORE PRIVATE
         ${INCLUDE_DIR}
         # Add top-level include directory for segfault handler


### PR DESCRIPTION
This was copied from #125 which only requires adding `-Wl,--export-dynamic` after relaxing alignment restrictions in #140. The linker script is a bit ugly since the `__start_*` and `__stop_*` symbols for shared sections don't necessarily correspond to the start and end of the sections, but it works as expected with both linkers since the contents of the shared sections are placed within these symbols and libia2.so uses these symbols rather than the start and end of the section to determine what to ignore.