### PR TITLE
libia2: Allow defining compartment-aware signal handlers on ARM and re-enable test

### DIFF
--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -73,6 +73,7 @@ instead of `fn`. */
 
 /* clang-format can't handle inline asm in macros */
 /* clang-format off */
+#if LIBIA2_X86_64
 #define _IA2_DEFINE_SIGNAL_HANDLER(function, pkey)    \
     __asm__(".global ia2_sighandler_" #function "\n"  \
             "ia2_sighandler_" #function ":\n"         \
@@ -87,6 +88,13 @@ instead of `fn`. */
             "movq %r11, %rdx\n"                       \
             "movq %r10, %rcx\n"                       \
             "jmp " #function "\n")
+#elif LIBIA2_AARCH64
+#define _IA2_DEFINE_SIGNAL_HANDLER(function, tag)    \
+    __asm__(".global ia2_sighandler_" #function "\n" \
+            "ia2_sighandler_" #function ":\n"        \
+            "movz_shifted_tag_x18 " #tag "\n"        \
+            "b " #function "\n")
+#endif
 /* clang-format on */
 
 /// Protect pages in the given shared object

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ add_subdirectory(two_keys_minimal)
 add_subdirectory(two_shared_ranges)
 add_subdirectory(global_fn_ptr)
 add_subdirectory(rewrite_macros)
+add_subdirectory(sighandler)
 # The following tests are not supported on ARM64 yet
 if (NOT LIBIA2_AARCH64)
     # not supported on ARM because they allocate
@@ -80,8 +81,6 @@ if (NOT LIBIA2_AARCH64)
     add_subdirectory(tls_protected)
     # no permissive mode on ARM
     add_subdirectory(permissive_mode)
-    # still need to port code for defining sighandlers
-    add_subdirectory(sighandler)
     # rewriter issue on ARM, likely caused by include dirs and spoofed criterion headers
     add_subdirectory(structs)
     # not sure why this is failing


### PR DESCRIPTION
The sighandler test now builds and runs. It fails at a `CHECK_VIOLATION` (as expected) because MTE is not enabled. I don't think it makes much sense to enable MTE before adding in real call gates (we currently just jump to the target function) so this and the tests in the other PRs should get enabled after #333 lands.