### PR TITLE
Make typedef'd function pointer return types work

### DIFF
--- a/header-rewriter/HeaderRewriter.cpp
+++ b/header-rewriter/HeaderRewriter.cpp
@@ -2,6 +2,7 @@
 #include "GenCallAsm.h"
 #include "TypeOps.h"
 #include "clang/AST/AST.h"
+#include "clang/AST/Type.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Basic/FileManager.h"
@@ -117,7 +118,7 @@ struct FunctionWrapper {
     auto fn_name = fn_decl->getNameInfo().getAsString();
 
     auto ret_type = fn_decl->getReturnType();
-    if (ret_type->isFunctionPointerType()) {
+    if (ret_type->isFunctionPointerType() && !ret_type->getAs<clang::TypedefType>()) {
       auto &sm = fn_decl->getASTContext().getSourceManager();
       llvm::errs() << "Function that returns a non-typedefed function pointer"
                       " is not supported, location:"


### PR DESCRIPTION
The error printed seems to imply that we can support returning function
pointers that are a typedef, but we didn't actually check for that case.