### PR TITLE
rewriter: Add clang attribute to skip wrapping functions

### DIFF
--- a/external/nginx/auto/cc/gcc
+++ b/external/nginx/auto/cc/gcc
@@ -177,3 +177,6 @@ CFLAGS="$CFLAGS -g"
 if [ ".$CPP" = "." ]; then
     CPP="$CC -E"
 fi
+
+# Supress warning for clang pragma
+CFLAGS="$CFLAGS -Wno-unknown-pragmas"

--- a/external/nginx/src/core/ngx_array.h
+++ b/external/nginx/src/core/ngx_array.h
@@ -9,9 +9,11 @@
 #define _NGX_ARRAY_H_INCLUDED_
 
 
+#include <ia2.h>
 #include <ngx_config.h>
 #include <ngx_core.h>
 
+IA2_BEGIN_NO_WRAP
 
 typedef struct {
     void        *elts;
@@ -49,5 +51,6 @@ ngx_array_init(ngx_array_t *array, ngx_pool_t *pool, ngx_uint_t n, size_t size)
     return NGX_OK;
 }
 
+IA2_END_NO_WRAP
 
 #endif /* _NGX_ARRAY_H_INCLUDED_ */

--- a/external/nginx/src/core/ngx_hash.h
+++ b/external/nginx/src/core/ngx_hash.h
@@ -9,9 +9,11 @@
 #define _NGX_HASH_H_INCLUDED_
 
 
+#include <ia2.h>
 #include <ngx_config.h>
 #include <ngx_core.h>
 
