### PR TITLE
Generate no-op call gates for ARM64

### DIFF
--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -442,8 +442,7 @@ static void emit_set_pkru(AsmWriter &aw, uint32_t target_pkey, Arch arch) {
     add_asm_line(aw, "movq %r11, %rdx");
   } else if (arch == Arch::Aarch64) {
     // set X18 to the pointer key (compartment number left-shifted 56 bits)
-    add_asm_line(aw, "mov x18, #" + std::to_string(target_pkey & 0xF));
-    add_asm_line(aw, "lsl x18, x18, #56");
+    llvm::errs() << "TODO x18 switching is not implemented\n";
   }
 }
 

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -419,7 +419,7 @@ static void emit_copy_args(AsmWriter &aw, size_t stack_return_size, size_t stack
   }
 }
 
-static void emit_fn_ptr(AsmWriter &aw, Arch arch) {
+static void emit_load_fn_ptr(AsmWriter &aw, Arch arch) {
   if (arch == Arch::X86) {
       add_asm_line(aw, "movq ia2_fn_ptr@GOTPCREL(%rip), %r12");
       add_asm_line(aw, "movq (%r12), %r12");
@@ -689,11 +689,11 @@ std::string emit_asm_wrapper(const CAbiSignature &sig,
   emit_copy_args(aw, stack_return_size, stack_return_padding, stack_alignment, stack_arg_count, stack_arg_size, caller_pkey, arch);
 
   if (reg_arg_count > 0) {
-    emit_scrub_regs(aw, target_pkey, return_locs, arch);
+    emit_scrub_regs(aw, caller_pkey, param_locs, arch);
   }
 
   if (kind == WrapperKind::IndirectCallsite) {
-    emit_fn_ptr(aw, arch);
+    emit_load_fn_ptr(aw, arch);
   }
 
   emit_set_pkru(aw, target_pkey, arch);

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -462,8 +462,9 @@ static void emit_set_pkru(AsmWriter &aw, uint32_t target_pkey, WrapperKind kind,
     add_asm_line(aw, "movq %r10, %rcx");
     add_asm_line(aw, "movq %r11, %rdx");
   } else if (arch == Arch::Aarch64) {
-    // TODO ARM set compartment
-    llvm::errs() << "TODO compartment setting not implemented on ARM\n";
+    // set X18 to the pointer key (compartment number left-shifted 56 bits)
+    add_asm_line(aw, "mov x18, #" + std::to_string(target_pkey & 0xF));
+    add_asm_line(aw, "lsl x18, x18, #56");
   }
 }
 

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -288,22 +288,19 @@ static void call_string(
 
   add_comment_line(aw, "Call wrapped function");
 
-  if (arch == Arch::X86) {
-    if (!target_name) {
-      // indirect call
-      assert(kind == WrapperKind::IndirectCallsite);
+  if (!target_name) {
+    // indirect call
+    assert(kind == WrapperKind::IndirectCallsite);
+    if (arch == Arch::X86) {
       add_asm_line(aw, "call *%r12");
-    } else {
-      // direct call
-      add_asm_line(aw, "call "s + target_name.value());
+    } else if (arch == Arch::Aarch64) {
+      add_asm_line(aw, "br x12"); // TODO, which register?
     }
-  } else if (arch == Arch::Aarch64) {
-    if (!target_name) {
-      // indirect call
-      assert(kind == WrapperKind::IndirectCallsite);
-      add_asm_line(aw, "br "s + target_name.value());
-    } else {
-      // direct call
+  } else {
+    // direct call
+    if (arch == Arch::X86) {
+      add_asm_line(aw, "call "s + target_name.value());
+    } else if (arch == Arch::Aarch64) {
       add_asm_line(aw, "b "s + target_name.value());
     }
   }

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -342,7 +342,8 @@ static void switch_stacks(AsmWriter &aw, uint32_t caller_pkey, uint32_t target_p
     // Switch stacks to the target stack
     emit_switch_stacks(aw, caller_pkey, target_pkey, "r11"s);
   } else if (arch == Arch::Aarch64) {
-    // no-op for now
+    // TODO ARM stack switching
+    llvm::errs() << "TODO stack switching not implemented on ARM\n";
   }
 }
 
@@ -400,7 +401,8 @@ static void copy_args(AsmWriter &aw, size_t stack_return_size, size_t stack_retu
       }
     }
   } else if (arch == Arch::Aarch64) {
-    // no-op for now
+    // TODO ARM arguments
+    llvm::errs() << "TODO arguments not implemented on ARM\n";
   }
 }
 
@@ -439,7 +441,8 @@ static void zero_regs(AsmWriter &aw, uint32_t caller_pkey, int reg_arg_count, co
       }
     }
   } else if (arch == Arch::Aarch64) {
-    // no-op for now
+    // TODO ARM reg zero
+    llvm::errs() << "TODO register zeroing not implemented on ARM\n";
   }
 }
 
