### PR TITLE
ia2_internal.h: avoid dl_phdr_info warning

### DIFF
--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -3,7 +3,12 @@
  * subject to change and should not be used directly. */
 #pragma once
 
-/* for struct dl_phdr_info */
+/* struct dl_phdr_info is only defined if _GNU_SOURCE but at rewriter runtime
+ * _GNU_SOURCE may not be defined in the user's code prior to the inclusion of
+ * <features.h>. As such, forward-declare it here as we only use it opaquely. */
+struct dl_phdr_info;
+
+/* for pkey_mprotect */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif


### PR DESCRIPTION
This is a weird thing around #include order when we run the rewriter. Tiny fix but I had already spent the time tracking it down so here it is. PR mostly just for CI.