### PR TITLE
libia2: Fix alignment issue in permissive mode

### DIFF
--- a/libia2/include/permissive_mode.h
+++ b/libia2/include/permissive_mode.h
@@ -195,7 +195,8 @@ void permissive_mode_handler(int sig, siginfo_t *info, void *ctxt) {
     uint64_t fp = (uint64_t)uctxt->uc_mcontext.gregs[REG_RBP];
     // Ensure that the logging thread is not popping values
     struct queue *q = get_queue();
-    uint64_t val = *(uint64_t *)info->si_addr;
+    uint64_t val;
+    memcpy(&val, info->si_addr, sizeof(uint64_t));
     mpk_err err = {.addr = (uint64_t)info->si_addr, .val = val, .pc = pc, .sp = sp, .fp = fp, .pkru = old_pkru, .local_addr = (uint64_t)&pc};
     push_queue(q, err);
     release_queue(q);


### PR DESCRIPTION
The values that cause MPK errors in the permissive mode logs are assumed to be uint64_t, but they may be any type. Since we don't always have reliable runtime type info or a reasonable way to determine the size of the memory access from the sighandler (I don't want to parse x86 instructions if possible), we arbitrarily assume that they're u64 and access them as such. This is a problem if the address is not aligned to 8 bytes so this commit replaces the direct pointer access with a memcpy to avoid the alignment requirement.