### PR TITLE
spoofed_criterion: Support non-zero exit code and enable should_segafult test on ARM

### DIFF
--- a/misc/spoofed_criterion/CMakeLists.txt
+++ b/misc/spoofed_criterion/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_library(criterion STATIC test_runner.c)
-target_include_directories(criterion INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(criterion
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/misc/spoofed_criterion/include/criterion/criterion.h
+++ b/misc/spoofed_criterion/include/criterion/criterion.h
@@ -2,13 +2,13 @@
 #include <criterion/new/assert.h>
 
 struct fake_criterion_test {
-  int (*test)(void);
+  void (*test)(void);
   int exit_code;
 };
 
 #define Test(suite, name, ...)                                                                                                 \
-  int fake_criterion_##suite##_##name(void);                                                                                   \
+  void fake_criterion_##suite##_##name(void);                                                                                  \
   __attribute__((__section__("fake_criterion_tests"))) struct fake_criterion_test fake_criterion_##suite##_##name##_##test = { \
       .test = fake_criterion_##suite##_##name,                                                                                 \
       ##__VA_ARGS__};                                                                                                          \
-  int fake_criterion_##suite##_##name(void)
+  void fake_criterion_##suite##_##name(void)

--- a/misc/spoofed_criterion/include/criterion/criterion.h
+++ b/misc/spoofed_criterion/include/criterion/criterion.h
@@ -1,8 +1,14 @@
 #include <criterion/logging.h>
 #include <criterion/new/assert.h>
 
-#define Test(suite, name) \
-    int fake_criterion_##suite##_##name(void); \
-    __attribute__((__section__("fake_criterion_tests"))) \
-        int (*fake_criterion_##suite##_##name##_##test)(void) = fake_criterion_##suite##_##name; \
-    int fake_criterion_##suite##_##name(void)
+struct fake_criterion_test {
+  int (*test)(void);
+  int exit_code;
+};
+
+#define Test(suite, name, ...)                                                                                                 \
+  int fake_criterion_##suite##_##name(void);                                                                                   \
+  __attribute__((__section__("fake_criterion_tests"))) struct fake_criterion_test fake_criterion_##suite##_##name##_##test = { \
+      .test = fake_criterion_##suite##_##name,                                                                                 \
+      ##__VA_ARGS__};                                                                                                          \
+  int fake_criterion_##suite##_##name(void)

--- a/misc/spoofed_criterion/test_runner.c
+++ b/misc/spoofed_criterion/test_runner.c
@@ -16,7 +16,7 @@ int main() {
     pid_t pid = fork();
     bool in_child = pid == 0;
     if (in_child) {
-      (*test_info->test)(); // TODO: test return values are ignored, so tests should return void
+      (*test_info->test)();
       return 0;
     }
     // otherwise, in parent

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ add_subdirectory(recursion)
 add_subdirectory(ro_sharing)
 # We don't actually compile the `omit_wrappers` test, but it is picked up by LIT.
 add_subdirectory(shared_data)
+add_subdirectory(should_segfault)
 add_subdirectory(trusted_direct)
 add_subdirectory(untrusted_indirect)
 add_subdirectory(two_keys_minimal)
@@ -83,8 +84,6 @@ if (NOT LIBIA2_AARCH64)
     add_subdirectory(sighandler)
     # rewriter issue on ARM, likely caused by include dirs and spoofed criterion headers
     add_subdirectory(structs)
-    # uses criterion API which we don't spoof yet
-    add_subdirectory(should_segfault)
     # not sure why this is failing
     add_subdirectory(mmap_loop)
     # we don't support call gates for indirect transitions yet


### PR DESCRIPTION
This does not handle forking correctly so we need to combine it with #343