### PR TITLE
runtime/tracer: print error when fstat fails

### DIFF
--- a/runtime/tracer/forbid_paths.c
+++ b/runtime/tracer/forbid_paths.c
@@ -27,6 +27,8 @@ static int allow_path(const char *path, const int ruleset_fd, bool shallow) {
     return -1;
   }
   if (fstat(path_beneath.parent_fd, &statbuf)) {
+    /* if we cannot stat the entry to distinguish file vs. dir, we must bail */
+    fprintf(stderr, "Failed fstat \"%s\": %s\n", path, strerror(errno));
     close(path_beneath.parent_fd);
     return -1;
   }


### PR DESCRIPTION
This is the only case that was silent previously. Follow-up to #330.