### PR TITLE
pad-tls: Add support for ARM64 to pad-tls and fix libc lookup in CMake

### DIFF
--- a/cmake/ia2.cmake
+++ b/cmake/ia2.cmake
@@ -102,7 +102,7 @@ function(pad_tls_library INPUT OUTPUT)
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${OUTPUT}.so
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${INPUT}> ${CMAKE_CURRENT_BINARY_DIR}/lib${OUTPUT}.so
     COMMAND ${CMAKE_BINARY_DIR}/tools/pad-tls/pad-tls --allow-no-tls ${CMAKE_CURRENT_BINARY_DIR}/lib${OUTPUT}.so
-    DEPENDS tools $<TARGET_FILE:${INPUT}>
+    DEPENDS ${PAD_TLS_SRCS} tools pad-tls $<TARGET_FILE:${INPUT}>
     COMMENT "Padding TLS segment of wrapped library"
   )
   add_custom_target(${OUTPUT}-padding DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/lib${OUTPUT}.so")
@@ -173,6 +173,7 @@ execute_process(COMMAND ${CLANG_EXE} -print-file-name=include-fixed
 message(STATUS "Found Clang fixed headers: ${CLANG_HEADERS_INCLUDE_FIXED}")
 
 file(GLOB REWRITER_SRCS ${CMAKE_SOURCE_DIR}/tools/rewriter/*.cpp)
+file(GLOB PAD_TLS_SRCS ${CMAKE_SOURCE_DIR}/tools/pad-tls/*.c)
 # This cannot be in the tools directory CMakeLists.txt because the target is for
 # the top-level CMake project
 add_custom_target(rewriter
@@ -180,6 +181,11 @@ add_custom_target(rewriter
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tools
     # tools dependency is for the CMake config step
     DEPENDS tools ${REWRITER_SRCS})
+
+add_custom_target(pad-tls
+    COMMAND ${CMAKE_COMMAND} --build . -t pad-tls
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tools
+    DEPENDS tools ${PAD_TLS_SRCS})
 
 # Create call gates for a target
 #

--- a/runtime/libia2/CMakeLists.txt
+++ b/runtime/libia2/CMakeLists.txt
@@ -46,12 +46,19 @@ set_property(TARGET libia2 PROPERTY INTERFACE_LINK_DEPENDS ${CMAKE_CURRENT_BINAR
 # Find libc. We cannot simply do `find_library(LIBC c REQUIRED)` because
 # `libc.so` itself is a linker script with glibc, while we need the path of
 # the actual ELF shared object itself so we can patch its program headers.
+if (LIBIA2_AARCH64)
+set(LIBC_PATHS /usr/aarch64-linux-gnu/lib /usr/aarch64-linux-gnu/lib64)
+else()
 set(LIBC_PATHS /lib /lib64 /lib/x86_64-linux-gnu)
+endif()
+
 foreach(CANDIDATE in ${LIBC_PATHS})
     if (EXISTS ${CANDIDATE}/libc.so.6)
         set(LIBC_PATH ${CANDIDATE}/libc.so.6)
     endif()
 endforeach()
+
+
 if(NOT DEFINED LIBC_PATH)
     message(FATAL_ERROR "Could not find libc.so.6 in: ${LIBC_PATHS}\n")
 endif()
@@ -61,7 +68,7 @@ add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libc.so.6
     COMMAND ${CMAKE_COMMAND} -E copy ${LIBC_PATH} ${CMAKE_CURRENT_BINARY_DIR}/libc.so.6
     COMMAND ${CMAKE_BINARY_DIR}/tools/pad-tls/pad-tls --allow-no-tls ${CMAKE_CURRENT_BINARY_DIR}/libc.so.6
-    DEPENDS tools
+    DEPENDS ${PAD_TLS_SRCS} tools pad-tls
     COMMENT "Padding TLS segment of libc"
 )
 

--- a/tools/pad-tls/pad-tls.c
+++ b/tools/pad-tls/pad-tls.c
@@ -33,7 +33,7 @@ enum patch_result patch_tls(void *elf, int64_t delta, uint64_t *size_out) {
     return BAD_MAGIC;
   }
 
-  if (ehdr->e_machine != EM_X86_64) {
+  if ((ehdr->e_machine != EM_X86_64) && (ehdr->e_machine != EM_AARCH64)) {
     return WRONG_ARCH;
   }
 


### PR DESCRIPTION
Previously CMake was picking up libc.so for x86 and running pad-tls on that. We were seemingly linking against it but the basic ARM test wasn't failing since QEMU doesn't actually load the guest libc.so into the address space only ld.so. This fixes both libc lookup paths and modifies pad-tls to allow EM_AARCH64. Since this has no effect on the ARM test when emulating with QEMU I checked the libc copy in the build dir manually.