### PR TITLE
Refactor GenCallAsm.cpp

### DIFF
--- a/header-rewriter/GenCallAsm.cpp
+++ b/header-rewriter/GenCallAsm.cpp
@@ -241,8 +241,8 @@ static std::string sig_string(const CAbiSignature &sig,
 }
 
 std::string emit_asm_wrapper(const CAbiSignature &sig, const std::string &name,
-                             WrapperKind kind, const std::string &target_pkey,
-                             bool as_macro) {
+                             WrapperKind kind, const std::string &caller_pkey,
+                             const std::string &target_pkey, bool as_macro) {
   // Indirect wrappers and manually defined direct wrappers are always generated
   // as macros
   as_macro = as_macro || (kind == WrapperKind::Indirect);
@@ -252,17 +252,6 @@ std::string emit_asm_wrapper(const CAbiSignature &sig, const std::string &name,
     terminator = "\\"s;
   }
   AsmWriter aw = {.ss = {}, .terminator = terminator};
-
-  std::string caller_pkey;
-  if (as_macro) {
-    // caller_pkey is the macro param defining the caller's pkey in the
-    // IA2_FNPTR_* macros
-    caller_pkey = "caller_pkey";
-  } else {
-    // The CALLER_PKEY macro must be defined to compile the wrapper source files
-    // that this is written to. Failure to define it gives a preprocessor error.
-    caller_pkey = "CALLER_PKEY";
-  }
 
   auto param_locs = param_locations(sig);
   size_t stack_arg_count = std::count_if(param_locs.begin(), param_locs.end(),

--- a/header-rewriter/GenCallAsm.cpp
+++ b/header-rewriter/GenCallAsm.cpp
@@ -337,7 +337,8 @@ std::string emit_asm_wrapper(const CAbiSignature &sig, const std::string &name,
   }
 
   // Count room for for the ret align padding, return value, and our ret ptr.
-  size_t compartment_stack_space = start_of_ret_space + stack_return_size + stack_return_padding + stack_arg_size;
+  size_t compartment_stack_space = start_of_ret_space + stack_return_size +
+                                   stack_return_padding + stack_arg_size;
   // Compute what the stack alignment would be before calling the wrapped
   // function to check if we need to insert 8 bytes for alignment. We add 8
   // bytes to the compartment_stack_space since the frame is initially off by 8
@@ -363,10 +364,10 @@ std::string emit_asm_wrapper(const CAbiSignature &sig, const std::string &name,
                                    asm_macro_expansion("target"),
                                    asm_macro_expansion(caller_pkey),
                                    asm_macro_expansion(target_pkey)));
-    add_asm_line(
-        aw, llvm::formatv(".equ __ia2_{0}_{1}_{2}, . ", asm_macro_expansion("target"),
-                          asm_macro_expansion(caller_pkey),
-                          asm_macro_expansion(target_pkey)));
+    add_asm_line(aw, llvm::formatv(".equ __ia2_{0}_{1}_{2}, . ",
+                                   asm_macro_expansion("target"),
+                                   asm_macro_expansion(caller_pkey),
+                                   asm_macro_expansion(target_pkey)));
   } else {
     // This is for wrappers defined in the shims
     add_asm_line(aw, ".text");

--- a/header-rewriter/GenCallAsm.h
+++ b/header-rewriter/GenCallAsm.h
@@ -21,5 +21,6 @@ enum class WrapperKind {
 // \p as_macro determines if the wrappers for direct calls is emitted as a
 // macro. Indirect calls are unconditionally emitted as macros.
 std::string emit_asm_wrapper(const CAbiSignature &sig, const std::string &name,
-                             WrapperKind kind, const std::string &callee_pkey,
+                             WrapperKind kind, const std::string &caller_pkey,
+                             const std::string &target_pkey,
                              bool as_macro = false);

--- a/header-rewriter/HeaderRewriter.cpp
+++ b/header-rewriter/HeaderRewriter.cpp
@@ -118,7 +118,8 @@ struct FunctionWrapper {
     auto fn_name = fn_decl->getNameInfo().getAsString();
 
     auto ret_type = fn_decl->getReturnType();
-    if (ret_type->isFunctionPointerType() && !ret_type->getAs<clang::TypedefType>()) {
+    if (ret_type->isFunctionPointerType() &&
+        !ret_type->getAs<clang::TypedefType>()) {
       auto &sm = fn_decl->getASTContext().getSourceManager();
       llvm::errs() << "Function that returns a non-typedefed function pointer"
                       " is not supported, location:"


### PR DESCRIPTION
The source rewriter prototype in PR #177 required refactoring GenCallAsm.cpp so I'm splitting out those changes to make review easier.

A `caller_pkey` argument is useful since the rewriter will eventually read all source files and know which compartment all functions. This means it'll be able to insert the caller and target pkeys itself instead of relying on the "compile with -DCALLER_PKEY" hack.