### PR TITLE
Revert "Remove mangled type ID from IA2_CALL macro"

### DIFF
--- a/rewriter/SourceRewriter.cpp
+++ b/rewriter/SourceRewriter.cpp
@@ -33,7 +33,6 @@ typedef std::string Function;
 typedef std::string Filename;
 typedef int Pkey;
 typedef std::string OpaqueStruct;
-typedef std::string FunctionType;
 
 // Apply a custom category to all command-line options so that they are the
 // only ones displayed.
@@ -110,6 +109,7 @@ public:
   virtual void run(const MatchFinder::MatchResult &result) {
     const clang::Decl *old_decl = nullptr;
     clang::QualType old_type;
+    std::string mangled_type;
     std::function<std::string(std::string &, std::string &)> generate_decl;
 
     // We only need to replace a subset of the source range for some fnPtrVar
@@ -205,15 +205,12 @@ public:
       return;
     }
 
-    OpaqueStruct mangled_type_name =
-        mangle_type(ctxt, fpt->getCanonicalTypeInternal());
-    std::string new_type = kFnPtrTypePrefix + mangled_type_name;
+    mangled_type = mangle_type(ctxt, fpt->getCanonicalTypeInternal());
+    OpaqueStruct new_type = kFnPtrTypePrefix + mangled_type;
     std::string name = llvm::cast<clang::NamedDecl>(old_decl)->getName().str();
     std::string new_decl = generate_decl(new_type, name);
 
-    std::string old_type_str =
-        type_string(old_type->getCanonicalTypeInternal());
-    fn_ptr_types[old_type_str] = mangled_type_name;
+    fn_ptr_types.insert(new_type);
 
     // This check must come after inserting new_type into fn_ptr_types but
     // before the Replacement is added
@@ -241,7 +238,7 @@ public:
     return;
   }
 
-  std::map<FunctionType, OpaqueStruct> fn_ptr_types;
+  std::set<OpaqueStruct> fn_ptr_types;
 
 private:
   std::map<std::string, Replacements> &file_replacements;
@@ -319,7 +316,7 @@ private:
 };
 
 /*
- * Rewrites indirect function calls as `IA2_CALL(fn_ptr)`. fn_ptr is
+ * Rewrites indirect function calls as `IA2_CALL(fn_ptr, ID)`. fn_ptr is
  * the original function pointer expression. ID is an integer assigned by this
  * pass and specific to each function pointer signature.
  */
@@ -328,6 +325,8 @@ public:
   FnPtrCall(ASTMatchRefactorer &refactorer,
             std::map<std::string, Replacements> &file_replacements)
       : file_replacements(file_replacements) {
+    // Initialize the function pointer signature ID counter
+    id_counter = 0;
 
     // This matches expressions that reference declared functions and we use
     // this to filter out direct calls in the following matcher
@@ -363,11 +362,12 @@ public:
 
     // Check if the function pointer type already has an ID
     auto expr_ty = fn_ptr_call->getType()->getCanonicalTypeInternal();
-    FunctionType expr_ty_str = type_string(expr_ty);
-
-    if (!called_fn_ptr_types.contains(expr_ty_str)) {
-      called_fn_ptr_types.insert(expr_ty_str);
+    auto expr_ty_str = expr_ty.getAsString();
+    if (!fn_ptr_ids.contains(expr_ty_str)) {
+      fn_ptr_ids[expr_ty_str] = id_counter;
+      id_counter += 1;
     }
+    auto fn_ptr_id = std::to_string(fn_ptr_ids.at(expr_ty_str));
 
     auto *fpt = expr_ty->castAs<clang::PointerType>()
                     ->getPointeeType()
@@ -385,7 +385,7 @@ public:
       if (spelling_line != expansion_line) {
         llvm::errs() << filename << ":" << spelling_line << " ";
       }
-      llvm::errs() << "must be rewritten manually\n";
+      llvm::errs() << "must be rewritten manually (ID = " << fn_ptr_id << ")\n";
       return;
     }
 
@@ -396,7 +396,8 @@ public:
     auto old_expr =
         clang::Lexer::getSourceText(char_range, sm, ctxt.getLangOpts());
 
-    std::string new_expr = "IA2_CALL("s + old_expr.str() + ")";
+    std::string new_expr =
+        "IA2_CALL("s + old_expr.str() + ", " + fn_ptr_id + ")";
 
     Replacement r{sm, char_range, new_expr};
     auto err = file_replacements[filename].add(r);
@@ -406,11 +407,12 @@ public:
     return;
   }
 
