### PR TITLE
Trace `madvise` syscall

### DIFF
--- a/runtime/forbid_paths.c
+++ b/runtime/forbid_paths.c
@@ -21,7 +21,8 @@ static int allow_path(const char *path, const int ruleset_fd, bool shallow) {
   struct stat statbuf;
 
   path_beneath.parent_fd = open(path, O_PATH | O_CLOEXEC);
-  if (path_beneath.parent_fd < 0) {
+  /* error on inability to open dir, unless it simply no longer exists */
+  if (path_beneath.parent_fd < 0 && errno != ENOENT) {
     fprintf(stderr, "Failed to open \"%s\": %s\n", path, strerror(errno));
     return -1;
   }

--- a/runtime/get_inferior_pkru.c
+++ b/runtime/get_inferior_pkru.c
@@ -28,7 +28,7 @@ bool get_inferior_pkru(pid_t pid, uint32_t *pkru_out) {
      Intel Skylake CPUs") that sometimes causes the mxcsr location in
      xstateregs not to be copied by PTRACE_GETREGSET.  Make sure that
      the location is at least initialized with a defined value.  */
-  memset(xstateregs, 0, sizeof(xstateregs));
+  memset(xstateregs, 0x69, sizeof(xstateregs));
   iov.iov_base = xstateregs;
   iov.iov_len = sizeof(xstateregs);
   if (ptrace(PTRACE_GETREGSET, pid, (unsigned int)NT_X86_XSTATE, (long)&iov) <

--- a/runtime/memory_map.h
+++ b/runtime/memory_map.h
@@ -43,6 +43,8 @@ bool memory_map_all_overlapping_regions_mprotected(const struct memory_map *map,
 
 uint32_t memory_map_region_get_prot(const struct memory_map *map, struct range needle);
 
+uint8_t memory_map_region_get_owner_pkey(const struct memory_map *map, struct range needle);
+
 bool memory_map_unmap_region(struct memory_map *map, struct range needle);
 
 bool memory_map_add_region(struct memory_map *map,

--- a/runtime/mmap_event.c
+++ b/runtime/mmap_event.c
@@ -10,6 +10,8 @@ enum mmap_event event_from_syscall(uint64_t rax) {
     return EVENT_MUNMAP;
   case __NR_mremap:
     return EVENT_MREMAP;
+  case __NR_madvise:
+    return EVENT_MADVISE;
   case __NR_mprotect:
     return EVENT_MPROTECT;
   case __NR_pkey_mprotect:

--- a/runtime/mmap_event.h
+++ b/runtime/mmap_event.h
@@ -78,4 +78,28 @@ static const char *event_name(enum mmap_event event) {
   return event_names[event];
 }
 
+static inline const struct range *event_target_range(enum mmap_event event, const union event_info *info) {
+  switch (event) {
+  case EVENT_MMAP:
+    return &info->mmap.range;
+  case EVENT_MUNMAP:
+    return &info->munmap.range;
+  case EVENT_MREMAP:
+    return &info->mremap.old_range;
+  case EVENT_MADVISE:
+    return &info->madvise.range;
+  case EVENT_MPROTECT:
+    return &info->mprotect.range;
+  case EVENT_PKEY_MPROTECT:
+    return &info->pkey_mprotect.range;
+  case EVENT_CLONE:
+    return NULL;
+  case EVENT_EXEC:
+    return NULL;
+  case EVENT_NONE:
+    return NULL;
+    break;
+  }
+}
+
 enum mmap_event event_from_syscall(uint64_t rax);

--- a/runtime/mmap_event.h
+++ b/runtime/mmap_event.h
@@ -24,6 +24,7 @@ struct mremap_info {
 
 struct madvise_info {
   struct range range;
+  int advice;
   unsigned char pkey;
 };
 

--- a/runtime/mmap_event.h
+++ b/runtime/mmap_event.h
@@ -22,6 +22,11 @@ struct mremap_info {
   unsigned char pkey;
 };
 
+struct madvise_info {
+  struct range range;
+  unsigned char pkey;
+};
+
 struct mprotect_info {
   struct range range;
   int prot;
@@ -39,6 +44,7 @@ union event_info {
   struct mmap_info mmap;
   struct munmap_info munmap;
   struct mremap_info mremap;
+  struct madvise_info madvise;
   struct mprotect_info mprotect;
   struct pkey_mprotect_info pkey_mprotect;
 };
@@ -47,6 +53,7 @@ enum mmap_event {
   EVENT_MMAP,
   EVENT_MUNMAP,
   EVENT_MREMAP,
+  EVENT_MADVISE,
   EVENT_MPROTECT,
   EVENT_PKEY_MPROTECT,
   EVENT_CLONE,
@@ -58,6 +65,7 @@ static const char *event_names[] = {
     "MMAP",
     "MUNMAP",
     "MREMAP",
+    "MADVISE",
     "MPROTECT",
     "PKEY_MPROTECT",
     "CLONE",

--- a/runtime/seccomp_filter.c
+++ b/runtime/seccomp_filter.c
@@ -40,6 +40,7 @@ struct sock_filter ia2_filter[] = {
     BPF_SYSCALL_POLICY(pkey_mprotect, TRACE),
     /* basic process syscalls */
     BPF_SYSCALL_POLICY(access, ALLOW),
+    BPF_SYSCALL_POLICY(open, ALLOW),
     BPF_SYSCALL_POLICY(arch_prctl, ALLOW),
     BPF_SYSCALL_POLICY(brk, ALLOW),
     BPF_SYSCALL_POLICY(clone3, ALLOW),

--- a/runtime/seccomp_filter.c
+++ b/runtime/seccomp_filter.c
@@ -34,6 +34,7 @@ struct sock_filter ia2_filter[] = {
     BPF_SYSCALL_POLICY(mprotect, TRACE),
     BPF_SYSCALL_POLICY(mremap, TRACE),
     BPF_SYSCALL_POLICY(munmap, TRACE),
+    BPF_SYSCALL_POLICY(madvise, TRACE),
     /* pkey syscalls */
     BPF_SYSCALL_POLICY(pkey_alloc, ALLOW),
     BPF_SYSCALL_POLICY(pkey_mprotect, TRACE),

--- a/runtime/track_memory_map.c
+++ b/runtime/track_memory_map.c
@@ -839,6 +839,10 @@ bool track_memory_map(pid_t pid, int *exit_status_out, enum trace_mode mode) {
     } else if (!is_op_permitted(map, event, &event_info)) {
       fprintf(stderr, "forbidden operation requested: ");
       print_event(event, &event_info);
+      const struct range *range = event_target_range(event, &event_info);
+      if (range != NULL) {
+        printf("region pkey: %d\n", memory_map_region_get_owner_pkey(map, *range));
+      }
       return_syscall_eperm(waited_pid);
       if (ptrace(continue_request, waited_pid, 0, 0) < 0) {
         perror("could not PTRACE_SYSCALL");

--- a/runtime/track_memory_map.c
+++ b/runtime/track_memory_map.c
@@ -297,11 +297,10 @@ static bool interpret_syscall(struct user_regs_struct *regs, unsigned char pkey,
     info->range.start = regs->rdi;
     info->range.len = regs->rsi;
     info->pkey = pkey;
-
-    int advice = regs->rdx;
+    info->advice = regs->rdx;
 
     debug_op("compartment %d madvise (%08zx, %zd) with advice=%d\n", info->pkey,
-             info->range.start, info->range.len, advice);
+             info->range.start, info->range.len, info->advice);
     break;
   }
   case EVENT_MPROTECT: {

--- a/runtime/track_memory_map.c
+++ b/runtime/track_memory_map.c
@@ -762,8 +762,8 @@ bool track_memory_map(pid_t pid, int *exit_status_out, enum trace_mode mode) {
     }
     case WAIT_SIGNALED: {
       fprintf(stderr, "process received fatal signal (syscall entry)\n");
-      propagate(handle_process_exit(&maps, waited_pid));
-      continue;
+      enum control_flow cf = handle_process_exit(&maps, waited_pid);
+      return false;
     }
     case WAIT_EXITED: {
       debug_exit("pid %d exited (syscall entry)\n", waited_pid);

--- a/runtime/track_memory_map.c
+++ b/runtime/track_memory_map.c
@@ -837,7 +837,8 @@ bool track_memory_map(pid_t pid, int *exit_status_out, enum trace_mode mode) {
         return false;
       }
     } else if (!is_op_permitted(map, event, &event_info)) {
-      fprintf(stderr, "forbidden operation requested: %s\n", event_name(event));
+      fprintf(stderr, "forbidden operation requested: ");
+      print_event(event, &event_info);
       return_syscall_eperm(waited_pid);
       if (ptrace(continue_request, waited_pid, 0, 0) < 0) {
         perror("could not PTRACE_SYSCALL");


### PR DESCRIPTION
`madvise(MADV_DONTNEED)` is equivalent to zeroing memory; we cannot allow this to be performed cross-compartment.

Because some other 'advices' may also have similar effects, for now we simply forbid all cross-compartment `madvise(advice)` calls regardless of the value of `advice`. We can loosen this policy if needed by some applications down the line, but for now this patches the security hole while keeping our tests passing.

#### Postscript

This took a few iterations to get tests green again. Round-by-round:

1. The first commit failed tests for a couple reasons, the primary of which is that the `madvise()` policy was being tripped and forbidding a `madvise(MADV_DONTNEED)` inside `free()` in PartitionAlloc. To debug this, I added the next few commits, through `runtime/track_memory_map: print details of forbidden operations`.
2. At this point, I had enough information to see that for some reason the tracer observed the program running inside compartment zero (pkru==0x00000000) the whole time. This led to the realization that the runtime could not properly read the pkru on the machine running our CI.
3. I added debugging to avoid using the pkru being seen as zero in some cases where our logic to read it via `ptrace(PTRACE_GETREGSET)`might fail. This immediately triggered, indicating that this is where the problem was (`runtime/get_inferior_pkru: initialize buffer with noticeable garbage`).
4. Investigating this further, I discovered that the approach that we (and gdb) had been using to read the pkru was non-portable. gdb has since [changed to a more portable approach](https://git.linaro.org/toolchain/binutils-gdb.git/commit/?id=c689d1fe58b2c0faf51e4f574d50271f1d0648e3), and I rewrote our code to do as the Intel documentation suggests, which should be future-proof (`runtime/get_inferior_pkru: query CPUID to determine the location of PKRU in xstate`).
5. Validating this change, I saw tests passing despite being killed by seccomp for syscall policy violation. I realized that my reworking to handle tracing of multiple threads and processes was masking the propagation of failure from processes being killed by fatal signals.
6. I fixed the masking bug and found that tests were using `open()` which is not on our syscall allowlist. I added it to the list as this was a mere oversight, caused by the fact that our tests do not use `open()` (preferring `openat()`) except via ubsan.
7. CI still failed due to a probabilistic abort caused by racy access to the filesystem when setting up our landlock FS sandbox. I fixed the error handling here (it's benign if we happen to be unable to allow access to a directory because it no longer exists) and now finally everything is green.