### PR TITLE
misc: spoof criterion for ARM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,8 @@ jobs:
             -DCLANG_EXE=`which clang-15`                            \
             -DLLVM_DIR=$LLVM_DIR                                    \
             -G Ninja
-          ninja -v minimal_no_criterion
+          ninja -v minimal
           qemu-aarch64-static -L /usr/aarch64-linux-gnu/ \
-            tests/minimal_no_criterion/minimal_no_criterion
+            tests/minimal/minimal
           popd
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(runtime)
 if (NOT LIBIA2_AARCH64)
     add_subdirectory(examples)
 endif()
+add_subdirectory(misc)
 
 add_subdirectory(tests)
 ExternalProject_Add(tools

--- a/cmake/ia2.cmake
+++ b/cmake/ia2.cmake
@@ -154,6 +154,10 @@ function(create_compile_commands NAME TYPE)
   # Copy target properties from the real target. We might need to add more properties.
   target_link_libraries(${COMPILE_COMMAND_TARGET} PRIVATE $<TARGET_PROPERTY:${NAME},LINK_LIBRARIES>)
   target_include_directories(${COMPILE_COMMAND_TARGET} PRIVATE ${INCLUDE_DIRECTORIES})
+  if (LIBIA2_AARCH64)
+    target_include_directories(${COMPILE_COMMAND_TARGET} PRIVATE
+        ${CMAKE_SOURCE_DIR}/misc/spoofed_criterion/include)
+  endif()
   set(CMAKE_EXPORT_COMPILE_COMMANDS OFF)
 endfunction()
 

--- a/cmake/ia2.cmake
+++ b/cmake/ia2.cmake
@@ -45,6 +45,13 @@ function(add_ia2_compartment NAME TYPE)
     add_library(${NAME} SHARED)
   endif()
 
+  # The x86 version is missing a dependency here and libs rely on include path overlap to pick up
+  # criterion header. I want to keep spoofed criterion static for simplicity so we add the -I
+  # directly here.
+  if (LIBIA2_AARCH64)
+    target_include_directories(${NAME} PRIVATE
+        ${CMAKE_SOURCE_DIR}/misc/spoofed_criterion/include)
+  endif()
   target_compile_definitions(${NAME} PRIVATE
     IA2_ENABLE=1
     PKEY=${ARG_PKEY}

--- a/docs/directory_structure.md
+++ b/docs/directory_structure.md
@@ -30,6 +30,10 @@ module to demo compartmentalizing Nginx plugins.
 Nginx media streaming RTMP module from github.com/arut/nginx-rtmp-module
 
 
+## misc/spoofed_criterion
+A basic library that spoofs the criterion interace used in our test suite. This is a workaround to
+avoid having to build criterion and its dependencies with -ffixed-x18.
+
 ## runtime 
 The compartmentalization runtime, including code for both the target process
 itself and for tracing the process.

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -1,0 +1,3 @@
+if (LIBIA2_AARCH64)
+    add_subdirectory(spoofed_criterion)
+endif()

--- a/misc/spoofed_criterion/CMakeLists.txt
+++ b/misc/spoofed_criterion/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(criterion STATIC test_runner.c)
+target_include_directories(criterion INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/misc/spoofed_criterion/include/criterion/criterion.h
+++ b/misc/spoofed_criterion/include/criterion/criterion.h
@@ -1,0 +1,6 @@
+#include <criterion/logging.h>
+
+#define Test(suite, name) \
+    void suite##_##name(void); \
+    __attribute__((__section__("fake_criterion_tests"))) void (*suite##_##name##_##test)(void) = suite##_##name; \
+    void suite##_##name(void)

--- a/misc/spoofed_criterion/include/criterion/logging.h
+++ b/misc/spoofed_criterion/include/criterion/logging.h
@@ -1,0 +1,3 @@
+#include <stdio.h>
+
+#define cr_log_info printf

--- a/misc/spoofed_criterion/include/criterion/new/assert.h
+++ b/misc/spoofed_criterion/include/criterion/new/assert.h
@@ -1,0 +1,2 @@
+#define cr_assert assert
+#define cr_fatal assert

--- a/misc/spoofed_criterion/test_runner.c
+++ b/misc/spoofed_criterion/test_runner.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+extern void (*__start_fake_criterion_tests)(void);
+extern void (*__stop_fake_criterion_tests)(void);
+
+int main() {
+    void (**test)(void) = &__start_fake_criterion_tests;
+    for (; test < &__stop_fake_criterion_tests; test++) {
+        if (!test) {
+            break;
+        }
+        (*test)();
+    }
+}


### PR DESCRIPTION
I got criterion working with ARM/QEMU in CI on #335 but objdump shows that libcriterion.so clobbers x18. Instead of building it and all transitive deps with ffixed-x18 let's just spoof criterion for now. This unblocks a lot of the small tasks in #314 which depend on libs not clobbering x18.

This lets us build all tests (modulo x86 code we haven't ifdefed out in libia2) but there's no cmake command to build all tests, only build and test w/o QEMU. We should either add a target to build all tests or add support for testing with QEMU.