### PR TITLE
Add explicit third variant to WrapperKind enum in GenCallAsm.cpp

### DIFF
--- a/header-rewriter/GenCallAsm.h
+++ b/header-rewriter/GenCallAsm.h
@@ -5,8 +5,10 @@
 enum class WrapperKind {
   // Direct call to another compartment
   Direct,
+  // Indirect call through a pointer sent to another compartment
+  Pointer,
   // Indirect call through a pointer received from another compartment
-  Indirect,
+  IndirectCallsite,
 };
 
 // Generates a wrapper for a function named \p name with the signature \p sig.

--- a/header-rewriter/HeaderRewriter.cpp
+++ b/header-rewriter/HeaderRewriter.cpp
@@ -495,8 +495,8 @@ static std::string generate_output_header(
        << "(target, caller_pkey, target_pkey) \\\n";
     // This argument must be a valid asm identifier for direct calls
     auto direct_wrapper =
-        emit_asm_wrapper(fi.sig, "target"s, WrapperKind::Direct, "caller_pkey"s,
-                         "target_pkey"s, true /* as_macro */);
+        emit_asm_wrapper(fi.sig, "target"s, WrapperKind::Pointer,
+                         "caller_pkey"s, "target_pkey"s, true /* as_macro */);
     os << direct_wrapper << "\n";
 
     // IA2_CALL_* takes an opaque pointer and returns a function
@@ -505,8 +505,8 @@ static std::string generate_output_header(
        << "(target, ty, caller_pkey, target_pkey) \\\n";
     // target_pkey is the macro param defining the callee's pkey
     auto wrapper_from_untrusted =
-        emit_asm_wrapper(fi.sig, fi.new_type, WrapperKind::Indirect,
-                         "caller_pkey"s, "target_pkey"s);
+        emit_asm_wrapper(fi.sig, fi.new_type, WrapperKind::IndirectCallsite,
+                         "caller_pkey"s, "target_pkey"s, true /* as_macro */);
     os << wrapper_from_untrusted << "\n";
   }
 


### PR DESCRIPTION
The three calls to `emit_asm_wrapper` generate three different types of wrappers. It accepts a `WrapperKind` enum with two variants which we used in combination with the presecence of an explicit `as_macro` argument to determine which of the three types of wrappers to generate. This commit adds an explicit 3rd `WrapperKind` variant and fixes the logic that relies on `as_macro` to use just the `WrapperKind` instead. The only thing that `as_macro` affects now is the terminator used when writing each line of asm.

This is part of the refactoring from PR #177 and the last one for now.