### PR TITLE
Move common wrappers to their own cmake file 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ find_package(PkgConfig REQUIRED)
 
 set(IA2_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
 
+include("cmake/define-ia2-wrapper.cmake")
+include("cmake/define-test.cmake")
+include("cmake/common-wrappers.cmake")
 
 add_subdirectory(libia2)
 add_subdirectory(header-rewriter)

--- a/cmake/common-wrappers.cmake
+++ b/cmake/common-wrappers.cmake
@@ -1,22 +1,63 @@
-# ffmpeg system library wrappers
-set(AVFORMAT_HEADERS libavformat/avformat.h libavformat/avio.h)
-set(AVUTIL_HEADERS libavutil/dict.h libavutil/version.h libavutil/macros.h
-    libavutil/common.h libavutil/mem.h libavutil/attributes.h libavutil/avutil.h
-    libavutil/rational.h libavutil/mathematics.h libavutil/intfloat.h
-    libavutil/log.h libavutil/pixfmt.h libavutil/error.h)
+include(CheckIncludeFile)
 
+function(gather_ffmpeg_headers)
+  set(outputVar ${ARGV0})
+  set(libName ${ARGV1})
+
+  find_path(headersPath ${libName})
+  file(GLOB headerList ${headersPath}/${libName}/*)
+
+  # Make sure that we can actually compile with each header, and remove the ones
+  # that we can't use in this configuration
+  foreach(header ${headerList})
+    CHECK_INCLUDE_FILE(${header} ${header}-valid)
+    if(NOT ${header}-valid)
+      list(REMOVE_ITEM headerList ${header})
+    endif()
+  endforeach()
+
+  set(${outputVar} ${headerList} PARENT_SCOPE)
+endfunction()
+
+# ffmpeg system library wrappers
+gather_ffmpeg_headers(AVFORMAT_HEADERS libavformat)
 define_ia2_wrapper(
     WRAPPER avformat_wrapper
     WRAPPED_LIB avformat
     HEADERS ${AVFORMAT_HEADERS}
+    OUTPUT_DIR libavformat
     USE_SYSTEM_HEADERS
     CALLER_PKEY 1
 )
+target_include_directories(avformat_wrapper
+  BEFORE PUBLIC ${IA2_INCLUDE_DIR}
+  INTERFACE ${CMAKE_CURRENT_BINARY_DIR}
+)
 
+gather_ffmpeg_headers(AVUTIL_HEADERS libavutil)
 define_ia2_wrapper(
     WRAPPER avutil_wrapper
     WRAPPED_LIB avutil
     HEADERS ${AVUTIL_HEADERS}
+    OUTPUT_DIR libavutil
     USE_SYSTEM_HEADERS
     CALLER_PKEY 1
+)
+target_include_directories(avutil_wrapper
+  BEFORE PUBLIC ${IA2_INCLUDE_DIR}
+  INTERFACE ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+gather_ffmpeg_headers(AVCODEC_HEADERS libavcodec)
+define_ia2_wrapper(
+    WRAPPER avcodec_wrapper
+    WRAPPED_LIB avcodec
+    HEADERS ${AVCODEC_HEADERS}
+    OUTPUT_DIR libavcodec
+    USE_SYSTEM_HEADERS
+    CALLER_PKEY 1
+)
+target_include_directories(avcodec_wrapper
+  BEFORE PUBLIC ${IA2_INCLUDE_DIR}
+  INTERFACE ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/cmake/common-wrappers.cmake
+++ b/cmake/common-wrappers.cmake
@@ -1,0 +1,22 @@
+# ffmpeg system library wrappers
+set(AVFORMAT_HEADERS libavformat/avformat.h libavformat/avio.h)
+set(AVUTIL_HEADERS libavutil/dict.h libavutil/version.h libavutil/macros.h
+    libavutil/common.h libavutil/mem.h libavutil/attributes.h libavutil/avutil.h
+    libavutil/rational.h libavutil/mathematics.h libavutil/intfloat.h
+    libavutil/log.h libavutil/pixfmt.h libavutil/error.h)
+
+define_ia2_wrapper(
+    WRAPPER avformat_wrapper
+    WRAPPED_LIB avformat
+    HEADERS ${AVFORMAT_HEADERS}
+    USE_SYSTEM_HEADERS
+    CALLER_PKEY 1
+)
+
+define_ia2_wrapper(
+    WRAPPER avutil_wrapper
+    WRAPPED_LIB avutil
+    HEADERS ${AVUTIL_HEADERS}
+    USE_SYSTEM_HEADERS
+    CALLER_PKEY 1
+)

--- a/cmake/define-ia2-wrapper.cmake
+++ b/cmake/define-ia2-wrapper.cmake
@@ -163,9 +163,10 @@ function(define_ia2_wrapper)
           ${REWRITTEN_HEADERS}
           --
           -fgnuc-version=6
-          -I ${REWRITTEN_HEADER_DIR}
+          -D_GNU_SOURCE
           -isystem ${C_SYSTEM_INCLUDE}
           -isystem ${C_SYSTEM_INCLUDE_FIXED}
+          -I ${IA2_INCLUDE_DIR}
         DEPENDS ${HEADER_SRCS} ia2-header-rewriter
         VERBATIM)
 

--- a/header-rewriter/tests/CMakeLists.txt
+++ b/header-rewriter/tests/CMakeLists.txt
@@ -1,8 +1,5 @@
 enable_testing()
 
-include("../../cmake/define-ia2-wrapper.cmake")
-include("../../cmake/define-test.cmake")
-
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/header-rewriter/tests/ffmpeg/CMakeLists.txt
+++ b/header-rewriter/tests/ffmpeg/CMakeLists.txt
@@ -1,25 +1,4 @@
-set(AVFORMAT_HEADERS libavformat/avformat.h libavformat/avio.h)
-set(AVUTIL_HEADERS libavutil/dict.h libavutil/version.h libavutil/macros.h
-    libavutil/common.h libavutil/mem.h libavutil/attributes.h libavutil/avutil.h
-    libavutil/rational.h libavutil/mathematics.h libavutil/intfloat.h
-    libavutil/log.h libavutil/pixfmt.h libavutil/error.h)
-
-# Build wrapper libs
-define_ia2_wrapper(
-    WRAPPER avformat_wrapper
-    WRAPPED_LIB avformat
-    HEADERS ${AVFORMAT_HEADERS}
-    USE_SYSTEM_HEADERS
-    CALLER_PKEY 1
-)
-
-define_ia2_wrapper(
-    WRAPPER avutil_wrapper
-    WRAPPED_LIB avutil
-    HEADERS ${AVUTIL_HEADERS}
-    USE_SYSTEM_HEADERS
-    CALLER_PKEY 1
-)
+# Wrappers are defined in cmake/common-wrappers.cmake
 
 # Build the test
 define_test(


### PR DESCRIPTION
Moves the ffmpeg wrapper definitions out of the ffmpeg test and into a
common area for use by other binaries in tree.