-  std::set<FunctionType> called_fn_ptr_types;
-  std::map<FunctionType, CAbiSignature> fn_ptr_abi_sig;
+  std::map<OpaqueStruct, int> fn_ptr_ids;
+  std::map<OpaqueStruct, CAbiSignature> fn_ptr_abi_sig;
 
 private:
   std::map<std::string, Replacements> &file_replacements;
+  int id_counter;
 };
 
 /*
@@ -848,7 +850,7 @@ int main(int argc, const char **argv) {
 
   auto rc = tool.runAndSave(newFrontendActionFactory(&refactorer).get());
   if (rc != 0) {
-    return rc;
+      return rc;
   }
 
   const char *assert_pkru_macro =
@@ -889,11 +891,13 @@ int main(int argc, const char **argv) {
    * ptr. Otherwise it sets ia2_fn_ptr to the opaque struct's value then calls
    * an indirect call gate depending on the opaque struct's type.
    */
-  header_out << "#define _IA2_CALL(opaque, pkey) ({ \\\n";
+  header_out << "#define __IA2_CALL(opaque, id, pkey) ({ \\\n";
   header_out << "  ia2_fn_ptr = opaque.ptr; \\\n";
-  header_out << "  IA2_SELECT_CALL(opaque, pkey); \\\n";
+  header_out
+      << "  (IA2_TYPE_##id)&__ia2_indirect_callgate_##id##_pkey_##pkey; \\\n";
   header_out << "})\n";
-  header_out << "#define IA2_CALL(opaque) _IA2_CALL(opaque, PKEY)\n";
+  header_out << "#define _IA2_CALL(opaque, id, pkey) __IA2_CALL(opaque, id, pkey)\n";
+  header_out << "#define IA2_CALL(opaque, id) _IA2_CALL(opaque, id, PKEY)\n";
 
   wrapper_out << "#include \"scrub_registers.h\"\n";
   wrapper_out << "#ifdef LIBIA2_INSECURE\n";
