### PR TITLE
ci: cache apt packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,17 +70,21 @@ jobs:
   aarch64-wip-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Install deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-                gcc-aarch64-linux-gnu \
-                g++-aarch64-linux-gnu \
-                clang-15 pkg-config \
-                cmake ninja-build \
-                llvm-15-dev libclang-15-dev \
-                zlib1g-dev \
-                libcapstone-dev
+      - name: Install dep packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: |
+            gcc-aarch64-linux-gnu
+            g++-aarch64-linux-gnu
+            clang-15
+            pkg-config
+            cmake
+            ninja-build
+            llvm-15-dev
+            libclang-15-dev
+            zlib1g-dev
+            libcapstone-dev
+          version: 1.0 # version of cache to load
       - name: Check out code
         uses: actions/checkout@v4
       - name: Check out QEMU


### PR DESCRIPTION
rav1d does this and it seems like a good idea; maybe it'll shave a few more seconds off of CI