### PR TITLE
Switch compartments for main function and thread body functions

### DIFF
--- a/libia2/CMakeLists.txt
+++ b/libia2/CMakeLists.txt
@@ -4,6 +4,10 @@ project(libia2)
 add_library(libia2 ia2.c threads.c main.c)
 target_compile_options(libia2 PRIVATE "-fPIC")
 
+if(LIBIA2_INSECURE)
+target_compile_definitions(libia2 PRIVATE LIBIA2_INSECURE=1)
+endif()
+
 target_link_options(libia2
     INTERFACE
         "-pthread"

--- a/libia2/CMakeLists.txt
+++ b/libia2/CMakeLists.txt
@@ -1,13 +1,14 @@
 cmake_minimum_required(VERSION 3.12)
 project(libia2)
 
-add_library(libia2 ia2.c threads.c)
+add_library(libia2 ia2.c threads.c main.c)
 target_compile_options(libia2 PRIVATE "-fPIC")
 
 target_link_options(libia2
     INTERFACE
         "-pthread"
         "-Wl,--wrap=pthread_create"
+        "-Wl,--wrap=main"
 )
 
 target_include_directories(libia2 PUBLIC include)

--- a/libia2/ia2.c
+++ b/libia2/ia2.c
@@ -102,6 +102,11 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
     if (!lib)
       exit(-1);
     uint64_t untrusted_stackptr_addr = (uint64_t)dlsym(lib, "ia2_stackptr_0");
+    if (untrusted_stackptr_addr & 0xFFF != 0) {
+      printf("address of ia2_stackptr_0 (%p) is not page-aligned\n",
+             (void *)untrusted_stackptr_addr);
+      exit(-1);
+    }
 
     /* Protect the TLS region except the page of the untrusted stack pointer. */
     if (untrusted_stackptr_addr > start && untrusted_stackptr_addr < end) {

--- a/libia2/ia2.c
+++ b/libia2/ia2.c
@@ -21,8 +21,6 @@ static const char *shared_sections[][2] = {
 // only an estimate of the maximum value of dlpi_phnum below.
 #define MAX_NUM_PHDRS 20
 
-__thread char ia2_threadlocal_padding[PAGE_SIZE] __attribute__((used));
-
 struct AddressRange {
   uint64_t start;
   uint64_t end;

--- a/libia2/ia2.c
+++ b/libia2/ia2.c
@@ -181,37 +181,6 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
     break;
   }
 
-  /* protect TLS segment */
-  for (size_t i = 0; i < info->dlpi_phnum; i++) {
-    Elf64_Phdr phdr = info->dlpi_phdr[i];
-    if (phdr.p_type != PT_TLS) {
-      continue;
-    }
-
-    void *start = info->dlpi_tls_data;
-    size_t len = phdr.p_memsz;
-
-    void *start_round_down = (void *)((uint64_t)start & ~0xFFFUL);
-    uint64_t start_moved = (uint64_t)start & 0xFFFUL;
-    // p_memsz is 0x1000 more than the size of what we actually need to protect
-    size_t len_round_up = (phdr.p_memsz + start_moved) & ~0xFFFUL;
-    if (len_round_up == 0) {
-      const char *libname = basename(info->dlpi_name);
-      /* dlpi_name is "" for the main executable */
-      if (libname && libname[0] == '\0') {
-        libname = "main";
-      }
-      printf("TLS segment of %s is not padded\n", libname);
-      exit(-1);
-    }
-    int mprotect_err = pkey_mprotect(start_round_down, len_round_up,
-                                     PROT_READ | PROT_WRITE, search_args->pkey);
-    if (mprotect_err != 0) {
-      printf("pkey_mprotect failed: %s\n", strerror(errno));
-      exit(-1);
-    }
-  }
-
   // TODO: We avoid dynamically allocating space for each of the `dlpi_phnum`
   // the SegmentInfo structs for simplicity. MAX_NUM_PHDRS is only an estimate,
   // so if this assert fails we should increment it. Once we test partition

--- a/libia2/ia2.c
+++ b/libia2/ia2.c
@@ -109,7 +109,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
     }
 
     /* Protect the TLS region except the page of the untrusted stack pointer. */
-    if (untrusted_stackptr_addr > start && untrusted_stackptr_addr < end) {
+    if (untrusted_stackptr_addr >= start && untrusted_stackptr_addr < end) {
       int mprotect_err =
           pkey_mprotect(start_round_down,
                         untrusted_stackptr_addr - (uint64_t)start_round_down,

--- a/libia2/ia2.c
+++ b/libia2/ia2.c
@@ -82,9 +82,9 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
     size_t len = phdr.p_memsz;
 
     void *start_round_down = (void *)((uint64_t)start & ~0xFFFUL);
-    uint64_t start_moved = (uint64_t)start & 0xFFFUL;
+    uint64_t start_moved_by = (uint64_t)start & 0xFFFUL;
     // p_memsz is 0x1000 more than the size of what we actually need to protect
-    size_t len_round_up = (phdr.p_memsz + start_moved) & ~0xFFFUL;
+    size_t len_round_up = (phdr.p_memsz + start_moved_by) & ~0xFFFUL;
     if (len_round_up == 0) {
       const char *libname = basename(info->dlpi_name);
       /* dlpi_name is "" for the main executable */

--- a/libia2/include/ia2.h
+++ b/libia2/include/ia2.h
@@ -314,5 +314,6 @@ static int insecure_pkey_mprotect(void *ptr, size_t len, int prot, int pkey) {
     /* Set up global resources. */                                             \
     ensure_pkeys_allocated(&ia2_n_pkeys_to_alloc);                             \
     /* Initialize stacks for the main thread/ */                               \
+    protect_tls();                                                             \
     init_stacks();                                                             \
   }

--- a/libia2/include/ia2.h
+++ b/libia2/include/ia2.h
@@ -135,12 +135,9 @@ static int insecure_pkey_mprotect(void *ptr, size_t len, int prot, int pkey) {
     /* stack pointer is part of the compartment whose stack it points to. */   \
     __asm__ volatile(                                                          \
         "mov %0, %%r10\n"                                                      \
-        "# zero eax/ebx/ecx/edx\n"                                             \
-        "xor %%eax,%%eax\n"                                                    \
-        "mov %%eax,%%ebx\n"                                                    \
-        "mov %%eax,%%ecx\n"                                                    \
-        "mov %%eax,%%edx\n"                                                    \
-        "# read old pkru\n"                                                    \
+        "# zero ecx as precondition of rdpkru\n"                               \
+        "xor %%ecx,%%ecx\n"                                                    \
+        "# eax = old pkru; also zeroes edx, which is required for wrpkru\n"    \
         IA2_RDPKRU "\n"                                                        \
         "# save pkru in r12d\n"                                                \
         "mov %%eax,%%r12d\n"                                                   \
@@ -162,7 +159,7 @@ static int insecure_pkey_mprotect(void *ptr, size_t len, int prot, int pkey) {
         IA2_WRPKRU "\n"                                                        \
         :                                                                      \
         : "rax"(stack)                                                         \
-        : "rdi", "rbx", "rcx", "rdx", "r10", "r11", "r12");                    \
+        : "rdi", "rcx", "rdx", "r10", "r11", "r12");                           \
   }
 /* clang-format on */
 

--- a/libia2/main.c
+++ b/libia2/main.c
@@ -16,6 +16,7 @@ __attribute__((naked)) int __wrap_main(int argc, char **argv) {
       // Load the stack pointer for this compartment's stack.
       "mov ia2_stackptr_1@GOTTPOFF(%%rip), %%r11\n"
       "mov %%fs:(%%r11), %%rsp\n"
+      // Switch pkey to the appropriate compartment.
       "xor %%ecx,%%ecx\n"
       "mov %%ecx,%%edx\n"
       "mov_pkru_eax 1\n"

--- a/libia2/main.c
+++ b/libia2/main.c
@@ -7,6 +7,7 @@ static void *main_sp __attribute__((used)) = 0;
 
 __attribute__((naked)) int __wrap_main(int argc, char **argv) {
   __asm__(
+      /* clang-format off */
       "pushq %%rbp\n"
       "movq %%rsp, %%rbp\n"
       // Save the old stack pointer in main_sp.
@@ -21,5 +22,7 @@ __attribute__((naked)) int __wrap_main(int argc, char **argv) {
       // Restore the old stack pointer before returning.
       "mov main_sp(%%rip), %%rsp\n"
       "popq %%rbp\n"
-      "ret\n" ::);
+      "ret\n"
+      /* clang-format on */
+      ::);
 }

--- a/libia2/main.c
+++ b/libia2/main.c
@@ -1,0 +1,25 @@
+#include "ia2.h"
+
+int __real_main(int argc, char **argv);
+
+/* Stores the stack pointer to return to after main() is called. */
+static void *main_sp __attribute__((used)) = 0;
+
+__attribute__((naked)) int __wrap_main(int argc, char **argv) {
+  __asm__(
+      "pushq %%rbp\n"
+      "movq %%rsp, %%rbp\n"
+      // Save the old stack pointer in main_sp.
+      "movq %%rsp, main_sp(%%rip)\n"
+      // Load the stack pointer for this compartment's stack.
+      "mov ia2_stackptr_1@GOTTPOFF(%%rip), %%r11\n"
+      "mov %%fs:(%%r11), %%rsp\n"
+      // Align the stack before calling main.
+      "subq $8, %%rsp\n"
+      // Call the real main function.
+      "call __real_main\n"
+      // Restore the old stack pointer before returning.
+      "mov main_sp(%%rip), %%rsp\n"
+      "popq %%rbp\n"
+      "ret\n" ::);
+}

--- a/libia2/main.c
+++ b/libia2/main.c
@@ -5,6 +5,7 @@ int __real_main(int argc, char **argv);
 /* Stores the stack pointer to return to after main() is called. */
 static void *main_sp __attribute__((used)) = 0;
 
+/* XXX: Assumes main compartment has pkey 1. */
 __attribute__((naked)) int __wrap_main(int argc, char **argv) {
   __asm__(
       /* clang-format off */

--- a/libia2/main.c
+++ b/libia2/main.c
@@ -15,6 +15,10 @@ __attribute__((naked)) int __wrap_main(int argc, char **argv) {
       // Load the stack pointer for this compartment's stack.
       "mov ia2_stackptr_1@GOTTPOFF(%%rip), %%r11\n"
       "mov %%fs:(%%r11), %%rsp\n"
+      "xor %%ecx,%%ecx\n"
+      "mov %%ecx,%%edx\n"
+      "mov_pkru_eax 1\n"
+      IA2_WRPKRU "\n"
       // Align the stack before calling main.
       "subq $8, %%rsp\n"
       // Call the real main function.

--- a/libia2/threads.c
+++ b/libia2/threads.c
@@ -47,10 +47,12 @@ void *ia2_thread_begin(void *arg) {
 #endif
       // Push old stack pointer, which aligns the stack.
       "pushq %%rdi\n"
+      "pushq %%rbp\n"
       // Call fn(data).
       "mov %[data], %%rdi\n"
       "call *%[fn]\n"
       // Restore old stack pointer.
+      "popq %%rbp\n"
       "popq %%rsp\n"
       : "=a"(result)
       : [fn] "rm"(fn), [data] "rm"(data), [new_sp_addr] "r"(new_sp_addr)

--- a/libia2/threads.c
+++ b/libia2/threads.c
@@ -55,7 +55,7 @@ void *ia2_thread_begin(void *arg) {
       "popq %%rbp\n"
       "popq %%rsp\n"
       : "=a"(result)
-      : [fn] "rm"(fn), [data] "rm"(data), [new_sp_addr] "r"(new_sp_addr)
+      : [fn] "r"(fn), [data] "r"(data), [new_sp_addr] "r"(new_sp_addr)
       : "rdi");
   /* clang-format on */
   return result;

--- a/libia2/threads.c
+++ b/libia2/threads.c
@@ -45,13 +45,19 @@ void *ia2_thread_begin(void *arg) {
       // Load the stack pointer for this compartment's stack.
       "mov (%[new_sp_addr]), %%rsp\n"
 #endif
-      // Push old stack pointer, which aligns the stack.
+      // Push old stack pointer.
       "pushq %%rdi\n"
       "pushq %%rbp\n"
+      // Save %rsp before alignment.
+      "movq %%rsp, %%rbp\n"
+      // Align the stack.
+      "andq $0xfffffffffffffff0, %%rsp\n"
       // Call fn(data).
       "mov %[data], %%rdi\n"
       "call *%[fn]\n"
-      // Restore old stack pointer.
+      // Restore pre-alignment stack pointer.
+      "movq %%rbp, %%rsp\n"
+      // Switch stacks back.
       "popq %%rbp\n"
       "popq %%rsp\n"
       : "=a"(result)

--- a/libia2/threads.c
+++ b/libia2/threads.c
@@ -4,6 +4,7 @@
 
 void init_stacks(void);
 void protect_tls(void);
+void **ia2_stackptr_for_pkru(uint32_t pkey);
 
 struct ia2_thread_thunk {
   void *(*fn)(void *);
@@ -20,9 +21,36 @@ void *ia2_thread_begin(void *arg) {
   protect_tls();
   init_stacks();
 
-  /* TODO: switch to compartment stack before calling `fn` */
+  /* Determine the current compartment so know which stack to use. */
+  uint32_t pkru = 0;
+  __asm__ volatile(
+      /* clang-format off */
+      "xor %%ecx,%%ecx\n"
+      IA2_RDPKRU "\n"
+      /* clang-format on */
+      : "=a"(pkru)::"ecx", "edx");
+  void **new_sp_addr = ia2_stackptr_for_pkru(pkru);
 
-  return fn(data);
+  /* Switch to the stack for this compartment, then call `fn(data)`. */
+  void *result;
+  __asm__ volatile(
+      /* clang-format off */
+      // Copy stack pointer to rdi.
+      "movq %%rsp, %%rdi\n"
+      // Load the stack pointer for this compartment's stack.
+      "mov (%[new_sp_addr]), %%rsp\n"
+      // Push old stack pointer, which aligns the stack.
+      "pushq %%rdi\n"
+      // Call fn(data).
+      "mov %[data], %%rdi\n"
+      "call *%[fn]\n"
+      // Restore old stack pointer.
+      "popq %%rsp\n"
+      : "=a"(result)
+      : [fn] "rm"(fn), [data] "rm"(data), [new_sp_addr] "r"(new_sp_addr)
+      : "rdi");
+  /* clang-format on */
+  return result;
 }
 
 int __real_pthread_create(pthread_t *restrict thread,

--- a/libia2/threads.c
+++ b/libia2/threads.c
@@ -48,12 +48,13 @@ void *ia2_thread_begin(void *arg) {
       // Push old stack pointer.
       "pushq %%rdi\n"
       "pushq %%rbp\n"
+      // Load argument.
+      "mov %[data], %%rdi\n"
       // Save %rsp before alignment.
       "movq %%rsp, %%rbp\n"
       // Align the stack.
       "andq $0xfffffffffffffff0, %%rsp\n"
       // Call fn(data).
-      "mov %[data], %%rdi\n"
       "call *%[fn]\n"
       // Restore pre-alignment stack pointer.
       "movq %%rbp, %%rsp\n"

--- a/libia2/threads.c
+++ b/libia2/threads.c
@@ -17,8 +17,8 @@ void *ia2_thread_begin(void *arg) {
   /* Free the thunk. */
   munmap(arg, sizeof(struct ia2_thread_thunk));
 
-  init_stacks();
   protect_tls();
+  init_stacks();
 
   /* TODO: switch to compartment stack before calling `fn` */
 


### PR DESCRIPTION
This means writing the PKRU before `main` and switching stacks for both `main` and thread body functions.

We do not currently restore PKRU after calling `main`; that's what @rinon is working on.

This PR also includes some security fixes around threading setup and TLS; see the commits "move thread-local padding to ia2.h and verify untrusted compartment TLS padding at runtime" and "fix stack/tls setup logic".

Fixes #171.