### PR TITLE
runtime/libia2: enable MTE

### DIFF
--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -127,6 +127,7 @@ int ia2_mprotect_with_tag(void *addr, size_t len, int prot, int tag) {
     int res = mprotect(addr, len, prot | PROT_MTE);
     if (res != 0) {
         /* Skip memory tagging if mprotect returned an error */
+        printf("mprotect failed with %d\n", res);
         return res;
     }
     assert((len % PAGE_SIZE) == 0);
@@ -236,7 +237,7 @@ static bool in_extra_libraries(struct dl_phdr_info *info, const char *extra_libr
 static int segment_flags_to_access_flags(Elf64_Word flags) {
   return ((flags & PF_X) != 0 ? PROT_EXEC : 0) |
          ((flags & PF_W) != 0 ? PROT_WRITE : 0) |
-         ((flags & PF_R) != 0 ? PROT_READ : 0);
+         ((flags & PF_R) != 0 ? PROT_READ : 0) | PROT_MTE;
 }
 
 int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -246,7 +246,7 @@ int ia2_mprotect_with_tag(void *addr, size_t len, int prot, int tag);
 #endif
 char *allocate_stack(int i);
 void verify_tls_padding(void);
-void ensure_pkeys_allocated(int *n_to_alloc);
+void ia2_set_up_tags(int *n_to_alloc);
 _Noreturn void ia2_reinit_stack_err(int i);
 
 #define _IA2_INIT_RUNTIME(n)                                                   \
@@ -272,7 +272,7 @@ _Noreturn void ia2_reinit_stack_err(int i);
                                                                                \
   __attribute__((constructor)) static void ia2_init(void) {                    \
     /* Set up global resources. */                                             \
-    ensure_pkeys_allocated(&ia2_n_pkeys_to_alloc);                             \
+    ia2_set_up_tags(&ia2_n_pkeys_to_alloc);                                    \
     /* Initialize stacks for the main thread/ */                               \
     init_stacks_and_setup_tls();                                               \
     REPEATB##n(setup_destructors_for_compartment, nop_macro);                  \

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -1,4 +1,6 @@
 #include "ia2_internal.h"
+#include <sys/auxv.h>
+#include <sys/prctl.h>
 
 /* The 0th compartment is unprivileged and does not protect its memory, */
 /* so declare its stack pointer in the shared object that sets up the */
@@ -43,8 +45,8 @@ void verify_tls_padding(void) {
   }
 }
 
-/* Ensure that all required pkeys are allocated or no-op on aarch64. */
-void ensure_pkeys_allocated(int *n_to_alloc) {
+/* Allocates the required pkeys on x86 or enables MTE on aarch64 */
+void ia2_set_up_tags(int *n_to_alloc) {
 #if LIBIA2_X86_64
   if (*n_to_alloc != 0) {
     for (int pkey = 1; pkey <= *n_to_alloc; pkey++) {
@@ -61,6 +63,17 @@ void ensure_pkeys_allocated(int *n_to_alloc) {
       }
     }
     *n_to_alloc = 0;
+  }
+#elif LIBIA2_AARCH64
+  if (!(getauxval(AT_HWCAP2) & HWCAP2_MTE)) {
+      printf("MTE is not supported\n");
+      exit(-1);
+  }
+  int res = prctl(PR_SET_TAGGED_ADDR_CTRL,
+                PR_TAGGED_ADDR_ENABLE | PR_MTE_TCF_SYNC | (0xFFFE << PR_MTE_TAG_SHIFT),
+                0, 0, 0);
+  if (res) {
+      printf("prctl failed (%d) to enable MTE\n", res);
   }
 #endif
 }


### PR DESCRIPTION
This PR actually enables MTE after #311 added support for cross-compiling for ARM. I wrote some basic tests that protects static data but we'll need to test a different way as explained in [this comment](https://github.com/immunant/IA2-Phase2/issues/314#issuecomment-2019145083).