### PR TITLE
 Switch to compartment and probe global data pages during init

### DIFF
--- a/external/chromium/src/base/allocator/partition_allocator/partition_bucket.cc
+++ b/external/chromium/src/base/allocator/partition_allocator/partition_bucket.cc
@@ -42,7 +42,7 @@
 #endif  // BUILDFLAG(STARSCAN)
 
 #include <sys/mman.h>
-#include <ia2_get_pkey.h>
+#include <ia2.h>
 
 namespace partition_alloc::internal {
 

--- a/libia2/CMakeLists.txt
+++ b/libia2/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(libia2 PRIVATE dl)
 
 target_include_directories(libia2 PUBLIC include)
 target_compile_definitions(libia2 PUBLIC _GNU_SOURCE)
+set_target_properties(libia2 PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/padding.ld ${CMAKE_CURRENT_BINARY_DIR}/)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/dynsym.syms ${CMAKE_CURRENT_BINARY_DIR}/)

--- a/libia2/ia2.c
+++ b/libia2/ia2.c
@@ -5,6 +5,74 @@
 
 #include "ia2.h"
 
+#ifdef LIBIA2_INSECURE
+size_t ia2_get_pkey() { return 0; }
+#else
+size_t ia2_get_pkey() {
+  uint32_t pkru;
+  __asm__("rdpkru" : "=a"(pkru) : "a"(0), "d"(0), "c"(0));
+  switch (pkru) {
+  case 0xFFFFFFFC: {
+    return 0;
+  }
+  case 0xFFFFFFF0: {
+    return 1;
+  }
+  case 0xFFFFFFCC: {
+    return 2;
+  }
+  case 0xFFFFFF3C: {
+    return 3;
+  }
+  case 0xFFFFFCFC: {
+    return 4;
+  }
+  case 0xFFFFF3FC: {
+    return 5;
+  }
+  case 0xFFFFCFFC: {
+    return 6;
+  }
+  case 0xFFFF3FFC: {
+    return 7;
+  }
+  case 0xFFFCFFFC: {
+    return 8;
+  }
+  case 0xFFF3FFFC: {
+    return 9;
+  }
+  case 0xFFCFFFFC: {
+    return 10;
+  }
+  case 0xFF3FFFFC: {
+    return 11;
+  }
+  case 0xFCFFFFFC: {
+    return 12;
+  }
+  case 0xF3FFFFFC: {
+    return 13;
+  }
+  case 0xCFFFFFFC: {
+    return 14;
+  }
+  case 0x3FFFFFFC: {
+    return 15;
+  }
+  // TODO: We currently treat any unexpected PKRU value as pkey 0 (the shared
+  // heap) for simplicity since glibc(?) initializes the PKRU to 0x55555554
+  // (usually). We don't set the PKRU until the first compartment transition, so
+  // let's default to using the shared heap before our first wrpkru. When we
+  // initialize the PKRU properly (see issue #95) we should probably abort when
+  // we see unexpected PKRU values.
+  default: {
+    return 0;
+  }
+  }
+}
+#endif // LIBIA2_INSECURE
+
 static const char *shared_sections[][2] = {
     {"__start_ia2_shared_data", "__stop_ia2_shared_data"},
 };

--- a/libia2/include/ia2.h
+++ b/libia2/include/ia2.h
@@ -100,6 +100,12 @@ static uint32_t ia2_get_pkru() {
 #define IA2_IGNORE_FIELD(decl) decl
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+size_t ia2_get_pkey();
+
 /// Protect pages in the given shared object
 ///
 /// \param info dynamic linker information for the current object
@@ -310,3 +316,7 @@ static int insecure_pkey_mprotect(void *ptr, size_t len, int prot, int pkey) {
     protect_tls();                                                             \
     init_stacks();                                                             \
   }
+
+#ifdef __cplusplus
+}
+#endif

--- a/libia2/include/ia2_compartment_init.inc
+++ b/libia2/include/ia2_compartment_init.inc
@@ -10,6 +10,10 @@
 #define CONCAT(x, y) CONCAT_(x, y)
 #define COMPARTMENT_IDENT(name) CONCAT(name##_, IA2_COMPARTMENT)
 
+/* Fully expand x to a string if x is a macro (e.g. IA2_COMPARTMENT) */
+#define XSTR(x) STR(x)
+#define STR(x) #x
+
 __thread void *COMPARTMENT_IDENT(ia2_stackptr) __attribute__((used));
 
 #ifndef LIBIA2_INSECURE
@@ -29,7 +33,26 @@ __attribute__((constructor)) static void COMPARTMENT_IDENT(init_pkey)() {
       .pkey = IA2_COMPARTMENT,
       .address = &COMPARTMENT_IDENT(init_pkey),
   };
