### PR TITLE
Inline compartment initialization

### DIFF
--- a/header-rewriter/tests/ffmpeg/main.c
+++ b/header-rewriter/tests/ffmpeg/main.c
@@ -26,16 +26,17 @@
  * @example metadata.c
  */
 
+#define IA2_INIT_COMPARTMENT 1
+#include <ia2.h>
+
 #include <stdio.h>
 
 #include <libavformat/avformat.h>
 #include <libavutil/dict.h>
 #include <libavutil/common.h>
 #include "libavutil/mem.h"
-#include <ia2.h>
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 int main (int argc, char **argv)
 {

--- a/header-rewriter/tests/function_allowlist/main.c
+++ b/header-rewriter/tests/function_allowlist/main.c
@@ -1,8 +1,9 @@
-#include "library.h"
+#define IA2_INIT_COMPARTMENT 1
 #include <ia2.h>
 
+#include "library.h"
+
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 int data_in_main = 30;
 

--- a/header-rewriter/tests/global_fn_ptr/main.c
+++ b/header-rewriter/tests/global_fn_ptr/main.c
@@ -1,12 +1,13 @@
-#include "operations.h"
+#define IA2_INIT_COMPARTMENT 1
 #include <ia2.h>
+
+#include "operations.h"
 
 uint32_t add(uint32_t x, uint32_t y) { return x + y; }
 uint16_t sub(uint16_t x, uint16_t y) { return x - y; }
 uint32_t mul(uint32_t x, uint32_t y) { return x * y; }
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 IA2_DEFINE_WRAPPER(add, _ZTSPFjjjE, 1);
 IA2_DEFINE_WRAPPER(sub, _ZTSPFtttE, 1);

--- a/header-rewriter/tests/header_includes/main.c
+++ b/header-rewriter/tests/header_includes/main.c
@@ -4,13 +4,14 @@ RUN: ia2-header-rewriter %T/wrapper.c liboption.h types.h -- -I. -I%resource_dir
 RUN: cat %T/wrapper.c.args | FileCheck --check-prefix=LINKARGS %S/include/liboption.h
 RUN: cat %T/wrapper.c.args | FileCheck --check-prefix=LINKARGS %S/include/impl.h
 */
+#define IA2_INIT_COMPARTMENT 1
+#include <ia2.h>
+
 #include "liboption.h"
 #include "types.h"
 #include <stdio.h>
-#include <ia2.h>
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 int main() {
     Option x = Some(3);

--- a/header-rewriter/tests/libusb/main.c
+++ b/header-rewriter/tests/libusb/main.c
@@ -16,16 +16,16 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#define IA2_INIT_COMPARTMENT 1
+#include <ia2.h>
 
 #include <stdio.h>
 #include <stdint.h>
-#include <ia2.h>
 
 #include "libusb.h"
 #include "usb-1.0_fn_ptr_ia2.h"
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 static void print_devs(libusb_device **devs)
 {

--- a/header-rewriter/tests/macro_attr/main.c
+++ b/header-rewriter/tests/macro_attr/main.c
@@ -1,9 +1,10 @@
-#include "functions.h"
-#include "macro_attr-original_fn_ptr_ia2.h"
+#define IA2_INIT_COMPARTMENT 1
 #include <ia2.h>
 
+#include "functions.h"
+#include "macro_attr-original_fn_ptr_ia2.h"
+
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 int main() {
     f();

--- a/header-rewriter/tests/minimal/main.c
+++ b/header-rewriter/tests/minimal/main.c
@@ -1,8 +1,9 @@
-#include "minimal.h"
+#define IA2_INIT_COMPARTMENT 1
 #include <ia2.h>
 
+#include "minimal.h"
+
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 int main() {
     foo();

--- a/header-rewriter/tests/read_config/main.c
+++ b/header-rewriter/tests/read_config/main.c
@@ -1,5 +1,7 @@
-#include "plugin.h"
+#define IA2_INIT_COMPARTMENT 1
 #include <ia2.h>
+
+#include "plugin.h"
 #include <stdio.h>
 #include <string.h>
 // TODO: Add the `#include output_header.h` to shared headers since they may
@@ -19,7 +21,6 @@
 */
 
 INIT_RUNTIME(2);
-INIT_COMPARTMENT(1);
 
 // The first 5 entries are plugin options and the rest are builtin
 #define PLUGIN_ENTRIES 5

--- a/header-rewriter/tests/read_config/plugin.c
+++ b/header-rewriter/tests/read_config/plugin.c
@@ -1,10 +1,10 @@
+#define IA2_INIT_COMPARTMENT 2
+#include <ia2.h>
+
 #include "core.h"
 #include "plugin.h"
-#include <ia2.h>
 #include <stdio.h>
 #include <string.h>
-
-INIT_COMPARTMENT(2);
 
 // A custom parsing function for a type defined by the plugin
 static void parse_tuple(char *opt, void *out);

--- a/header-rewriter/tests/ro_sharing/main.c
+++ b/header-rewriter/tests/ro_sharing/main.c
@@ -1,6 +1,9 @@
 #include "plugin.h"
-#include <ia2.h>
 #include <stdio.h>
+
+#define IA2_INIT_COMPARTMENT 1
+#include <ia2.h>
+
 #define IA2_DEFINE_TEST_HANDLER
 #include "test_fault_handler.h"
 
@@ -11,7 +14,6 @@
 
 // This test uses two protection keys
 INIT_RUNTIME(2);
-INIT_COMPARTMENT(1);
 
 // All string literals should be in .rodata
 const char *main_str = "this is the main binary's string\n";

--- a/header-rewriter/tests/ro_sharing/plugin.c
+++ b/header-rewriter/tests/ro_sharing/plugin.c
@@ -1,10 +1,11 @@
-#include "test_fault_handler.h"
+
+#define IA2_INIT_COMPARTMENT 2
 #include <ia2.h>
+
+#include "test_fault_handler.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-
-INIT_COMPARTMENT(2);
 
 // All string literals should be in .rodata
 const char *plugin_str = "this is the plugin's string\n";

--- a/header-rewriter/tests/shared_data/main.c
+++ b/header-rewriter/tests/shared_data/main.c
@@ -1,10 +1,11 @@
+#define IA2_INIT_COMPARTMENT 1
+#include <ia2.h>
+
 #include <stdint.h>
 #include <assert.h>
-#include <ia2.h>
 #include "access_shared.h"
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 uint8_t shared_val[4097] IA2_SHARED_DATA = { 0 };
 

--- a/header-rewriter/tests/should_segfault/main.c
+++ b/header-rewriter/tests/should_segfault/main.c
@@ -1,13 +1,14 @@
+#define IA2_INIT_COMPARTMENT 1
+#include <ia2.h>
+
 #include <stdio.h>
 #include <unistd.h>
 #include <stdint.h>
 #include <print_secret.h>
-#include <ia2.h>
 #define IA2_DEFINE_TEST_HANDLER
 #include "test_fault_handler.h"
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 uint32_t secret = 0xdeadbeef;
 

--- a/header-rewriter/tests/simple1/main.c
+++ b/header-rewriter/tests/simple1/main.c
@@ -1,14 +1,14 @@
+#define IA2_INIT_COMPARTMENT 1
+#include <ia2.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-
-#include <ia2.h>
 
 #include "hooks.h"
 #include "simple1.h"
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 // libsimple1 checks if the function pointer is NULL. To initialize this to a
 // function defined in this binary, we'd need to define a wrapper with

--- a/header-rewriter/tests/structs/main.c
+++ b/header-rewriter/tests/structs/main.c
@@ -1,6 +1,8 @@
+#define IA2_INIT_COMPARTMENT 1
+#include <ia2.h>
+
 #include <stdio.h>
 #include "structs.h"
-#include <ia2.h>
 #include <math.h>
 #include <assert.h>
 
@@ -10,7 +12,6 @@
 */
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 #define check_close_float(name, val) { printf("%s(s) = %.4f (expected %.4f)\n", #name, name(s), val); }
 #define check_field_float(name, val) { printf("s.%s = %.4f (expected %.4f)\n", #name, s.name, val); }

--- a/header-rewriter/tests/trusted_direct/main.c
+++ b/header-rewriter/tests/trusted_direct/main.c
@@ -1,9 +1,11 @@
+#define IA2_INIT_COMPARTMENT 1
+#include <ia2.h>
+
 #include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 
-#include <ia2.h>
 #include "plugin.h"
 #define IA2_DEFINE_TEST_HANDLER
 #include "test_fault_handler.h"
@@ -13,7 +15,6 @@
 // passed in. Otherwise the program exits cleanly.
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 uint32_t secret = 0x09431233;
 

--- a/header-rewriter/tests/trusted_indirect/main.c
+++ b/header-rewriter/tests/trusted_indirect/main.c
@@ -1,6 +1,8 @@
+#define IA2_INIT_COMPARTMENT 1
+#include <ia2.h>
+
 #include <stdio.h>
 #include "rand_op.h"
-#include <ia2.h>
 #define IA2_DEFINE_TEST_HANDLER
 #include "test_fault_handler.h"
 
@@ -10,7 +12,6 @@
 */
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 bool clean_exit IA2_SHARED_DATA = false;
 

--- a/header-rewriter/tests/two_keys_minimal/main.c
+++ b/header-rewriter/tests/two_keys_minimal/main.c
@@ -1,13 +1,14 @@
+#define IA2_INIT_COMPARTMENT 1
+#include <ia2.h>
+
 #include <stdio.h>
 #include <unistd.h>
-#include <ia2.h>
 #include "plugin.h"
 #define IA2_DEFINE_TEST_HANDLER
 #include "test_fault_handler.h"
 
 // This test uses two protection keys
 INIT_RUNTIME(2);
-INIT_COMPARTMENT(1);
 
 uint32_t secret = 0x09431233;
 

--- a/header-rewriter/tests/two_keys_minimal/plugin.c
+++ b/header-rewriter/tests/two_keys_minimal/plugin.c
@@ -1,9 +1,9 @@
-#include <stdio.h>
+#define IA2_INIT_COMPARTMENT 2
 #include <ia2.h>
+
+#include <stdio.h>
 #include "exported_fn.h"
 #include "test_fault_handler.h"
-
-INIT_COMPARTMENT(2);
 
 uint32_t plugin_secret = 0x78341244;
 

--- a/header-rewriter/tests/two_shared_ranges/main.c
+++ b/header-rewriter/tests/two_shared_ranges/main.c
@@ -1,13 +1,14 @@
+#define IA2_INIT_COMPARTMENT 1
+#include <ia2.h>
+
 #include <stdio.h>
 #include <unistd.h>
-#include <ia2.h>
 #include "plugin.h"
 #define IA2_DEFINE_TEST_HANDLER
 #include "test_fault_handler.h"
 
 // This test uses two protection keys
 INIT_RUNTIME(2);
-INIT_COMPARTMENT(1);
 
 uint32_t secret = 0x09431233;
 uint32_t shared IA2_SHARED_DATA = 0xb75784ee;

--- a/header-rewriter/tests/two_shared_ranges/plugin.c
+++ b/header-rewriter/tests/two_shared_ranges/plugin.c
@@ -1,9 +1,9 @@
-#include <stdio.h>
+#define IA2_INIT_COMPARTMENT 2
 #include <ia2.h>
+
+#include <stdio.h>
 #include "exported_fn.h"
 #include "test_fault_handler.h"
-
-INIT_COMPARTMENT(2);
 
 uint32_t plugin_secret = 0x78341244;
 uint32_t plugin_shared IA2_SHARED_DATA = 0x415ea635;

--- a/header-rewriter/tests/untrusted_indirect/main.c
+++ b/header-rewriter/tests/untrusted_indirect/main.c
@@ -1,3 +1,6 @@
+#define IA2_INIT_COMPARTMENT 1
+#include <ia2.h>
+
 #include <stdio.h>
 #include <stdint.h>
 #include "foo.h"
@@ -6,7 +9,6 @@
 #include "test_fault_handler.h"
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
 
 /*
     This program tests that a trusted binary can pass function pointers to an untrusted shared

--- a/libia2/CMakeLists.txt
+++ b/libia2/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 3.12)
 project(libia2)
 
-add_library(libia2 ia2.c)
+add_library(libia2 INTERFACE)
 
-target_include_directories(libia2 PUBLIC include)
-target_compile_definitions(libia2 PRIVATE _GNU_SOURCE)
+target_include_directories(libia2 INTERFACE include)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/padding.ld ${CMAKE_CURRENT_BINARY_DIR}/)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/dynsym.syms ${CMAKE_CURRENT_BINARY_DIR}/)

--- a/libia2/padding.ld
+++ b/libia2/padding.ld
@@ -11,7 +11,7 @@
 */
 SECTIONS {
     ia2_shared_data ALIGN(4096): {
-        __start_ia2_shared_data = .;
+        HIDDEN(__start_ia2_shared_data = .);
         *(ia2_shared_data)
         /*
            This weird alignment expression is required so that the section will
@@ -20,6 +20,6 @@ SECTIONS {
            binutils commit 9d12f64cdc6540b75938097d7f4ab460bb346528
         */
         . = ALIGN(. != 0 ? 4096 : 1);
-        __stop_ia2_shared_data = .;
+        HIDDEN(__stop_ia2_shared_data = .);
     }
 } INSERT AFTER .data;


### PR DESCRIPTION
Compartment initialization is a sensitive operation and it must not be
possible to modify inputs to this operation and replay it with different
compartment IDs or ranges. This change inlines initialization statically
into the compartment so that we don't have to accept arbitrary addresses
and key IDs. As a nice side-effect, this means we no longer have to rely
on dlopen/dlsym to find the shared data section symbols.

Fixes #172 