@@ -458,6 +461,9 @@ static void set_pkru(AsmWriter &aw, uint32_t target_pkey, WrapperKind kind, Arch
     emit_wrpkru(aw, target_pkey);
     add_asm_line(aw, "movq %r10, %rcx");
     add_asm_line(aw, "movq %r11, %rdx");
+  } else if (arch == Arch::Aarch64) {
+    // TODO ARM set compartment
+    llvm::errs() << "TODO compartment setting not implemented on ARM\n";
   }
 }
 
@@ -487,6 +493,9 @@ static void cleanup_and_restore_after_call(AsmWriter &aw, uint32_t caller_pkey, 
       assert(stack_alignment == 8);
       add_asm_line(aw, "addq $8, %rsp");
     }
+  } else if (arch == Arch::Aarch64) {
+    // TODO ARM cleanup and restore
+    llvm::errs() << "TODO cleanup not implemented on ARM\n";
   }
 }
 
@@ -516,6 +525,9 @@ static void copy_stack_returns_and_switch_back(AsmWriter &aw, size_t stack_retur
 
     // Switch back to the caller's stack
     emit_switch_stacks(aw, target_pkey, caller_pkey, "r11"s);
+  } else if (arch == Arch::Aarch64) {
+    // TODO ARM stack switch back
+    llvm::errs() << "TODO stack switch-back not implemented on ARM\n";
   }
 }
 
@@ -569,6 +581,9 @@ static void finalize_and_return_to_caller(AsmWriter &aw, uint32_t target_pkey, u
     // Return to the caller
     add_comment_line(aw, "Return to the caller");
     add_asm_line(aw, "ret");
+  } else if (arch == Arch::Aarch64) {
+    // TODO ARM return to called
+    llvm::errs() << "TODO return to caller not implemented on ARM\n";
   }
 }
 

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -548,7 +548,7 @@ static void emit_set_return_pkru(AsmWriter &aw, uint32_t caller_pkey, Arch arch)
   }
 }
 
-static void emit_eiplogue(AsmWriter &aw, uint32_t caller_pkey, Arch arch) {
+static void emit_epilogue(AsmWriter &aw, uint32_t caller_pkey, Arch arch) {
   if (arch == Arch::X86) {
     // Load registers that are preserved across function calls after switching
     // back to the caller's compartment's stack. This is on the caller's stack so
@@ -712,7 +712,7 @@ std::string emit_asm_wrapper(const CAbiSignature &sig,
 
   emit_set_return_pkru(aw, caller_pkey, arch);
 
-  emit_eiplogue(aw, caller_pkey, arch);
+  emit_epilogue(aw, caller_pkey, arch);
 
   emit_return(aw, arch);
 

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -74,6 +74,7 @@ static llvm::cl::opt<std::string>
                  llvm::cl::cat(SourceRewriterCategory),
                  llvm::cl::desc("<prefix for output files>"));
 
+
 // Map each translation unit's filename to its pkey.
 static std::map<Filename, Pkey> file_pkeys;
 
@@ -1101,6 +1102,7 @@ int main(int argc, const char **argv) {
       std::string wrapper_name = "__ia2_indirect_callgate_"s +
                                  mangled_ty + "_pkey_" +
                                  std::to_string(caller_pkey);
+
       std::string asm_wrapper =
           emit_asm_wrapper(c_abi_sig, wrapper_name, std::nullopt,
                            WrapperKind::IndirectCallsite, caller_pkey, 0, Target);


### PR DESCRIPTION
Merge in my branch with the no-op call gates and call gates refactoring for multi-arch.

WIP, still working on making sure this is the correct assembly, but the `minimal_arm_main_wrapped` target compiles.