### PR TITLE
Mark the end of IA2 init

### DIFF
--- a/runtime/memory-map/src/lib.rs
+++ b/runtime/memory-map/src/lib.rs
@@ -409,12 +409,15 @@ pub extern "C" fn memory_map_mprotect_region(map: &mut MemoryMap, range: Range, 
             state.prot = prot;
             map.add_region(range, state)
         } else {
-            printerrln!(
-                "warning: reprotecting already-mprotected region {:?} (prot {} => {})",
-                range,
-                state.prot,
-                prot
-            );
+            /* after init has finished, we should warn about reprotecting regions */
+            if map.init_finished {
+                printerrln!(
+                    "warning: reprotecting already-mprotected region {:?} (prot {} => {})",
+                    range,
+                    state.prot,
+                    prot
+                );
+            }
             state.mprotected = true;
             state.prot = prot;
             map.add_region(range, state)

--- a/runtime/memory-map/src/lib.rs
+++ b/runtime/memory-map/src/lib.rs
@@ -82,12 +82,22 @@ use disjoint_interval_tree::NonOverlappingIntervalTree;
 
 pub struct MemoryMap {
     regions: NonOverlappingIntervalTree<usize, State>,
+    init_finished: bool,
 }
 
 impl MemoryMap {
     pub fn new() -> Self {
         MemoryMap {
             regions: Default::default(),
+            init_finished: false,
+        }
+    }
+    pub fn mark_init_finished(&mut self) -> bool {
+        if self.init_finished {
+            false
+        } else {
+            self.init_finished = true;
+            true
         }
     }
     pub fn add_region(&mut self, mut range: Range, state: State) -> bool {
@@ -234,6 +244,16 @@ pub extern "C" fn memory_map_new() -> Box<MemoryMap> {
 
 #[no_mangle]
 pub extern "C" fn memory_map_destroy(_map: Box<MemoryMap>) {}
+
+#[no_mangle]
+pub extern "C" fn memory_map_mark_init_finished(map: &mut MemoryMap) -> bool {
+    map.mark_init_finished()
+}
+
+#[no_mangle]
+pub extern "C" fn memory_map_is_init_finished(map: &MemoryMap) -> bool {
+    map.init_finished
+}
 
 #[no_mangle]
 pub extern "C" fn memory_map_all_overlapping_regions_have_pkey(

--- a/runtime/memory_map.h
+++ b/runtime/memory_map.h
@@ -25,6 +25,10 @@ struct memory_map *memory_map_new(void);
 
 void memory_map_destroy(struct memory_map *_map);
 
+bool memory_map_mark_init_finished(struct memory_map *map);
+
+bool memory_map_is_init_finished(const struct memory_map *map);
+
 bool memory_map_all_overlapping_regions_have_pkey(const struct memory_map *map,
                                                   struct range needle,
                                                   uint8_t pkey);

--- a/runtime/track_memory_map.c
+++ b/runtime/track_memory_map.c
@@ -53,6 +53,10 @@ bool is_op_permitted(struct memory_map *map, int event,
                                                       false);
     if (impacts_only_unprotected_memory)
       return true;
+    /* during init, we allow re-mprotecting memory, which we need to alter
+    initially-RO destructors */
+    else if (!memory_map_is_init_finished(map))
+      return true;
 
     /* allow mprotecting memory that is already writable */
     uint32_t prot = memory_map_region_get_prot(map, info->mprotect.range);


### PR DESCRIPTION
This lets us avoid errors when running programs with destructors under the memory-map tracking runtime.

I want to factor out the magic constant--where should it live?