### PR TITLE
ci: cache built QEMU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,15 @@ jobs:
         with:
           repository: immunant/qemu
           path: ${{ github.workspace }}/qemu
+      - name: Cache built QEMU
+        id: cache-qemu
+        uses: actions/cache@v4
+        with:
+          path: |
+            qemu/build
+          key: ${{ runner.os }}-qemu
       - name: Build QEMU
+        if: steps.cache-qemu.outputs.cache-hit != 'true'
         working-directory: ${{ github.workspace }}/qemu
         run: ./build.sh
       - name: Test ARM build


### PR DESCRIPTION
this only saves us about a minute of CI time, but I'd rather debug our first CI caching against a 1-minute QEMU build than Clang's interminable build