### PR TITLE
Permissive mode improvements

### DIFF
--- a/libia2/include/permissive_mode.h
+++ b/libia2/include/permissive_mode.h
@@ -163,7 +163,7 @@ void permissive_mode_handler(int sig, siginfo_t *info, void *ctxt) {
   bool handling_trap = sig == SIGTRAP;
   ucontext_t *uctxt = (ucontext_t *)ctxt;
   if (!handling_pkuerr && !handling_trap) {
-    return;
+    abort();
   }
   uint64_t *eflags = (uint64_t *)(&uctxt->uc_mcontext.gregs[REG_EFL]);
 


### PR DESCRIPTION
- Improves logging in permissive mode to print offsets rather than absolute addresses when possible.
- Abort on segfaults that are not PKRU violations in permissive mode.