+IA2_BEGIN_NO_WRAP
 
 typedef struct {
     void             *value;
@@ -118,5 +120,6 @@ ngx_int_t ngx_hash_keys_array_init(ngx_hash_keys_arrays_t *ha, ngx_uint_t type);
 ngx_int_t ngx_hash_add_key(ngx_hash_keys_arrays_t *ha, ngx_str_t *key,
     void *value, ngx_uint_t flags);
 
+IA2_END_NO_WRAP
 
 #endif /* _NGX_HASH_H_INCLUDED_ */

--- a/external/nginx/src/core/ngx_rbtree.h
+++ b/external/nginx/src/core/ngx_rbtree.h
@@ -13,6 +13,7 @@
 #include <ngx_core.h>
 #include <ia2.h>
 
+IA2_BEGIN_NO_WRAP
 
 typedef ngx_uint_t  ngx_rbtree_key_t;
 typedef ngx_int_t   ngx_rbtree_key_int_t;
@@ -46,7 +47,7 @@ struct ngx_rbtree_s {
     ngx_rbtree_sentinel_init(s);                                              \
     (tree)->root = s;                                                         \
     (tree)->sentinel = s;                                                     \
-    (tree)->insert = IA2_FN(i)
+    (tree)->insert = i
 
 #define ngx_rbtree_data(node, type, link)                                     \
     (type *) ((u_char *) (node) - offsetof(type, link))
@@ -84,5 +85,6 @@ ngx_rbtree_min(ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel)
     return node;
 }
 
+IA2_END_NO_WRAP
 
 #endif /* _NGX_RBTREE_H_INCLUDED_ */

--- a/external/nginx/src/core/ngx_string.h
+++ b/external/nginx/src/core/ngx_string.h
@@ -9,9 +9,11 @@
 #define _NGX_STRING_H_INCLUDED_
 
 
+#include <ia2.h>
 #include <ngx_config.h>
 #include <ngx_core.h>
 
+IA2_BEGIN_NO_WRAP
 
 typedef struct {
     size_t      len;
@@ -234,5 +236,6 @@ void ngx_sort(void *base, size_t n, size_t size,
 #define ngx_value_helper(n)   #n
 #define ngx_value(n)          ngx_value_helper(n)
 
+IA2_END_NO_WRAP
 
 #endif /* _NGX_STRING_H_INCLUDED_ */

--- a/external/nginx/src/os/unix/ngx_alloc.h
+++ b/external/nginx/src/os/unix/ngx_alloc.h
@@ -9,9 +9,11 @@
 #define _NGX_ALLOC_H_INCLUDED_
 
 
+#include <ia2.h>
 #include <ngx_config.h>
 #include <ngx_core.h>
 
+IA2_BEGIN_NO_WRAP
 
 void *ngx_alloc(size_t size, ngx_log_t *log);
 void *ngx_calloc(size_t size, ngx_log_t *log);
@@ -41,5 +43,6 @@ extern ngx_uint_t  ngx_pagesize;
 extern ngx_uint_t  ngx_pagesize_shift;
 extern ngx_uint_t  ngx_cacheline_size;
 
+IA2_END_NO_WRAP
 
 #endif /* _NGX_ALLOC_H_INCLUDED_ */

--- a/external/nginx/src/os/unix/ngx_files.h
+++ b/external/nginx/src/os/unix/ngx_files.h
@@ -9,9 +9,11 @@
 #define _NGX_FILES_H_INCLUDED_
 
 
+#include <ia2.h>
 #include <ngx_config.h>
 #include <ngx_core.h>
 
+IA2_BEGIN_NO_WRAP
 
 typedef int                      ngx_fd_t;
 typedef struct stat              ngx_file_info_t;
@@ -392,5 +394,6 @@ ssize_t ngx_thread_write_chain_to_file(ngx_file_t *file, ngx_chain_t *cl,
     off_t offset, ngx_pool_t *pool);
 #endif
 
+IA2_END_NO_WRAP
 
 #endif /* _NGX_FILES_H_INCLUDED_ */

--- a/external/nginx/src/os/unix/ngx_time.h
+++ b/external/nginx/src/os/unix/ngx_time.h
@@ -9,6 +9,7 @@
 #define _NGX_TIME_H_INCLUDED_
 
 
+#include <ia2.h>
 #include <ngx_config.h>
 #include <ngx_core.h>
 
@@ -54,9 +55,14 @@ typedef struct tm             ngx_tm_t;
 
 
 void ngx_timezone_update(void);
+
+IA2_BEGIN_NO_WRAP
+
 void ngx_localtime(time_t s, ngx_tm_t *tm);
 void ngx_libc_localtime(time_t s, struct tm *tm);
 void ngx_libc_gmtime(time_t s, struct tm *tm);
+
+IA2_END_NO_WRAP
 
 #define ngx_gettimeofday(tp)  (void) gettimeofday(tp, NULL);
 #define ngx_msleep(ms)        (void) usleep(ms * 1000)

--- a/libia2/include/ia2.h
+++ b/libia2/include/ia2.h
@@ -67,6 +67,28 @@
 
 #define IA2_IGNORE(x) x
 
+/// Do not wrap functions or function pointers in the following code.
+///
+/// This must be paired with a matching IA2_END_NO_WRAP that pops the
+/// annotation.
+///
+/// Some functions, e.g. utility functions that don't touch global state, should
+/// not be wrapped and should always run in the caller compartment. If we wrap
+/// these functions they may act as simple accessors for another compartment's
+/// private data. For example, consider an vector_pop() function that pops an
+/// element from a vector. If this function is declared in compartment A and
+/// used from compartment B, it allows compartment B to pop any element from
+/// compartment A's private vectors.
+///
+/// Any functions declared between this macro and IA2_END_NO_WRAP will not be
+/// wrapped by the rewriter and any calls to these functions and function
+/// pointers will execute in the caller's compartment.
+#define IA2_BEGIN_NO_WRAP                                                      \
+  _Pragma(                                                                     \
+      "clang attribute push(__attribute__((annotate(\"ia2_skip_wrap\"))), apply_to = hasType(functionType))");
+
+#define IA2_END_NO_WRAP _Pragma("clang attribute pop");
+
 #if IA2_PREREWRITER
 #define IA2_FN_ADDR(func) func
 #define IA2_ADDR(opaque) (void *)opaque

--- a/rewriter/SourceRewriter.cpp
+++ b/rewriter/SourceRewriter.cpp
@@ -17,10 +17,13 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
+#include <clang/AST/Decl.h>
 #include <clang/AST/PrettyPrinter.h>
+#include <clang/Basic/SourceLocation.h>
 #include <dirent.h>
 #include <fstream>
 #include <iostream>
+#include <llvm/ADT/Optional.h>
 #include <map>
 #include <optional>
 #include <string>
@@ -33,6 +36,8 @@
 using namespace clang::ast_matchers;
 using namespace clang::tooling;
 using namespace std::string_literals;
+
+static constexpr llvm::StringLiteral SKIP_WRAP_ATTR("ia2_skip_wrap");
 
 typedef std::string Function;
 typedef std::string Filename;
@@ -128,14 +133,30 @@ static Pkey get_file_pkey(const clang::SourceManager &sm) {
 }
 
 static bool ignore_file(const Filename &filename) {
-  return !filename.starts_with(OutputDirectory) && !filename.starts_with(RootDirectory);
+  return !filename.starts_with(OutputDirectory) &&
+         !filename.starts_with(RootDirectory);
 }
 
-static bool ignore_function(const Filename &filename, const Function &function) {
-  if (function.starts_with("ia2_compartment_destructor")) {
-    return false;
+static bool ignore_function(const clang::Decl &decl,
+                            const llvm::Optional<clang::SourceLocation> &loc,
+                            const clang::SourceManager &sm) {
+  if (const auto *named_decl = dyn_cast<clang::NamedDecl>(&decl)) {
+    if (named_decl->getNameAsString().starts_with(
+            "ia2_compartment_destructor")) {
+          return false;
+    }
   }
-  return ignore_file(filename);
+
+  auto annotation = decl.getAttr<clang::AnnotateAttr>();
+  if (annotation && annotation->getAnnotation() == SKIP_WRAP_ATTR) {
+    return true;
+  }
+
+  if (loc) {
+    return ignore_file(get_filename(*loc, sm));
+  }
+
+  return false;
 }
 
 static std::string append_name_if_nonempty(const std::string &new_type,
@@ -248,8 +269,8 @@ public:
     }
 
     auto loc = old_decl->getLocation();
-    Filename filename = get_filename(loc, sm);
-    if (ignore_file(filename)) {
+    auto filename = get_filename(loc, sm);
+    if (ignore_function(*old_decl, loc, sm)) {
       return;
     }
 
@@ -402,12 +423,14 @@ public:
     // Matches function calls excluding direct calls. Only the callee nodes are
     // bound to "fnPtrCall"
     StatementMatcher fn_ptr_call = callExpr(callee(
-        expr(unless(ignoringImplicit(declared_function))).bind("fnPtrCall")));
+        expr(unless(ignoringImplicit(declared_function))).bind("fnPtrExpr"))).bind("fnPtrCall");
 
     refactorer.addMatcher(fn_ptr_call, this);
   }
   virtual void run(const MatchFinder::MatchResult &result) {
-    auto *fn_ptr_call = result.Nodes.getNodeAs<clang::Expr>("fnPtrCall");
+    auto *fn_ptr_expr = result.Nodes.getNodeAs<clang::Expr>("fnPtrExpr");
+    assert(fn_ptr_expr != nullptr);
+    auto *fn_ptr_call = result.Nodes.getNodeAs<clang::CallExpr>("fnPtrCall");
     assert(fn_ptr_call != nullptr);
 
     assert(result.SourceManager != nullptr);
@@ -421,14 +444,19 @@ public:
       return;
     }
 
-    clang::SourceLocation loc = fn_ptr_call->getExprLoc();
+    clang::SourceLocation loc = fn_ptr_expr->getExprLoc();
     Filename filename = get_filename(loc, sm);
     if (ignore_file(filename)) {
       return;
     }
 
+    auto callee_decl = fn_ptr_call->getCalleeDecl();
+    if (callee_decl && ignore_function(*callee_decl, {}, sm)) {
+      return;
+    }
+
     // Check if the function pointer type already has an ID
-    auto expr_ty = fn_ptr_call->getType()->getCanonicalTypeInternal();
+    auto expr_ty = fn_ptr_expr->getType()->getCanonicalTypeInternal();
     auto expr_ty_str = expr_ty.getAsString();
     if (!fn_ptr_ids.contains(expr_ty_str)) {
       fn_ptr_ids[expr_ty_str] = id_counter;
@@ -458,7 +486,7 @@ public:
 
     // getTokenRange is required to replace the entire callee expression
     auto char_range =
-        clang::CharSourceRange::getTokenRange(fn_ptr_call->getSourceRange());
+        clang::CharSourceRange::getTokenRange(fn_ptr_expr->getSourceRange());
 
     auto old_expr =
         clang::Lexer::getSourceText(char_range, sm, ctxt.getLangOpts());
@@ -517,8 +545,13 @@ public:
                        hasEitherOperand(expr(
                            ignoringImplicit(equalsBoundNode("fnPtrExpr"))))));
 
+    auto param_expr = hasParent(implicitCastExpr(hasParent(callExpr(
+        forEachArgumentWithParam(equalsBoundNode("fnPtrExpr"),
+                                 parmVarDecl().bind("fnPtrParamDecl"))))));
+
     StatementMatcher fn_ptr_expr =
-        expr(fn_expr, unless(call_expr), unless(in_bin_op));
+        expr(fn_expr, unless(call_expr), unless(in_bin_op),
+             optionally(param_expr));
 
     refactorer.addMatcher(fn_ptr_expr, this);
   }
@@ -538,13 +571,18 @@ public:
     }
 
     clang::SourceLocation loc = fn_ptr_expr->getExprLoc();