+
+  __asm__ volatile(
+      /* Set PKRU to the compartment's value */
+      "xorl %%ecx, %%ecx\n"
+      "xorl %%edx, %%edx\n"
+      "mov_pkru_eax " XSTR(IA2_COMPARTMENT) "\n"
+      IA2_WRPKRU "\n"
+      :
+      :
+      : "rax", "rcx", "rdx");
   dl_iterate_phdr(protect_pages, &args);
+  __asm__ volatile(
+      /* Set PKRU to fully untrusted (no access) */
+      "xorl %%ecx, %%ecx\n"
+      "xorl %%edx, %%edx\n"
+      "xorl %%eax, %%eax\n"
+      IA2_WRPKRU "\n"
+      :
+      :
+      : "rax", "rcx", "rdx");
 }
 
 void COMPARTMENT_IDENT(init_tls)(void) {

--- a/partition-alloc/CMakeLists.txt
+++ b/partition-alloc/CMakeLists.txt
@@ -57,6 +57,8 @@ add_library(partition-alloc SHARED
     src/allocator_shim.cc
     ${PA_SRCS})
 
+target_link_libraries(partition-alloc libia2)
+
 if(LIBIA2_INSECURE)
     target_compile_definitions(partition-alloc PUBLIC LIBIA2_INSECURE=1)
 endif()

--- a/partition-alloc/src/allocator_shim.cc
+++ b/partition-alloc/src/allocator_shim.cc
@@ -8,77 +8,7 @@
 #include "allocator_shim.h"
 #include "base/allocator/partition_allocator/partition_alloc.h"
 #include "base/allocator/partition_allocator/partition_root.h"
-#include <ia2_get_pkey.h>
-
-extern "C" {
-
-#ifdef LIBIA2_INSECURE
-size_t ia2_get_pkey() { return 0; }
-#else
-size_t ia2_get_pkey() {
-  uint32_t pkru;
-  __asm__("rdpkru" : "=a"(pkru) : "a"(0), "d"(0), "c"(0));
-  switch (pkru) {
-  case 0xFFFFFFFC: {
-    return 0;
-  }
-  case 0xFFFFFFF0: {
-    return 1;
-  }
-  case 0xFFFFFFCC: {
-    return 2;
-  }
-  case 0xFFFFFF3C: {
-    return 3;
-  }
-  case 0xFFFFFCFC: {
-    return 4;
-  }
-  case 0xFFFFF3FC: {
-    return 5;
-  }
-  case 0xFFFFCFFC: {
-    return 6;
-  }
-  case 0xFFFF3FFC: {
-    return 7;
-  }
-  case 0xFFFCFFFC: {
-    return 8;
-  }
-  case 0xFFF3FFFC: {
-    return 9;
-  }
-  case 0xFFCFFFFC: {
-    return 10;
-  }
-  case 0xFF3FFFFC: {
-    return 11;
-  }
-  case 0xFCFFFFFC: {
-    return 12;
-  }
-  case 0xF3FFFFFC: {
-    return 13;
-  }
-  case 0xCFFFFFFC: {
-    return 14;
-  }
-  case 0x3FFFFFFC: {
-    return 15;
-  }
-  // TODO: We currently treat any unexpected PKRU value as pkey 0 (the shared
-  // heap) for simplicity since glibc(?) initializes the PKRU to 0x55555554
-  // (usually). We don't set the PKRU until the first compartment transition, so
-  // let's default to using the shared heap before our first wrpkru. When we
-  // initialize the PKRU properly (see issue #95) we should probably abort when
-  // we see unexpected PKRU values.
-  default: {
-    return 0;
-  }
-  }
-}
-#endif // LIBIA2_INSECURE
+#include <ia2.h>
 
 using namespace partition_alloc::internal;
 using partition_alloc::PartitionOptions;
@@ -217,5 +147,3 @@ void *ShimCallocWithPkey(size_t num, size_t size, size_t pkey) {
     return ret;
   }
 }
-
-} // extern "C"

--- a/scripts/partition_alloc/partition_alloc.diff
+++ b/scripts/partition_alloc/partition_alloc.diff
@@ -7,7 +7,7 @@ index 6434ee54..c27030dd 100644
  #endif  // BUILDFLAG(STARSCAN)
  
 +#include <sys/mman.h>
-+#include <ia2_get_pkey.h>
++#include <ia2.h>
 +
  namespace partition_alloc::internal {
  


### PR DESCRIPTION
Secure global data pkey_mprotect calls by ensuring that we can access
the pages that we are switching to our private compartment. We do this
by switching to the compartment target, verifying that the expected
target compartment and current pkey matches, then attempting to read
from each page in the protection range before protecting the pages as
private to the target compartment.

Fixes #172 