### PR TITLE
Add ia2_init.c for per-compartment initialization

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -93,7 +93,8 @@ the object's source files.
 INIT_RUNTIME(1);
 
 // Assign protection key 1 to the main binary.
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 ```
 
 Then we rebuild the library and ensure it's linked against the main shim. We
@@ -196,7 +197,8 @@ IA2_WRAPPER(target_fn, target_pkey)
 #include "ptr.h"
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 // This creates an opaque struct set to NULL.
 Fn uninit = IA2_NULL_FNPTR(_ZTSPFiiE);

--- a/external/nginx-rtmp-module/ngx_rtmp.c
+++ b/external/nginx-rtmp-module/ngx_rtmp.c
@@ -11,7 +11,8 @@
 #include "ngx_rtmp.h"
 #include <ia2.h>
 
-INIT_COMPARTMENT(2);
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>
 
 
 static char *ngx_rtmp_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);

--- a/external/nginx/src/core/nginx.c
+++ b/external/nginx/src/core/nginx.c
@@ -12,7 +12,8 @@
 #include <permissive_mode.h>
 
 INIT_RUNTIME(2);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 
 static void ngx_show_version_info(void);

--- a/libia2/include/ia2_compartment_init.inc
+++ b/libia2/include/ia2_compartment_init.inc
@@ -1,0 +1,43 @@
+/* -*-c-*- vi:filetype=c:
+ */
+#ifndef IA2_COMPARTMENT
+#error Missing IA2_COMPARTMENT
+#endif
+
+#include <ia2.h>
+
+#define CONCAT_(x, y) x##y
+#define CONCAT(x, y) CONCAT_(x, y)
+#define COMPARTMENT_IDENT(name) CONCAT(name##_, IA2_COMPARTMENT)
+
+__thread void *COMPARTMENT_IDENT(ia2_stackptr) __attribute__((used));
+
+#ifndef LIBIA2_INSECURE
+
+/*
+** Initializes a compartment with protection key `n`. Called automatically as a
+** constructor when the ELF defining this symbol is loaded. This must only be
+** called once for each key. The compartment includes all segments in the ELF
+** except the `ia2_shared_data` section, if one exists.
+**/
+
+extern int ia2_n_pkeys_to_alloc;
+void ensure_pkeys_allocated(int *n_to_alloc);
+__attribute__((constructor)) static void COMPARTMENT_IDENT(init_pkey)() {
+  ensure_pkeys_allocated(&ia2_n_pkeys_to_alloc);
+  struct PhdrSearchArgs args = {
+      .pkey = IA2_COMPARTMENT,
+      .address = &COMPARTMENT_IDENT(init_pkey),
+  };
+  dl_iterate_phdr(protect_pages, &args);
+}
+
+void COMPARTMENT_IDENT(init_tls)(void) {
+  struct PhdrSearchArgs args = {
+      .pkey = IA2_COMPARTMENT,
+      .address = &COMPARTMENT_IDENT(init_tls),
+  };
+  dl_iterate_phdr(protect_tls_pages, &args);
+}
+
+#endif /* LIBIA2_INSECURE not defined */

--- a/libia2/test/permissive_mode.c
+++ b/libia2/test/permissive_mode.c
@@ -3,7 +3,8 @@
 #include <permissive_mode.h>
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 int main(int argc, char** argv) {
     char* buffer = NULL;

--- a/rewriter/SourceRewriter.cpp
+++ b/rewriter/SourceRewriter.cpp
@@ -92,6 +92,7 @@ static Pkey get_file_pkey(const clang::SourceManager &sm) {
 
 static bool ignore_file(const Filename &filename) {
   return filename.starts_with("/usr/") || filename.ends_with("ia2.h") ||
+         filename.ends_with("ia2_compartment_init.inc") ||
          filename.ends_with("test_fault_handler.h") || filename == "";
 }
 

--- a/rewriter/tests/ffmpeg/main.c
+++ b/rewriter/tests/ffmpeg/main.c
@@ -35,7 +35,8 @@
 #include <ia2.h>
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 int main (int argc, char **argv)
 {

--- a/rewriter/tests/function_allowlist/main.c
+++ b/rewriter/tests/function_allowlist/main.c
@@ -6,7 +6,8 @@ RUN: %binary_dir/tests/function_allowlist/function_allowlist_main_wrapped | diff
 #include <ia2.h>
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 int data_in_main = 30;
 

--- a/rewriter/tests/global_fn_ptr/main.c
+++ b/rewriter/tests/global_fn_ptr/main.c
@@ -10,7 +10,8 @@ uint16_t sub(uint16_t x, uint16_t y) { return x - y; }
 uint32_t mul(uint32_t x, uint32_t y) { return x * y; }
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 // `sum` can't be set to __ia2_add since it's defined in asm so the compiler doesn't know it's a valid initializer
 //static WordFn sum = __ia2_add;

--- a/rewriter/tests/header_includes/main.c
+++ b/rewriter/tests/header_includes/main.c
@@ -7,7 +7,8 @@ RUN: sh -c 'if [ ! -s "header_includes_call_gates_0.ld" ]; then echo "No link ar
 #include <ia2.h>
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 int main() {
     Option x = Some(3);

--- a/rewriter/tests/heap_two_keys/main.c
+++ b/rewriter/tests/heap_two_keys/main.c
@@ -16,7 +16,8 @@ TODO: %binary_dir/tests/heap_two_keys/heap_two_keys_main_wrapped 2 | diff %sourc
 
 // This test uses two protection keys
 INIT_RUNTIME(2);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 // Test that the program can exit without error
 // TODO(#112): it cannot.

--- a/rewriter/tests/heap_two_keys/plugin.c
+++ b/rewriter/tests/heap_two_keys/plugin.c
@@ -6,7 +6,8 @@ RUN: cat heap_two_keys_call_gates_1.ld | FileCheck --check-prefix=LINKARGS %s
 #include "exported_fn.h"
 #include "test_fault_handler.h"
 
-INIT_COMPARTMENT(2);
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>
 
 // LINKARGS: --wrap=trigger_compartment_init
 void trigger_compartment_init(void) {}

--- a/rewriter/tests/libusb/main.c
+++ b/rewriter/tests/libusb/main.c
@@ -25,7 +25,8 @@
 #include "usb-1.0_fn_ptr_ia2.h"
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 static void print_devs(libusb_device **devs)
 {

--- a/rewriter/tests/macro_attr/main.c
+++ b/rewriter/tests/macro_attr/main.c
@@ -5,7 +5,8 @@ RUN: sh -c 'if [ ! -s "macro_attr_call_gates_0.ld" ]; then echo "No link args as
 #include <ia2.h>
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 int main() {
     f();

--- a/rewriter/tests/minimal/main.c
+++ b/rewriter/tests/minimal/main.c
@@ -12,7 +12,8 @@ RUN: readelf -lW %binary_dir/tests/minimal/minimal_main_wrapped | FileCheck --ch
 #include <ia2.h>
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 int main() {
     foo();

--- a/rewriter/tests/read_config/main.c
+++ b/rewriter/tests/read_config/main.c
@@ -31,7 +31,8 @@ RUN: cat main.c | FileCheck --match-full-lines --check-prefix=REWRITER %s
 */
 
 INIT_RUNTIME(2);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 // The first 5 entries are plugin options and the rest are builtin
 #define PLUGIN_ENTRIES 5

--- a/rewriter/tests/read_config/plugin.c
+++ b/rewriter/tests/read_config/plugin.c
@@ -11,7 +11,8 @@ RUN: readelf -lW %binary_dir/tests/read_config/libread_config_lib_wrapped.so | F
 #include <stdio.h>
 #include <string.h>
 
-INIT_COMPARTMENT(2);
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>
 
 // A custom parsing function for a type defined by the plugin
 static void parse_tuple(char *opt, void *out);

--- a/rewriter/tests/recursion/dso.c
+++ b/rewriter/tests/recursion/dso.c
@@ -5,7 +5,8 @@ RUN: cat recursion_call_gates_1.ld | FileCheck --check-prefix=LINKARGS %s
 #include <ia2.h>
 #include <stdio.h>
 
-INIT_COMPARTMENT(2);
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>
 
 // LINKARGS: --wrap=recurse_dso
 void recurse_dso(int count) {

--- a/rewriter/tests/recursion/main.c
+++ b/rewriter/tests/recursion/main.c
@@ -10,7 +10,8 @@ RUN: %binary_dir/tests/recursion/recursion_main_wrapped | diff %binary_dir/tests
 #include "test_fault_handler.h"
 
 INIT_RUNTIME(2);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 // LINKARGS: --wrap=recurse_main
 void recurse_main(int count) {

--- a/rewriter/tests/rewrite_fn_ptr_eq/main.c
+++ b/rewriter/tests/rewrite_fn_ptr_eq/main.c
@@ -6,7 +6,8 @@ RUN: cat main.c | FileCheck --match-full-lines --check-prefix=REWRITER %S/main.c
 #include <ia2.h>
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 int add(int x, int y) {
     return x + y;

--- a/rewriter/tests/rewrite_macros/main.c
+++ b/rewriter/tests/rewrite_macros/main.c
@@ -6,7 +6,8 @@ RUN: cat main.c | FileCheck --match-full-lines --check-prefix=REWRITER %s
 #include <ia2.h>
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 int main() {
     init_actions();

--- a/rewriter/tests/ro_sharing/main.c
+++ b/rewriter/tests/ro_sharing/main.c
@@ -17,7 +17,8 @@ RUN: %binary_dir/tests/ro_sharing/ro_sharing_main_wrapped main | diff %binary_di
 
 // This test uses two protection keys
 INIT_RUNTIME(2);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 // All string literals should be in .rodata
 const char *main_str = "this is the main binary's string\n";

--- a/rewriter/tests/ro_sharing/plugin.c
+++ b/rewriter/tests/ro_sharing/plugin.c
@@ -7,7 +7,8 @@ RUN: cat ro_sharing_call_gates_1.ld | FileCheck --check-prefix=LINKARGS %s
 #include <stdio.h>
 #include <string.h>
 
-INIT_COMPARTMENT(2);
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>
 
 // All string literals should be in .rodata
 const char *plugin_str = "this is the plugin's string\n";

--- a/rewriter/tests/shared_data/main.c
+++ b/rewriter/tests/shared_data/main.c
@@ -8,7 +8,8 @@ RUN: %binary_dir/tests/shared_data/shared_data_main_wrapped | diff %S/Output/sha
 #include "access_shared.h"
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 uint8_t shared_val[4097] IA2_SHARED_DATA = { 0 };
 

--- a/rewriter/tests/should_segfault/main.c
+++ b/rewriter/tests/should_segfault/main.c
@@ -12,7 +12,8 @@ RUN: %binary_dir/tests/should_segfault/should_segfault_main_wrapped early_fault 
 #include "test_fault_handler.h"
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 uint32_t secret = 0xdeadbeef;
 

--- a/rewriter/tests/sighandler/lib.c
+++ b/rewriter/tests/sighandler/lib.c
@@ -6,7 +6,8 @@ RUN: cat sighandler_call_gates_1.ld | FileCheck --check-prefix=LINKARGS %s
 #include <signal.h>
 #include <ia2.h>
 
-INIT_COMPARTMENT(2);
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>
 
 int lib_secret = 4;
 

--- a/rewriter/tests/sighandler/main.c
+++ b/rewriter/tests/sighandler/main.c
@@ -9,7 +9,8 @@ RUN: %binary_dir/tests/sighandler/sighandler_main_wrapped | diff %binary_dir/tes
 #include <test_fault_handler.h>
 
 INIT_RUNTIME(2);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 
 struct handler {

--- a/rewriter/tests/simple1/main.c
+++ b/rewriter/tests/simple1/main.c
@@ -12,7 +12,8 @@ RUN: cat simple1_call_gates_0.ld | FileCheck --check-prefix=LINKARGS %s
 #include "simple1.h"
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 // libsimple1 checks if the function pointer is NULL. To initialize this to a
 // function defined in this binary, we'd need to define a wrapper with

--- a/rewriter/tests/structs/main.c
+++ b/rewriter/tests/structs/main.c
@@ -14,7 +14,8 @@ RUN: %binary_dir/tests/structs/structs_main_wrapped | diff %S/Output/structs.out
 */
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 #define check_close_float(name, val) { printf("%s(s) = %.4f (expected %.4f)\n", #name, name(s), val); }
 #define check_field_float(name, val) { printf("s.%s = %.4f (expected %.4f)\n", #name, s.name, val); }

--- a/rewriter/tests/threads/main.c
+++ b/rewriter/tests/threads/main.c
@@ -13,7 +13,8 @@ RUN: %binary_dir/tests/threads/threads_main_wrapped | FileCheck --dump-input=alw
 #include <unistd.h>
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 int data_in_main = 30;
 

--- a/rewriter/tests/tls_protected/library.c
+++ b/rewriter/tests/tls_protected/library.c
@@ -9,7 +9,8 @@ RUN: sh -c 'if [ ! -s "tls_protected_call_gates_2.ld" ]; then echo "No link args
 #include <stdio.h>
 #include <stdlib.h>
 
-INIT_COMPARTMENT(2);
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>
 
 thread_local uint32_t lib_secret = 0x1eaf1e55;
 

--- a/rewriter/tests/tls_protected/main.c
+++ b/rewriter/tests/tls_protected/main.c
@@ -14,7 +14,8 @@ RUN: %binary_dir/tests/tls_protected/tls_protected_main_wrapped print_lib_secret
 #include <threads.h>
 
 INIT_RUNTIME(2);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 thread_local uint32_t main_secret = 0xdeadbeef;
 

--- a/rewriter/tests/trusted_direct/main.c
+++ b/rewriter/tests/trusted_direct/main.c
@@ -18,7 +18,8 @@ RUN: %binary_dir/tests/trusted_direct/trusted_direct_main_wrapped clean_exit | d
 // passed in. Otherwise the program exits cleanly.
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 uint32_t secret = 0x09431233;
 

--- a/rewriter/tests/trusted_indirect/main.c
+++ b/rewriter/tests/trusted_indirect/main.c
@@ -16,7 +16,8 @@ RUN: %binary_dir/tests/trusted_indirect/trusted_indirect_main_wrapped clean_exit
 */
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 bool clean_exit IA2_SHARED_DATA = false;
 

--- a/rewriter/tests/two_keys_minimal/main.c
+++ b/rewriter/tests/two_keys_minimal/main.c
@@ -20,7 +20,8 @@ RUN: readelf -lW %binary_dir/tests/two_keys_minimal/two_keys_minimal_main_wrappe
 
 // This test uses two protection keys
 INIT_RUNTIME(2);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 uint32_t secret = 0x09431233;
 

--- a/rewriter/tests/two_keys_minimal/plugin.c
+++ b/rewriter/tests/two_keys_minimal/plugin.c
@@ -12,7 +12,8 @@ RUN: readelf -lW %binary_dir/tests/two_keys_minimal/libtwo_keys_minimal_lib_wrap
 #include "exported_fn.h"
 #include "test_fault_handler.h"
 
-INIT_COMPARTMENT(2);
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>
 
 uint32_t plugin_secret = 0x78341244;
 

--- a/rewriter/tests/two_shared_ranges/main.c
+++ b/rewriter/tests/two_shared_ranges/main.c
@@ -19,7 +19,8 @@ RUN: readelf -lW %binary_dir/tests/two_shared_ranges/two_shared_ranges_main_wrap
 
 // This test uses two protection keys
 INIT_RUNTIME(2);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 uint32_t secret = 0x09431233;
 uint32_t shared IA2_SHARED_DATA = 0xb75784ee;

--- a/rewriter/tests/two_shared_ranges/plugin.c
+++ b/rewriter/tests/two_shared_ranges/plugin.c
@@ -12,7 +12,8 @@ RUN: readelf -lW %binary_dir/tests/two_shared_ranges/libtwo_shared_ranges_lib_wr
 #include "exported_fn.h"
 #include "test_fault_handler.h"
 
-INIT_COMPARTMENT(2);
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>
 
 uint32_t plugin_secret = 0x78341244;
 uint32_t plugin_shared IA2_SHARED_DATA = 0x415ea635;

--- a/rewriter/tests/untrusted_indirect/main.c
+++ b/rewriter/tests/untrusted_indirect/main.c
@@ -9,7 +9,8 @@ RUN: sh -c 'if [ ! -s "untrusted_indirect_call_gates_0.ld" ]; then echo "No link
 #include "test_fault_handler.h"
 
 INIT_RUNTIME(1);
-INIT_COMPARTMENT(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
 
 /*
     This program tests that a trusted binary can pass function pointers to an untrusted shared


### PR DESCRIPTION
Our INIT_COMPARTMENT macro was getting rather large and unwieldy, in addition to being undebuggable because line info was missing for generated functions. Instead we can use a C file with the compartment id defined.