### PR TITLE
use `_exit` in `CHECK_VIOLATION`

### DIFF
--- a/libia2/include/test_fault_handler.h
+++ b/libia2/include/test_fault_handler.h
@@ -28,7 +28,7 @@
     asm volatile("" : : : "memory");                                           \
     volatile typeof(expr) _tmp = expr;                                         \
     printf("CHECK_VIOLATION: did not seg fault as expected\n");                \
-    exit(0);                                                                   \
+    _exit(0);                                                                  \
     _tmp;                                                                      \
   })
 


### PR DESCRIPTION
`_exit` skips `atexit` routines and dtors, which is good because we do not want to possibly segfault (and wrongly print a happy message) during execution of other code that only ran because we called `exit()` inside the `CHECK_VIOLATION` handler; once we get to this point of `CHECK_VIOLATION`, we want to end the test immediately.