@@ -913,28 +917,20 @@ int main(int argc, const char **argv) {
    */
   std::cout << "Generating indirect callsite wrappers\n";
   std::string wrapper_decls;
-  std::string select_call_macro = "#define IA2_SELECT_CALL(opaque, pkey) \\\n"s;
-  int closing_parens = 0;
+  std::set<int> type_id_macros_generated = {};
   for (int caller_pkey = 1; caller_pkey < num_pkeys; caller_pkey++) {
-    for (const auto &fn_ptr_ty : ptr_call_pass.called_fn_ptr_types) {
-      std::string opaque_ty;
-      try {
-        opaque_ty = ptr_types_pass.fn_ptr_types.at(fn_ptr_ty);
-      } catch (std::out_of_range const &exc) {
-        llvm::errs() << "Could not find opaque type for " << fn_ptr_ty.c_str()
-                     << '\n';
-      }
-
+    for (const auto &[ty, id] : ptr_call_pass.fn_ptr_ids) {
       CAbiSignature c_abi_sig;
       try {
-        c_abi_sig = ptr_call_pass.fn_ptr_abi_sig.at(fn_ptr_ty);
+        c_abi_sig = ptr_call_pass.fn_ptr_abi_sig.at(ty);
       } catch (std::out_of_range const &exc) {
-        llvm::errs() << "Opaque struct " << opaque_ty.c_str()
+        llvm::errs() << "Opaque struct " << ty.c_str()
                      << " not found by FnPtrCall pass\n";
         assert(0);
       }
-      std::string wrapper_name = "__ia2_indirect_callgate_"s + opaque_ty +
-                                 "_pkey_" + std::to_string(caller_pkey);
+      std::string wrapper_name = "__ia2_indirect_callgate_"s +
+                                 std::to_string(id) + "_pkey_" +
+                                 std::to_string(caller_pkey);
       std::string asm_wrapper =
           emit_asm_wrapper(c_abi_sig, wrapper_name, std::nullopt,
                            WrapperKind::IndirectCallsite, caller_pkey, 0);
@@ -942,28 +938,20 @@ int main(int argc, const char **argv) {
       wrapper_out << asm_wrapper;
       wrapper_out << ");\n";
 
+      if (!type_id_macros_generated.contains(id)) {
+        header_out << "#define IA2_TYPE_"s << id << " " << ty << "\n";
+        type_id_macros_generated.insert(id);
+      }
       wrapper_decls += "extern char " + wrapper_name + ";\n";
-      auto types_match = "__builtin_types_compatible_p(typeof(opaque), "s +
-                         kFnPtrTypePrefix + opaque_ty + " )";
-      auto call_gate = "("s + fn_ptr_ty + ")&__ia2_indirect_callgate_" +
-                       opaque_ty + "_pkey_##pkey";
-      select_call_macro += "    __builtin_choose_expr(" + types_match + ", " +
-                           call_gate + ", \\\n";
-      closing_parens += 1;
     }
   }
-  select_call_macro += "(void *)0";
-  for (int i = 0; i < closing_parens; i++) {
-    select_call_macro += ")";
-  }
-  header_out << select_call_macro.c_str() << "\n";
   header_out << wrapper_decls.c_str();
 
   std::cout << "Generating opaque function pointer types\n";
   // Define opaque struct types for function pointers e.g.
   // struct IA2_fnptr__ZTSFiiE { char *ptr; };
-  for (const auto &[fn_type, opaque] : ptr_types_pass.fn_ptr_types) {
-    header_out << kFnPtrTypePrefix << opaque << " { char *ptr; };\n";
+  for (const auto &opaque : ptr_types_pass.fn_ptr_types) {
+    header_out << opaque << " { char *ptr; };\n";
   }
 
   // Declare the pointer read by the indirect call gates

--- a/rewriter/tests/read_config/main.c
+++ b/rewriter/tests/read_config/main.c
@@ -120,7 +120,7 @@ int main(int arcg, char **argv) {
     // This function pointer may come from the plugin, so drop from pkey 1 to
     // pkey 0 before calling it. If the function is in the built-in module,
     // it'll have a wrapper from pkey 0 to pkey 1.
-    // REWRITER: IA2_CALL((opt->parse))(delim + 1, &shared_entry.value);
+    // REWRITER: IA2_CALL((opt->parse), 0)(delim + 1, &shared_entry.value);
     (opt->parse)(delim + 1, &shared_entry.value);
     // Copy the value from the shared entry to the main binary's stack.
     entries[idx].value = shared_entry.value;

--- a/rewriter/tests/simple1/main.c
+++ b/rewriter/tests/simple1/main.c
@@ -79,7 +79,7 @@ int main() {
     // untrusted since libsimple1 sets the value of exit_hook_fn. If
     // exit_hook_fn were to point to a function defined in this binary, it must
     // be a wrapped function with an untrusted caller and callee with pkey 0.
-    // REWRITER: IA2_CALL(exit_hook_fn)();
+    // REWRITER: IA2_CALL(exit_hook_fn, 0)();
     exit_hook_fn();
   }
 

--- a/rewriter/tests/trusted_indirect/main.c
+++ b/rewriter/tests/trusted_indirect/main.c
@@ -36,16 +36,16 @@ void call_fn_ptr() {
     uint32_t x = 987234;
     uint32_t y = 142151;
     // This calls `f.op` with and without parentheses to ensure the rewriter handles both
-    // REWRITER: uint32_t res = IA2_CALL(f.op)(x, y);
+    // REWRITER: uint32_t res = IA2_CALL(f.op, 0)(x, y);
     uint32_t res = f.op(x, y);
     printf("%s(%d, %d) = %d\n", f.name, x, y, res);
     // REWRITER: f.op = IA2_FN(multiply);
     f.op = multiply;
-    // REWRITER: printf("mul(%d, %d) = %d\n", x, y, IA2_CALL((f.op))(x, y));
+    // REWRITER: printf("mul(%d, %d) = %d\n", x, y, IA2_CALL((f.op), 0)(x, y));
     printf("mul(%d, %d) = %d\n", x, y, (f.op)(x, y));
     // REWRITER: f.op = IA2_FN(divide);
     f.op = divide;
-    // REWRITER: printf("div(%d, %d) = %d\n", x, y, IA2_CALL(f.op)(x, y));
+    // REWRITER: printf("div(%d, %d) = %d\n", x, y, IA2_CALL(f.op, 0)(x, y));
     printf("div(%d, %d) = %d\n", x, y, f.op(x, y));
 }
 
@@ -65,6 +65,6 @@ int main(int argc, char **argv) {
 
     static uint32_t secret = 34;
     leak_secret_address(&secret);
-    // REWRITER: IA2_CALL((f.op))(0, 0);
+    // REWRITER: IA2_CALL((f.op), 0)(0, 0);
     (f.op)(0, 0);
 }


### PR DESCRIPTION
This reverts the commits in #222 because they require declaring all types which appear as arguments/return values in function pointer types in the generated header. Since some types such as typedefs and enums cannot be forward declared, this requires moving around existing type definitions which is tricky because of dependencies among types.