### PR TITLE
Rewrite functions compared to function pointers

### DIFF
--- a/header-rewriter/SourceRewriter.cpp
+++ b/header-rewriter/SourceRewriter.cpp
@@ -866,7 +866,7 @@ int main(int argc, const char **argv) {
   header_out << '\n';
 
   header_out << "#define IA2_FN_ADDR(func) (typeof(&func))(&__ia2_##func)\n";
-  header_out << "#define IA2_ADDR(opaque) opaque.ptr\n";
+  header_out << "#define IA2_ADDR(opaque) (void*)((opaque).ptr)\n";
   header_out
       << "#define IA2_FN(func) (typeof(__ia2_##func)) { (void*)&__ia2_##func }\n";
 

--- a/header-rewriter/tests/rewrite_fn_ptr_eq/main.c
+++ b/header-rewriter/tests/rewrite_fn_ptr_eq/main.c
@@ -53,6 +53,10 @@ int main() {
     struct module *mod_ptr = &mod;
     if (mod_ptr->fn) { }
 
+    bin_op *ptr = &fn;
+    // REWRITER: if (IA2_ADDR(*ptr)) { }
+    if (*ptr) { }
+
     // REWRITER: if (NULL == IA2_ADDR(mod_ptr->fn)) { }
     if (NULL == mod_ptr->fn) { }
     // REWRITER: if (IA2_ADDR(mod.fn) != NULL) { }

--- a/header-rewriter/tests/rewrite_fn_ptr_eq/main.c
+++ b/header-rewriter/tests/rewrite_fn_ptr_eq/main.c
@@ -61,6 +61,11 @@ int main() {
     // REWRITER: if (IA2_ADDR(mod.fn) == IA2_ADDR(mod_ptr->fn)) { }
     if (mod.fn == mod_ptr->fn) { }
 
+    // REWRITER: if (IA2_ADDR(mod.fn) == IA2_FN_ADDR(add)) { }
+    if (mod.fn == add) { }
+    // REWRITER: if (IA2_FN_ADDR(sub) == IA2_ADDR(mod_ptr->fn)) { }
+    if (sub == mod_ptr->fn) { }
+
     // REWRITER: if (x && IA2_ADDR(fn2)) { }
     if (x && fn2) { }
     // REWRITER: if (y || !IA2_ADDR(fn)) { }


### PR DESCRIPTION
This adds two new AST matchers to the FnPtrEq rewriter pass for when functions appear on either side of a binary operator (excluding assignments). These passes rewrite function operands as `IA2_FN_ADDR(function)` which expands to the address of the call gate wrapper for the function. This is necessary because if the other side of the binary operator is a function pointer it can only ever be NULL or point to a call gate wrapper so it can never be equal to the original function. Also while the existing FnPtrEq matchers applied to all non-assignment binary operators (e.g. `some_condition && ptr` or ||), the changes above only apply to the == and != operators.

The first commit also restricts the cases that the FnPtrExpr pass applies to to avoid overlap with the new AST matchers. This is analogous to the existing `unless(call_expr)` in FnPtrExpr which is required since the FnPtrCall pass rewrites a subset of all function pointer expressions.

The second commit just fixes some issues with IA2_ADDR (see commit message for details).