### PR TITLE
Remove mangled type ID from IA2_CALL macro

### DIFF
--- a/rewriter/SourceRewriter.cpp
+++ b/rewriter/SourceRewriter.cpp
@@ -319,9 +319,8 @@ private:
 };
 
 /*
- * Rewrites indirect function calls as `IA2_CALL(fn_ptr)`. fn_ptr is
- * the original function pointer expression. ID is an integer assigned by this
- * pass and specific to each function pointer signature.
+ * Rewrites indirect function calls as `IA2_CALL(fn_ptr)` where fn_ptr is the
+ * original function pointer expression.
  */
 class FnPtrCall : public RefactoringCallback {
 public:
@@ -361,7 +360,6 @@ public:
       return;
     }
 
-    // Check if the function pointer type already has an ID
     auto expr_ty = fn_ptr_call->getType()->getCanonicalTypeInternal();
     FunctionType expr_ty_str = type_string(expr_ty);
 
@@ -920,16 +918,41 @@ int main(int argc, const char **argv) {
       wrapper_out << ");\n";
 
       wrapper_decls += "extern char " + wrapper_name + ";\n";
+      /*
+       * This is the first argument to choose_expr below which checks if the
+       * opaque struct expression passed to IA2_SELECT_CALL has the same type as
+       * any of the indirect callsites that we are looping over
+       */
       auto types_match = "__builtin_types_compatible_p(typeof(opaque), "s +
                          kFnPtrTypePrefix + opaque_ty + " )";
+      /*
+       * This is the second argument to choose_expr which expands to the address
+       * of the indirect callgate we generated in this iteration of the loop
+       * cast to the appropriate type
+       */
       auto call_gate = "("s + fn_ptr_ty + ")&__ia2_indirect_callgate_" +
                        opaque_ty + "_pkey_##pkey";
+      /*
+       * Add a new line to the IA2_SELECT_CALL macro. Each line has a
+       * choose_expr call with the two arguments described above. The third
+       * argument to every choose_expr is the following line which is added in
+       * the next iteration of this loop. For the last iteration we generate an
+       * expression after the loop.
+       */
       select_call_macro += "    __builtin_choose_expr(" + types_match + ", " +
                            call_gate + ", \\\n";
       closing_parens += 1;
     }
   }
-  select_call_macro += "(void *)0";
+  /*
+   * This is the third argument for the last choose_expr in the loop. Since
+   * IA2_SELECT_CALL is only added at callsites (indirectly through the IA2_CALL
+   * macro), this expression will give a compiler error if evaluated. We want a
+   * compiler error in this case because if it's reached, it means an opaque
+   * struct without a corresponding call gate was passed to IA2_CALL
+   */
+  select_call_macro += "    (void *)0";
+  // Add closing parentheses for each choose_expr call in the loop
   for (int i = 0; i < closing_parens; i++) {
     select_call_macro += ")";
   }

--- a/rewriter/tests/read_config/main.c
+++ b/rewriter/tests/read_config/main.c
@@ -120,7 +120,7 @@ int main(int arcg, char **argv) {
     // This function pointer may come from the plugin, so drop from pkey 1 to
     // pkey 0 before calling it. If the function is in the built-in module,
     // it'll have a wrapper from pkey 0 to pkey 1.
-    // REWRITER: IA2_CALL((opt->parse), 0)(delim + 1, &shared_entry.value);
+    // REWRITER: IA2_CALL((opt->parse))(delim + 1, &shared_entry.value);
     (opt->parse)(delim + 1, &shared_entry.value);
     // Copy the value from the shared entry to the main binary's stack.
     entries[idx].value = shared_entry.value;

--- a/rewriter/tests/simple1/main.c
+++ b/rewriter/tests/simple1/main.c
@@ -79,7 +79,7 @@ int main() {
     // untrusted since libsimple1 sets the value of exit_hook_fn. If
     // exit_hook_fn were to point to a function defined in this binary, it must
     // be a wrapped function with an untrusted caller and callee with pkey 0.
-    // REWRITER: IA2_CALL(exit_hook_fn, 0)();
+    // REWRITER: IA2_CALL(exit_hook_fn)();
     exit_hook_fn();
   }
 

--- a/rewriter/tests/trusted_indirect/main.c
+++ b/rewriter/tests/trusted_indirect/main.c
@@ -36,16 +36,16 @@ void call_fn_ptr() {
     uint32_t x = 987234;
     uint32_t y = 142151;
     // This calls `f.op` with and without parentheses to ensure the rewriter handles both
-    // REWRITER: uint32_t res = IA2_CALL(f.op, 0)(x, y);
+    // REWRITER: uint32_t res = IA2_CALL(f.op)(x, y);
     uint32_t res = f.op(x, y);
     printf("%s(%d, %d) = %d\n", f.name, x, y, res);
     // REWRITER: f.op = IA2_FN(multiply);
     f.op = multiply;
-    // REWRITER: printf("mul(%d, %d) = %d\n", x, y, IA2_CALL((f.op), 0)(x, y));
+    // REWRITER: printf("mul(%d, %d) = %d\n", x, y, IA2_CALL((f.op))(x, y));
     printf("mul(%d, %d) = %d\n", x, y, (f.op)(x, y));
     // REWRITER: f.op = IA2_FN(divide);
     f.op = divide;
-    // REWRITER: printf("div(%d, %d) = %d\n", x, y, IA2_CALL(f.op, 0)(x, y));
+    // REWRITER: printf("div(%d, %d) = %d\n", x, y, IA2_CALL(f.op)(x, y));
     printf("div(%d, %d) = %d\n", x, y, f.op(x, y));
 }
 
@@ -65,6 +65,6 @@ int main(int argc, char **argv) {
 
     static uint32_t secret = 34;
     leak_secret_address(&secret);
-    // REWRITER: IA2_CALL((f.op), 0)(0, 0);
+    // REWRITER: IA2_CALL((f.op))(0, 0);
     (f.op)(0, 0);
 }


### PR DESCRIPTION
Marked as WIP since I'm not sure if we want to merge this yet and because this doesn't completely remove the mangled type IDs. Ideally we'd remove them completely and leave only the mangled types in symbol names (i.e. won't be visible to the user) to simplify #208.