### PR TITLE
tools/rewriter: Replace type IDs with mangled types again

### DIFF
--- a/tests/read_config/main.c
+++ b/tests/read_config/main.c
@@ -120,7 +120,7 @@ Test(read_config, main) {
     // This function pointer may come from the plugin, so drop from pkey 1 to
     // pkey 0 before calling it. If the function is in the built-in module,
     // it'll have a wrapper from pkey 0 to pkey 1.
-    // REWRITER: IA2_CALL((opt->parse), 0)(delim + 1, &shared_entry.value);
+    // REWRITER: IA2_CALL((opt->parse), _ZTSPFvPcPvE)(delim + 1, &shared_entry.value);
     (opt->parse)(delim + 1, &shared_entry.value);
     // Copy the value from the shared entry to the main binary's stack.
     entries[idx].value = shared_entry.value;

--- a/tests/rewrite_macros/include/lib.h
+++ b/tests/rewrite_macros/include/lib.h
@@ -32,7 +32,7 @@ extern struct event_actions actions;
 #if PRE_REWRITER
 #define call_add_event(evt) (actions.add)(evt)
 #else
-#define call_add_event(evt) IA2_CALL(actions.add, 0)(evt)
+#define call_add_event(evt) IA2_CALL(actions.add, _ZTSPFbP5eventE)(evt)
 #endif
 
 struct event *get_event();

--- a/tests/rewrite_macros/main.c
+++ b/tests/rewrite_macros/main.c
@@ -20,9 +20,9 @@ Test(rewrite_macros, main) {
 
     struct event *evt = get_event();
     // Test that the FnPtrCall pass can rewrite simple macros
-    // REWRITER: IA2_CALL(add_event, 0)(evt);
+    // REWRITER: IA2_CALL(add_event, _ZTSPFbP5eventE)(evt);
     add_event(evt);
-    // REWRITER: IA2_CALL(actions.add, 0)(evt);
+    // REWRITER: IA2_CALL(actions.add, _ZTSPFbP5eventE)(evt);
     actions.add(evt);
 
     bool(*fn)(struct event *evt) = add_event;
@@ -34,6 +34,6 @@ Test(rewrite_macros, main) {
     // REWRITER: if (IA2_ADDR(fn) == IA2_ADDR(actions.add)) {}
     if (fn == actions.add) {}
 
-    // REWRITER: IA2_CALL(fn, 0)(evt);
+    // REWRITER: IA2_CALL(fn, _ZTSPFbP5eventE)(evt);
     fn(evt);
 }

--- a/tests/simple1/main.c
+++ b/tests/simple1/main.c
@@ -82,7 +82,7 @@ Test(simple1, main) {
     // untrusted since libsimple1 sets the value of exit_hook_fn. If
     // exit_hook_fn were to point to a function defined in this binary, it must
     // be a wrapped function with an untrusted caller and callee with pkey 0.
-    // REWRITER: IA2_CALL(exit_hook_fn, 0)();
+    // REWRITER: IA2_CALL(exit_hook_fn, _ZTSPFvvE)();
     exit_hook_fn();
   }
 }

--- a/tests/trusted_indirect/main.c
+++ b/tests/trusted_indirect/main.c
@@ -36,16 +36,16 @@ void call_fn_ptr() {
     uint32_t x = 987234;
     uint32_t y = 142151;
     // This calls `f.op` with and without parentheses to ensure the rewriter handles both
-    // REWRITER: uint32_t res1 = IA2_CALL(f.op, 0)(x, y);
+    // REWRITER: uint32_t res1 = IA2_CALL(f.op, _ZTSPFjjjE)(x, y);
     uint32_t res1 = f.op(x, y);
     // REWRITER: f.op = IA2_FN(multiply);
     f.op = multiply;
-    // REWRITER: uint32_t res2 = IA2_CALL((f.op), 0)(x, y);
+    // REWRITER: uint32_t res2 = IA2_CALL((f.op), _ZTSPFjjjE)(x, y);
     uint32_t res2 = (f.op)(x, y);
     cr_assert_eq(res2, 2897346862);
     // REWRITER: f.op = IA2_FN(divide);
     f.op = divide;
-    // REWRITER: uint32_t res3 = IA2_CALL(f.op, 0)(x, y);
+    // REWRITER: uint32_t res3 = IA2_CALL(f.op, _ZTSPFjjjE)(x, y);
     uint32_t res3 = f.op(x, y);
     cr_assert_eq(res3, 6);
 }
@@ -63,7 +63,7 @@ void do_test() {
 
     static uint32_t secret = 34;
     leak_secret_address(&secret);
-    // REWRITER: IA2_CALL((f.op), 0)(0, 0);
+    // REWRITER: IA2_CALL((f.op), _ZTSPFjjjE)(0, 0);
     (f.op)(0, 0);
 }
 


### PR DESCRIPTION
Closes #326. Also the nginx demo doesn't need to be updated since no IA2_CALL macros were added checked in.