### PR TITLE
Fix permissive mode to restore PKRU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(IA2Phase2)
 
 find_package(PkgConfig REQUIRED)
 
+include(CTest)
 
 set(EXTERNAL_DIR ${PROJECT_SOURCE_DIR}/external)
 

--- a/libia2/CMakeLists.txt
+++ b/libia2/CMakeLists.txt
@@ -22,3 +22,5 @@ target_compile_definitions(libia2 PRIVATE _GNU_SOURCE)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/padding.ld ${CMAKE_CURRENT_BINARY_DIR}/)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/dynsym.syms ${CMAKE_CURRENT_BINARY_DIR}/)
+
+add_subdirectory(test)

--- a/libia2/CMakeLists.txt
+++ b/libia2/CMakeLists.txt
@@ -15,6 +15,8 @@ target_link_options(libia2
         "-Wl,--wrap=main"
 )
 
+target_link_libraries(libia2 PRIVATE dl)
+
 target_include_directories(libia2 PUBLIC include)
 target_compile_definitions(libia2 PRIVATE _GNU_SOURCE)
 

--- a/libia2/include/ia2.h
+++ b/libia2/include/ia2.h
@@ -36,6 +36,13 @@
 
 #endif
 
+/// Helper to get the PKRU register value
+static uint32_t ia2_get_pkru() {
+  uint32_t pkru;
+  __asm__ volatile("rdpkru" : "=a"(pkru) : "a"(0), "d"(0), "c"(0));
+  return pkru;
+}
+
 /// Protect pages in the given shared object
 ///
 /// \param info dynamic linker information for the current object

--- a/libia2/include/permissive_mode.h
+++ b/libia2/include/permissive_mode.h
@@ -1,10 +1,15 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE // for SIG* macro
 #endif
+#include <assert.h>
+#include <dlfcn.h>
 #include <pthread.h>
 #include <signal.h>
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 /*
  * PKRU is defined to be bit 9 in the XSAVE state component bitmap (Intel SDM

--- a/libia2/include/permissive_mode.h
+++ b/libia2/include/permissive_mode.h
@@ -196,6 +196,8 @@ static char log_name[24] IA2_SHARED_DATA = {0};
 
 // The main function in the logging thread
 void *log_mpk_violations(void *arg) {
+  /* Explicitly enter compartment 1, because this function isn't wrapped. */
+  __asm__("wrpkru\n" : : "a"(0xFFFFFFF0), "d"(0), "c"(0));
   snprintf(log_name, sizeof(log_name), "mpk_log_%d", getpid());
   FILE *log = fopen(log_name, "w");
   assert(log);

--- a/libia2/include/permissive_mode.h
+++ b/libia2/include/permissive_mode.h
@@ -77,7 +77,7 @@ int pkru_offset(void) {
   unsigned int ebx, edx;
   asm volatile("cpuid"
                : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
-               : "0"(eax), "2"(ebx));
+               : "0"(eax), "2"(ecx));
   return ebx;
 }
 

--- a/libia2/test/CMakeLists.txt
+++ b/libia2/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(permissive_mode_test permissive_mode.c)
+target_link_libraries(permissive_mode_test libia2)
+target_link_options(permissive_mode_test PRIVATE "-Wl,-z,now")
+
+if(NOT LIBIA2_INSECURE)
+  add_test(NAME permissive_mode_test COMMAND permissive_mode_test)
+endif()

--- a/libia2/test/permissive_mode.c
+++ b/libia2/test/permissive_mode.c
@@ -1,0 +1,26 @@
+#define _GNU_SOURCE
+#include <ia2.h>
+#include <permissive_mode.h>
+
+INIT_RUNTIME(1);
+INIT_COMPARTMENT(1);
+
+int main(int argc, char** argv) {
+    char* buffer = NULL;
+    assert(ia2_get_pkru() == 0xFFFFFFF0);
+
+    /* allocate an extra pkey */
+    assert(pkey_alloc(0, PKEY_DISABLE_ACCESS | PKEY_DISABLE_WRITE) == 2);
+
+    buffer = mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+
+    pkey_mprotect(buffer, 4096, PROT_READ | PROT_WRITE, 1);
+    buffer[0] = 'a';
+
+    pkey_mprotect(buffer, 4096, PROT_READ | PROT_WRITE, 2);
+    buffer[0] = 'b';
+
+    assert(ia2_get_pkru() == 0xFFFFFFF0);
+
+    return 0;
+}


### PR DESCRIPTION
Permissive mode had a few issues, most importantly:
- PKRU offset cpuid call was using the wrong register
- PKRU was not modified properly if it was 0 before the signal handler

The kernel only restores the PKRU value from the XSAVE area after the
signal handler if the PKRU bit in the XSAVE header is set (See Intel
manual Chapter 13.4 and linux kernel xstate.c). We want to change the
PKRU value after the permissive mode handler runs, so we need to make
sure this header bit is unconditionally set. If the PKRU value was 0,
the kernel will not set the bit before the signal handler runs.

Fixes #238 