### PR TITLE
Fix zero-len `pkey_mprotect`

### DIFF
--- a/libia2/ia2.c
+++ b/libia2/ia2.c
@@ -235,6 +235,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
     // it is followed by padding that ensures nothing else occupies the rest of
     // its page.
     if (untrusted_stackptr_addr >= start && untrusted_stackptr_addr < end) {
+      // Protect TLS region start to the beginning of the untrusted region.
       int mprotect_err = pkey_mprotect(
           (void *)start_round_down, untrusted_stackptr_addr - start_round_down,
           PROT_READ | PROT_WRITE, search_args->pkey);
@@ -242,12 +243,16 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
         printf("pkey_mprotect failed: %s\n", strerror(errno));
         exit(-1);
       }
-      mprotect_err = pkey_mprotect((void *)untrusted_stackptr_addr + 0x1000,
-                                   end - (untrusted_stackptr_addr + 0x1000),
-                                   PROT_READ | PROT_WRITE, search_args->pkey);
-      if (mprotect_err != 0) {
-        printf("pkey_mprotect failed: %s\n", strerror(errno));
-        exit(-1);
+      uint64_t after_untrusted_region_start = untrusted_stackptr_addr + 0x1000;
+      uint64_t after_untrusted_region_len = end - after_untrusted_region_start;
+      if (after_untrusted_region_len > 0) {
+        mprotect_err = pkey_mprotect((void *)after_untrusted_region_start,
+                                     after_untrusted_region_len,
+                                     PROT_READ | PROT_WRITE, search_args->pkey);
+        if (mprotect_err != 0) {
+          printf("pkey_mprotect failed: %s\n", strerror(errno));
+          exit(-1);
+        }
       }
     } else {
       int mprotect_err =

--- a/runtime/track_memory_map.c
+++ b/runtime/track_memory_map.c
@@ -151,8 +151,8 @@ bool update_memory_map(struct memory_map *map, int event,
 #define PKRU(pkey) (~((3 << (2 * pkey)) | 3))
 
 unsigned char pkey_for_pkru(uint32_t pkru) {
-#define CHECK(x)                                                               \
-  case PKRU(x):                                                                \
+#define CHECK(x) \
+  case PKRU(x):  \
     return x;
   switch (pkru) {
     CHECK(0);
@@ -415,7 +415,7 @@ void track_memory_map(pid_t pid, struct memory_map *map) {
 
     /* track effect of syscall on memory map */
     if (!update_memory_map(map, event, &event_info)) {
-      fprintf(stderr, "could not update memory map! (operation=%d)\n", event);
+      fprintf(stderr, "could not update memory map! (operation=%s, rip=%p)\n", event_name(event), (void *)regs.rip);
       return;
     }
   }


### PR DESCRIPTION
This isn't a security issue, but was causing spurious killings of the inferior from the memory-map tracking because a zero-length `pkey_mprotect` is not something we expect to happen.