### PR TITLE
Move defines to libia2 cmake module

### DIFF
--- a/cmake/define-test.cmake
+++ b/cmake/define-test.cmake
@@ -89,18 +89,9 @@ function(define_shared_lib)
     foreach(target ${LIBNAME} ${WRAPPED_LIBNAME})
         set_target_properties(${target} PROPERTIES PKEY ${SHARED_LIB_PKEY})
 
-        add_dependencies(${target} libia2)
-
-        if(LIBIA2_INSECURE)
-            target_compile_definitions(${target} PUBLIC LIBIA2_INSECURE=1)
-        endif()
-        if(LIBIA2_DEBUG)
-            target_compile_definitions(${target} PUBLIC LIBIA2_DEBUG=1)
-        endif()
         if (DEFINED SHARED_LIB_PKEY)
             target_compile_definitions(${target} PRIVATE PKEY=${SHARED_LIB_PKEY})
         endif()
-        target_compile_definitions(${target} PRIVATE _GNU_SOURCE)
         target_compile_options(${target} PRIVATE
             "-Werror=incompatible-pointer-types"
             "-fsanitize=undefined"
@@ -223,18 +214,9 @@ function(define_test)
     foreach(target ${MAIN} ${WRAPPED_MAIN})
         set_target_properties(${target} PROPERTIES PKEY ${DEFINE_TEST_PKEY})
 
-        add_dependencies(${target} libia2)
-
-        if(LIBIA2_INSECURE)
-            target_compile_definitions(${target} PUBLIC LIBIA2_INSECURE=1)
-        endif()
-        if(LIBIA2_DEBUG)
-            target_compile_definitions(${target} PUBLIC LIBIA2_DEBUG=1)
-        endif()
         if(DEFINED DEFINE_TEST_PKEY)
             target_compile_definitions(${target} PRIVATE PKEY=${DEFINE_TEST_PKEY})
         endif()
-        target_compile_definitions(${target} PRIVATE _GNU_SOURCE)
         target_compile_options(${target} PRIVATE
             "-Werror=incompatible-pointer-types"
             "-fsanitize=undefined"

--- a/cmake/define-test.cmake
+++ b/cmake/define-test.cmake
@@ -107,7 +107,6 @@ function(define_shared_lib)
             "-isystem${C_SYSTEM_INCLUDE}"
             "-isystem${C_SYSTEM_INCLUDE_FIXED}")
         target_link_options(${target} PRIVATE
-            "-Wl,-z,now"
             # UBSAN requires passing this as both a compiler and linker flag
             "-fsanitize=undefined")
         target_link_libraries(${target} PRIVATE
@@ -232,7 +231,6 @@ function(define_test)
             "-isystem${C_SYSTEM_INCLUDE}"
             "-isystem${C_SYSTEM_INCLUDE_FIXED}")
         target_link_options(${target} PRIVATE
-            "-Wl,-z,now"
             # UBSAN requires passing this as both a compiler and linker flag
             "-fsanitize=undefined"
             "-Wl,--export-dynamic")

--- a/libia2/CMakeLists.txt
+++ b/libia2/CMakeLists.txt
@@ -16,6 +16,11 @@ target_link_options(libia2
         "-pthread"
         "-Wl,--wrap=pthread_create"
         "-Wl,--wrap=main"
+
+        # Eagerly resolve GOT relocations
+        "-Wl,-z,now"
+        # So that we can mark all relocatable data as read-only after relocation
+        "-Wl,-z,relro"
 )
 
 target_link_libraries(libia2 PRIVATE dl)

--- a/libia2/CMakeLists.txt
+++ b/libia2/CMakeLists.txt
@@ -8,7 +8,7 @@ if(LIBIA2_INSECURE)
     target_compile_definitions(libia2 PUBLIC LIBIA2_INSECURE=1)
 endif()
 if(LIBIA2_DEBUG)
-    target_compile_definitions(libia2 INTERFACE LIBIA2_DEBUG=1)
+    target_compile_definitions(libia2 PUBLIC LIBIA2_DEBUG=1)
 endif()
 
 target_link_options(libia2
@@ -21,7 +21,7 @@ target_link_options(libia2
 target_link_libraries(libia2 PRIVATE dl)
 
 target_include_directories(libia2 PUBLIC include)
-target_compile_definitions(libia2 PRIVATE _GNU_SOURCE)
+target_compile_definitions(libia2 PUBLIC _GNU_SOURCE)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/padding.ld ${CMAKE_CURRENT_BINARY_DIR}/)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/dynsym.syms ${CMAKE_CURRENT_BINARY_DIR}/)

--- a/libia2/test/CMakeLists.txt
+++ b/libia2/test/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_executable(permissive_mode_test permissive_mode.c)
 target_link_libraries(permissive_mode_test libia2)
-target_link_options(permissive_mode_test PRIVATE "-Wl,-z,now")
 
 if(NOT LIBIA2_INSECURE)
   add_test(NAME permissive_mode_test COMMAND permissive_mode_test)


### PR DESCRIPTION
Binaries that use libia2 should pick up defines from the library module, rather than having to re-declare the same defines every time we use the library. Moves the LIBIA2_INSECURE and LIBIA2_DEBUG definitions to libia2 itself.