### PR TITLE
Define _GNU_SOURCE for tests

### DIFF
--- a/cmake/define-ia2-wrapper.cmake
+++ b/cmake/define-ia2-wrapper.cmake
@@ -179,6 +179,7 @@ function(define_ia2_wrapper)
     if(LIBIA2_INSECURE)
         target_compile_definitions(${WRAPPER_TARGET} PUBLIC LIBIA2_INSECURE=1)
     endif()
+    target_compile_definitions(${WRAPPER_TARGET} PRIVATE _GNU_SOURCE)
     target_compile_options(${WRAPPER_TARGET} PRIVATE
         "-Wno-deprecated-declarations"
         ${DEFINE_CALLER_PKEY})

--- a/cmake/define-test.cmake
+++ b/cmake/define-test.cmake
@@ -30,6 +30,7 @@ function(define_shared_lib)
     if(LIBIA2_INSECURE)
         target_compile_definitions(${LIBNAME} PUBLIC LIBIA2_INSECURE=1)
     endif()
+    target_compile_definitions(${LIBNAME} PRIVATE _GNU_SOURCE)
     target_compile_options(${LIBNAME} PRIVATE "-fPIC")
     target_include_directories(${LIBNAME} BEFORE PRIVATE
         ${INCLUDE_DIR}
@@ -79,6 +80,7 @@ function(define_test)
     if(LIBIA2_INSECURE)
         target_compile_definitions(${MAIN} PUBLIC LIBIA2_INSECURE=1)
     endif()
+    target_compile_definitions(${MAIN} PRIVATE _GNU_SOURCE)
     target_compile_options(${MAIN} PRIVATE
         "-Werror=incompatible-pointer-types"
         "-fsanitize=undefined"


### PR DESCRIPTION
ia2.h requires defining _GNU_SOURCE since it uses the definition of
`dl_phdr_info`. Using `#define _GNU_SOURCE` is unreliable since link.h defines
dl_phdr_info and may be included by another header before ia2.h so we have to
use `-D_GNU_SOURCE`.