### PR TITLE
Refactor and clean up `protect_pages()` and fix alignment requirements

### DIFF
--- a/libia2/ia2.c
+++ b/libia2/ia2.c
@@ -1,15 +1,35 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <link.h>
+
 #include "ia2.h"
 
-int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
-  // Use the address in `data` (PhdrSearchArgs) to determine which program
-  // headers belong to the compartment being initialized.
-  if (!data || !info) {
-    printf("Passed invalid args to dl_iterate_phdr callback\n");
-    exit(-1);
-  }
-  struct PhdrSearchArgs *search_args = (struct PhdrSearchArgs *)data;
-  Elf64_Addr address = (Elf64_Addr)search_args->address;
-  bool this_compartment = false;
+static const char *shared_sections[][2] = {
+    {"__start_ia2_shared_data", "__stop_ia2_shared_data"},
+    {"__start_ia2_shared_rodata", "__stop_ia2_shared_rodata"},
+};
+
+// The number of ELF sections that may be shared by protect_pages
+#define NUM_SHARED_RANGES (sizeof(shared_sections) / sizeof(shared_sections[0]))
+
+// The number of program headers to allocate space for in protect_pages. This is
+// only an estimate of the maximum value of dlpi_phnum below.
+#define MAX_NUM_PHDRS 20
+
+struct AddressRange {
+  uint64_t start;
+  uint64_t end;
+};
+
+struct SegmentInfo {
+  uint64_t addr;
+  size_t size;
+  int prot;
+};
+
+/// Check if \p address is in a LOAD segment in \p info
+static bool in_loaded_segment(struct dl_phdr_info *info, Elf64_Addr address) {
   for (size_t i = 0; i < info->dlpi_phnum; i++) {
     if (!info->dlpi_phdr) {
       exit(-1);
@@ -21,65 +41,72 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
     Elf64_Addr start = info->dlpi_addr + phdr.p_vaddr;
     Elf64_Addr end = start + phdr.p_memsz;
     if (start <= address && address <= end) {
-      this_compartment = true;
-      break;
+      return true;
     }
   }
-  if (!this_compartment) {
-    return 0;
-  }
-  const char *ignored_sections[NUM_IGNORED_SECTIONS][2] = {
-      {"__start_ia2_shared_data", "__stop_ia2_shared_data"},
-      {"__start_ia2_shared_rodata", "__stop_ia2_shared_rodata"},
-  };
-  struct AddressRange {
-    uint64_t start;
-    uint64_t end;
-  };
-  struct AddressRange ignored_ranges[NUM_IGNORED_SECTIONS];
-  void *lib = dlopen(info->dlpi_name, RTLD_NOW);
-  if (!lib) {
+  return false;
+}
+
+/// Map ELF segment flags to mprotect access flags
+static int segment_flags_to_access_flags(Elf64_Word flags) {
+  return ((flags & PF_X) != 0 ? PROT_EXEC : 0) |
+         ((flags & PF_W) != 0 ? PROT_WRITE : 0) |
+         ((flags & PF_R) != 0 ? PROT_READ : 0);
+}
+
+int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
+  if (!data || !info) {
+    printf("Passed invalid args to dl_iterate_phdr callback\n");
     exit(-1);
   }
-  for (size_t i = 0; i < NUM_IGNORED_SECTIONS; i++) {
+
+  struct PhdrSearchArgs *search_args = (struct PhdrSearchArgs *)data;
+  Elf64_Addr address = (Elf64_Addr)search_args->address;
+  if (!in_loaded_segment(info, address)) {
+    // Continue iterating to check the next object
+    return 0;
+  }
+
+  void *lib = dlopen(info->dlpi_name, RTLD_NOW);
+  if (!lib)
+    exit(-1);
+
+  struct AddressRange shared_ranges[NUM_SHARED_RANGES];
+  for (size_t i = 0; i < NUM_SHARED_RANGES; i++) {
     // Clear any potential old error conditions
     dlerror();
-    ignored_ranges[i].start = (uint64_t)dlsym(lib, ignored_sections[i][0]);
-    uint64_t aligned_start = ignored_ranges[i].start & ~0xFFFUL;
-    if (aligned_start != ignored_ranges[i].start) {
+    shared_ranges[i].start = (uint64_t)dlsym(lib, shared_sections[i][0]);
+    uint64_t aligned_start = shared_ranges[i].start & ~0xFFFUL;
+    if (aligned_start != shared_ranges[i].start) {
       printf("Start of section %s is not page-aligned\n",
-             ignored_sections[i][0]);
+             shared_sections[i][0]);
       exit(-1);
     }
-    if (dlerror()) {
+    if (dlerror())
+      exit(-1);
+
+    shared_ranges[i].end = (uint64_t)dlsym(lib, shared_sections[i][1]);
+    uint64_t aligned_end = (shared_ranges[i].end + 0xFFFUL) & ~0xFFFUL;
+    if (aligned_end != shared_ranges[i].end) {
+      printf("End of section %s is not page-aligned\n", shared_sections[i][1]);
       exit(-1);
     }
-    ignored_ranges[i].end = (uint64_t)dlsym(lib, ignored_sections[i][1]);
-    uint64_t aligned_end = (ignored_ranges[i].end + 0xFFFUL) & ~0xFFFUL;
-    if (aligned_end != ignored_ranges[i].end) {
-      printf("End of section %s is not page-aligned\n", ignored_sections[i][1]);
+    if (dlerror())
       exit(-1);
-    }
-    if (dlerror()) {
-      exit(-1);
-    }
   }
-  struct SegmentInfo {
-    uint64_t addr;
-    size_t size;
-    int prot;
-  };
-  // Allocate one SegmentInfo per program header plus 2 extra in case
-  // ia2_shared_data or ia2_shared_rodata have non-zero size and split their
-  // corresponding segments.
-  struct SegmentInfo segment_info[NUM_PHDRS + NUM_IGNORED_SECTIONS] = {0};
 
   // TODO: We avoid dynamically allocating space for each of the `dlpi_phnum`
-  // the SegmentInfo structs for simplicity. NUM_PHDRS is only an estimate, so
-  // if this assert fails we should increment it. Once we test partition
+  // the SegmentInfo structs for simplicity. MAX_NUM_PHDRS is only an estimate,
+  // so if this assert fails we should increment it. Once we test partition
   // allocator more thoroughly we should use malloc here and free the structs at
   // the end of this function.
-  assert(info->dlpi_phnum <= NUM_PHDRS);
+  assert(info->dlpi_phnum <= MAX_NUM_PHDRS);
+
+  // Reserve one SegmentInfo per program header plus one for each shared range
+  // in case any of those ranges have non-zero size in the middle of their
+  // segment.
+  struct SegmentInfo segment_info[MAX_NUM_PHDRS + NUM_SHARED_RANGES] = {0};
+
   // The latter halves of split program headers (if any) are stored starting at
   // segment_info[dlpi_phnum]. If a shared section doesn't exist, the unused
   // `SegmentInfo` will have its size field set to zero
@@ -90,35 +117,28 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
     if ((phdr.p_type != PT_LOAD) && (phdr.p_type != PT_GNU_RELRO)) {
       continue;
     }
-    int prot = PROT_NONE;
-    if ((phdr.p_flags & PF_X) != 0) {
-      prot |= PROT_EXEC;
-    }
-    if ((phdr.p_flags & PF_W) != 0) {
-      prot |= PROT_WRITE;
-    }
-    if ((phdr.p_flags & PF_R) != 0) {
-      prot |= PROT_READ;
-    }
+
+    int prot = segment_flags_to_access_flags(phdr.p_flags);
+
     Elf64_Addr start = (info->dlpi_addr + phdr.p_vaddr) & ~0xFFFUL;
     Elf64_Addr stop = (start + phdr.p_memsz + 0xFFFUL) & ~0xFFFUL;
     // TODO: This logic assumes that each segment may only be split by one
     // shared section
-    for (size_t j = 0; j < NUM_IGNORED_SECTIONS; j++) {
-      if ((ignored_ranges[j].start <= start) &&
-          (ignored_ranges[j].end >= start)) {
-        start = ignored_ranges[j].end;
-      } else if ((ignored_ranges[j].end >= stop) &&
-                 (ignored_ranges[j].start <= stop)) {
-        stop = ignored_ranges[j].start;
-      } else if ((ignored_ranges[j].end <= stop) &&
-                 (ignored_ranges[j].start >= start)) {
-        size_t len = stop - ignored_ranges[j].end;
-        segment_info[extra_seg_info].addr = ignored_ranges[j].end;
+    for (size_t j = 0; j < NUM_SHARED_RANGES; j++) {
+      if ((shared_ranges[j].start <= start) &&
+          (shared_ranges[j].end >= start)) {
+        start = shared_ranges[j].end;
+      } else if ((shared_ranges[j].end >= stop) &&
+                 (shared_ranges[j].start <= stop)) {
+        stop = shared_ranges[j].start;
+      } else if ((shared_ranges[j].end <= stop) &&
+                 (shared_ranges[j].start >= start)) {
+        size_t len = stop - shared_ranges[j].end;
+        segment_info[extra_seg_info].addr = shared_ranges[j].end;
         segment_info[extra_seg_info].size = len;
         segment_info[extra_seg_info].prot = prot;
 
-        stop = ignored_ranges[j].start;
+        stop = shared_ranges[j].start;
         extra_seg_info += 1;
       }
     }
@@ -127,7 +147,8 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
     segment_info[i].size = len;
     segment_info[i].prot = prot;
   }
-  for (size_t i = 0; i < info->dlpi_phnum + NUM_IGNORED_SECTIONS; i++) {
+
+  for (size_t i = 0; i < info->dlpi_phnum + NUM_SHARED_RANGES; i++) {
     // Check if any of the extra entries weren't used
     if (segment_info[i].size != 0) {
       int mprotect_err =
@@ -139,5 +160,7 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
       }
     }
   }
+
+  // Do not continue, we found the right object
   return 1;
 }

--- a/libia2/padding.ld
+++ b/libia2/padding.ld
@@ -10,21 +10,25 @@
    __start_$SECTION and before __stop_$SECTION.
 */
 SECTIONS {
-    ia2_shared_rodata : {
-        . = ALIGN(4096);
+    ia2_shared_rodata ALIGN(4096): {
         __start_ia2_shared_rodata = .;
         *(ia2_shared_rodata)
-        . = ALIGN(4096);
+        /*
+           This weird alignment expression is required so that the section will
+           get elided if empty. ld.bfd special-cases this syntax to mean this,
+           which is not documented but appears in its default linker script; see
+           binutils commit 9d12f64cdc6540b75938097d7f4ab460bb346528
+        */
+        . = ALIGN(. != 0 ? 4096 : 1);
         __stop_ia2_shared_rodata = .;
     }
 } INSERT AFTER .rodata;
 
 SECTIONS {
-    ia2_shared_data : {
-        . = ALIGN(4096);
+    ia2_shared_data ALIGN(4096): {
         __start_ia2_shared_data = .;
         *(ia2_shared_data)
-        . = ALIGN(4096);
+        . = ALIGN(. != 0 ? 4096 : 1); /* Elide the section if empty */
         __stop_ia2_shared_data = .;
     }
 } INSERT AFTER .data;


### PR DESCRIPTION
Clean up the protect_pages callback for `dl_iterate_phdr`.

Also relaxes the requirement that `ia2_shared_*` must exist, which lets us fix the linker script to eliminate these sections if they aren't required.