### PR TITLE
partition-alloc: fix warnings in CI

### DIFF
--- a/external/chromium/src/base/allocator/partition_allocator/partition_alloc_base/compiler_specific.h
+++ b/external/chromium/src/base/allocator/partition_allocator/partition_alloc_base/compiler_specific.h
@@ -25,7 +25,11 @@
 // Use like:
 //   NOINLINE void DoStuff() { ... }
 #if defined(__clang__) && PA_HAS_ATTRIBUTE(noinline)
+#if __clang_major__ > 14
 #define PA_NOINLINE [[clang::noinline]]
+#else
+#define PA_NOINLINE
+#endif
 #elif defined(COMPILER_GCC) && PA_HAS_ATTRIBUTE(noinline)
 #define PA_NOINLINE __attribute__((noinline))
 #elif defined(COMPILER_MSVC)


### PR DESCRIPTION
This makes it easier to peruse our CI output.