### PR TITLE
runtime/tracer: Ignore procfs race in syscall tracer

### DIFF
--- a/runtime/tracer/forbid_paths.c
+++ b/runtime/tracer/forbid_paths.c
@@ -135,7 +135,8 @@ static int forbid_deep_or_shallow(const char *fpath, const struct stat *sb,
 
   /* allow whole dir or file */
   int ret = allow_path(fpath, ctx.ruleset_fd, false);
-  if (ret < 0) {
+  bool in_proc = !strncmp(fpath, "/proc/", sizeof("/proc/") - 1);
+  if (ret < 0 && !in_proc) {
     ctx.error = ret;
     return FTW_STOP;
   }


### PR DESCRIPTION
This is the fix I added in #311 for a procfs issue. On second thought the cleaner solution would be to propagate actual errors from allow_path to its callers and check those like we did in #318 with ENOENT.