### PR TITLE
Add some missing #includes

### DIFF
--- a/libia2/threads.c
+++ b/libia2/threads.c
@@ -1,5 +1,6 @@
 #include <pthread.h>
 #include <signal.h>
+#include <sys/mman.h>
 
 #include "ia2.h"
 

--- a/rewriter/tests/heap_two_keys/main.c
+++ b/rewriter/tests/heap_two_keys/main.c
@@ -7,6 +7,7 @@ TODO: %binary_dir/tests/heap_two_keys/heap_two_keys_main_wrapped 2 | diff %S/Out
 */
 #include <stdio.h>
 #include <unistd.h>
+#include <assert.h>
 #include <ia2.h>
 #include <ia2_allocator.h>
 #include "plugin.h"

--- a/rewriter/tests/permissive_mode/permissive_mode.c
+++ b/rewriter/tests/permissive_mode/permissive_mode.c
@@ -4,6 +4,7 @@ RUN: %binary_dir/tests/permissive_mode/permissive_mode_main_wrapped
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
+#include <assert.h>
 #include <ia2.h>
 #include <permissive_mode.h>
 

--- a/rewriter/tests/read_config/plugin.c
+++ b/rewriter/tests/read_config/plugin.c
@@ -9,6 +9,7 @@ RUN: readelf -lW %binary_dir/tests/read_config/libread_config_lib_wrapped.so | F
 #include "core.h"
 #include <ia2.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define IA2_COMPARTMENT 2


### PR DESCRIPTION
Should be non-contentious, PR for CI. I think recent ia2.h and permissive_mode.h cleanups mean our headers no longer provide these so consumers need them separately.