### PR TITLE
Do not remove variadic functions from the wrapped headers

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -126,6 +126,13 @@ If direct calls occur in only one direction (e.g. libraries rarely call the main
 binary directly), only one shim is required. To wrap calls between two shared
 libraries in different compartments, the process is the same.
 
+We currently cannot wrap variadic (varargs) functions correctly. To switch
+stacks in that case, we would need to know how many arguments need to be passed
+on the stack, and that requires application-specific knowledge (see #18 for
+details). We emit a warning for variadic functions in processed headers, but we
+preserve the function declaration as-is. This will result in calls to that
+function not switching compartments and running with the caller's permission.
+
 ## Indirect calls
 
 Cross-compartment indirect calls go through call gate wrappers defined by macros

--- a/header-rewriter/HeaderRewriter.cpp
+++ b/header-rewriter/HeaderRewriter.cpp
@@ -226,12 +226,8 @@ public:
     // remaining class of functions for which this holds is variadics; see:
     // https://github.com/immunant/IA2-Phase2/issues/18
     if (fn_decl->isVariadic()) {
-      if (!replace_decl(fn_decl, "", FileReplacements)) {
-        return;
-      } else {
-        llvm::errs() << "Warning: deleting variadic function "
-                     << fn_decl->getNameAsString() << '\n';
-      }
+      llvm::errs() << "Warning: not wrapping variadic function "
+                   << fn_decl->getNameAsString() << '\n';
       return;
     }
 


### PR DESCRIPTION
If we only build against the wrapped headers, without the originals, but
still need to use a variadic function, we need to preserve these
functions in the header. Until #18 is fixed we should still allow users
to call variadics from their current compartment, when possible.