### PR TITLE
Don't fail fast if tracing-enabled tests fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ on:
 jobs:
   test-on-pkru-enabled-host:
     runs-on: self-hosted
+    continue-on-error: ${{ matrix.ia2-tracer == 'ON' }}
     strategy:
+      fail-fast: true
       matrix:
         build-type: [Release, Debug]
         c_compiler: [clang, gcc]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         ia2-tracer: [ON, OFF]
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build
         run: |
           LLVM_DIR=`llvm-config --cmakedir`
@@ -37,7 +37,7 @@ jobs:
             -DLLVM_DIR=$LLVM_DIR                                         \
             -DLLVM_EXTERNAL_LIT=$HOME/.local/bin/lit                     \
             -DLIBIA2_DEBUG=${{ matrix.ia2-debug }}                       \
-            -DIA2_TRACER=${{ matrix.ia2-tracer }}                      \
+            -DIA2_TRACER=${{ matrix.ia2-tracer }}                        \
             -G Ninja
           ninja
           popd
@@ -50,7 +50,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build nginx
         run: |
           LLVM_DIR=`llvm-config --cmakedir`
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Test ARM build
         run: |
           sudo apt-get update


### PR DESCRIPTION
Close #339.

Non-tracing-enabled runs will now continue but the overall run will still fail if a tracing-enabled one does. LMK if this is the desired functionality or not. 