### PR TITLE
ci: build+cache Clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,15 @@ jobs:
       - name: Build Clang
         if: steps.cache-clang.outputs.cache-hit != 'true'
         working-directory: ${{ github.workspace }}/llvm-project
-        run: ./build.sh
+        run: |
+          # first free up space used by unnecessary host tool cache to make room to build clang
+          df -h /
+          cd /opt
+          find . -maxdepth 1 -mindepth 1 '!' -path ./containerd '!' -path ./actionarchivecache \
+          '!' -path ./runner '!' -path ./runner-cache -exec rm -rf '{}' ';'
+          df -h /
+          cd -
+          ./build.sh
       - name: Test ARM build
         run: |
           LLVM_DIR=`llvm-config-15 --cmakedir`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,18 +87,18 @@ jobs:
           version: 1.0 # version of cache to load
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Check out QEMU
-        uses: actions/checkout@v4
-        with:
-          repository: immunant/qemu
-          path: ${{ github.workspace }}/qemu
       - name: Cache built QEMU
         id: cache-qemu
         uses: actions/cache@v4
         with:
-          path: |
-            qemu/build
+          path: qemu/build
           key: ${{ runner.os }}-qemu
+      - name: Check out QEMU
+        if: steps.cache-qemu.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: immunant/qemu
+          path: ${{ github.workspace }}/qemu
       - name: Build QEMU
         if: steps.cache-qemu.outputs.cache-hit != 'true'
         working-directory: ${{ github.workspace }}/qemu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,23 @@ jobs:
         if: steps.cache-qemu.outputs.cache-hit != 'true'
         working-directory: ${{ github.workspace }}/qemu
         run: ./build.sh
+      - name: Cache built Clang
+        id: cache-clang
+        uses: actions/cache@v4
+        with:
+          path: llvm-project/build/bin
+          key: ${{ runner.os }}-clang
+      - name: Check out Clang
+        if: steps.cache-clang.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: immunant/llvm-project
+          ref: am/mte_instrumentation
+          path: ${{ github.workspace }}/llvm-project
+      - name: Build Clang
+        if: steps.cache-clang.outputs.cache-hit != 'true'
+        working-directory: ${{ github.workspace }}/llvm-project
+        run: ./build.sh
       - name: Test ARM build
         run: |
           LLVM_DIR=`llvm-config-15 --cmakedir`


### PR DESCRIPTION
First some `ci.yml` tweaks to QEMU that we'll want for Clang, then the Clang build itself.