### PR TITLE
Minimize warnings for variadic functions

### DIFF
--- a/rewriter/SourceRewriter.cpp
+++ b/rewriter/SourceRewriter.cpp
@@ -738,7 +738,14 @@ public:
       return;
     }
 
+    Function fn_name = fn_node->getNameAsString();
+
     if (fn_node->isVariadic()) {
+      static std::set<Function> variadic_warnings_printed = {};
+      if (variadic_warnings_printed.contains(fn_name)) {
+          return;
+      }
+      variadic_warnings_printed.insert(fn_name);
       llvm::errs()
           << "Wrapping variadic functions is not yet supported, skipping ";
       fn_node->getNameForDiagnostic(
@@ -747,7 +754,6 @@ public:
       return;
     }
 
-    Function fn_name = fn_node->getNameAsString();
     CAbiSignature fn_sig = determineAbiForDecl(*fn_node);
     abi_signatures[fn_name] = fn_sig;
 


### PR DESCRIPTION
Printing warnings for variadic functions that remain unwrapped in the Nginx demo takes a non-negligible amount of time. This commit minimizes the number of warnings printed by warning only once per function.