-    if (ignore_file(get_filename(loc, sm))) {
-      return;
-    }
-
     auto *fn_decl =
         llvm::cast<clang::NamedDecl>(fn_ptr_expr->getReferencedDeclOfCallee());
     assert(fn_decl != nullptr);
+
+    if (ignore_function(*fn_decl, loc, sm)) {
+      return;
+    }
+
+    auto *param_decl = result.Nodes.getNodeAs<clang::ParmVarDecl>("fnPtrParamDecl");
+    if (param_decl && ignore_function(*param_decl, {}, sm)) {
+      return;
+    }
 
     Function fn_name = fn_decl->getName().str();
 
@@ -779,7 +817,7 @@ public:
     Function fn_name = fn_node->getNameAsString();
 
     // Ignore declarations in libc and libia2 headers
-    if (ignore_function(get_filename(fn_node->getLocation(), sm), fn_name)) {
+    if (ignore_function(*fn_node, fn_node->getLocation(), sm)) {
       return;
     }
 


### PR DESCRIPTION
Some functions, e.g. utility functions that don't touch global state,
should not be wrapped and should always run in the caller compartment.
If we wrap these functions they may act as simple accessors for another
compartment's private data. For example, consider an vector_pop()
function that pops an element from a vector. If this function is
declared in compartment A and used from compartment B, it allows
compartment B to pop any element from compartment A's private vectors.

This change adds the `ia2_skip_wrap` annotation attribute that skips
wrapping of any functions, and function pointers it is applied to (and
calls to these function pointers). It should be applied with the
following set of pragmas:

    #pragma clang attribute push (__attribute__((annotate("ia2_skip_wrap"))), apply_to = hasType(functionType))

    // function declarations...

    #pragma clang attribute pop