### PR TITLE
Simplify ASSERT_PKRU to abort inline

### DIFF
--- a/rewriter/SourceRewriter.cpp
+++ b/rewriter/SourceRewriter.cpp
@@ -889,7 +889,9 @@ int main(int argc, const char **argv) {
       "    \"xorl %ecx, %ecx\\n\" \\\n"
       "    \"rdpkru\\n\" \\\n"
       "    \"cmpl $\" #pkru \", %eax\\n\" \\\n"
-      "    \"jne __libia2_abort\\n\" \\\n"
+      "    \"je 1f\\n\" \\\n"
+      "    \"ud2\\n\" \\\n"
+      "\"1:\\n\" \\\n"
       "    \"movq %r11, %rdx\\n\" \\\n"
       "    \"movq %r10, %rcx\\n\"\n"
       "#else\n"
@@ -931,9 +933,6 @@ int main(int argc, const char **argv) {
   wrapper_out << "#define IA2_WRPKRU \"wrpkru\"\n";
   wrapper_out << "#endif\n";
   wrapper_out << assert_pkru_macro;
-
-  wrapper_out << "asm(\"__libia2_abort:\\n\"\n"
-              << "    \"ud2\");\n";
 
   /*
    * Define wrappers for IA2_CALL. These switch from the caller's pkey to pkey 0


### PR DESCRIPTION
Jumping to a separate abort label hid the location that actually asserted when using a debugger. This change moves the abort instruction into the assert itself instead so that we abort with a useful PC value.