### PR TITLE
Remove PKEY argument from IA2_CALL macro

### DIFF
--- a/header-rewriter/tests/read_config/main.c
+++ b/header-rewriter/tests/read_config/main.c
@@ -2,6 +2,7 @@
 RUN: cat read_config_call_gates_2.ld | FileCheck --check-prefix=LINKARGS %s
 TODO: %binary_dir/tests/read_config/read_config_main_wrapped | diff %S/Output/read_config.out -
 RUN: readelf -lW %binary_dir/tests/read_config/read_config_main_wrapped | FileCheck --check-prefix=SEGMENTS %s
+RUN: cat main.c | FileCheck --match-full-lines --check-prefix=REWRITER %s
 */
 
 // Check that readelf shows exactly one executable segment
@@ -119,7 +120,7 @@ int main(int arcg, char **argv) {
     // This function pointer may come from the plugin, so drop from pkey 1 to
     // pkey 0 before calling it. If the function is in the built-in module,
     // it'll have a wrapper from pkey 0 to pkey 1.
-    // REWRITER: IA2_CALL(opt->parse, 0, 1)(delim + 1, &shared_entry.value);
+    // REWRITER: IA2_CALL((opt->parse), 0)(delim + 1, &shared_entry.value);
     (opt->parse)(delim + 1, &shared_entry.value);
     // Copy the value from the shared entry to the main binary's stack.
     entries[idx].value = shared_entry.value;

--- a/header-rewriter/tests/simple1/main.c
+++ b/header-rewriter/tests/simple1/main.c
@@ -79,7 +79,7 @@ int main() {
     // untrusted since libsimple1 sets the value of exit_hook_fn. If
     // exit_hook_fn were to point to a function defined in this binary, it must
     // be a wrapped function with an untrusted caller and callee with pkey 0.
-    // REWRITER: IA2_CALL(exit_hook_fn, 0, 1)();
+    // REWRITER: IA2_CALL(exit_hook_fn, 0)();
     exit_hook_fn();
   }
 


### PR DESCRIPTION
Since all translation units must be compiled with `-DPKEY=N` we can use this macro to avoid specifying the pkey argument in the IA2_CALL macro. This commit also updates tests with `IA2_CALL` and enables the rewriter checks in the read_config and trusted_indirect tests.