### PR TITLE
Flesh out `spoofed_criterion` for AArch64

### DIFF
--- a/misc/spoofed_criterion/include/criterion/criterion.h
+++ b/misc/spoofed_criterion/include/criterion/criterion.h
@@ -3,6 +3,7 @@
 
 struct fake_criterion_test {
   void (*test)(void);
+  void (*init)(void);
   int exit_code;
 };
 

--- a/misc/spoofed_criterion/include/criterion/logging.h
+++ b/misc/spoofed_criterion/include/criterion/logging.h
@@ -1,4 +1,5 @@
 #include <stdio.h>
 #include <criterion/new/assert.h>
 
-#define cr_log_info printf
+#define cr_log_info(f, ...) printf(f "\n", ##__VA_ARGS__)
+#define cr_log_error(f, ...) fprintf(stderr, f "\n", ##__VA_ARGS__)

--- a/misc/spoofed_criterion/include/criterion/new/assert.h
+++ b/misc/spoofed_criterion/include/criterion/new/assert.h
@@ -1,6 +1,10 @@
 #include <assert.h>
 
 #define cr_assert assert
-#define cr_assert_eq(a,b) cr_assert((a) == (b))
-#define cr_assert_lt(a,b) cr_assert((a) < (b))
-#define cr_fatal(s) do {fprintf(stderr, s "\n"); exit(1);} while(0)
+#define cr_assert_eq(a, b) cr_assert((a) == (b))
+#define cr_assert_lt(a, b) cr_assert((a) < (b))
+#define cr_fatal(s)          \
+  do {                       \
+    fprintf(stderr, s "\n"); \
+    exit(1);                 \
+  } while (0)

--- a/misc/spoofed_criterion/include/criterion/new/assert.h
+++ b/misc/spoofed_criterion/include/criterion/new/assert.h
@@ -3,4 +3,4 @@
 #define cr_assert assert
 #define cr_assert_eq(a,b) cr_assert((a) == (b))
 #define cr_assert_lt(a,b) cr_assert((a) < (b))
-#define cr_fatal assert
+#define cr_fatal(s) do {fprintf(stderr, s "\n"); exit(1);} while(0)

--- a/misc/spoofed_criterion/test_runner.c
+++ b/misc/spoofed_criterion/test_runner.c
@@ -16,6 +16,9 @@ int main() {
     pid_t pid = fork();
     bool in_child = pid == 0;
     if (in_child) {
+      if (test_info->init) {
+        (*test_info->init)();
+      }
       (*test_info->test)();
       return 0;
     }

--- a/misc/spoofed_criterion/test_runner.c
+++ b/misc/spoofed_criterion/test_runner.c
@@ -27,11 +27,10 @@ int main() {
       return 2;
     }
     int exit_status = WEXITSTATUS(stat);
-    if (exit_status == test_info->exit_code) {
-      return 0;
-    } else {
+    if (exit_status != test_info->exit_code) {
       fprintf(stderr, "forked test child exited with status %d, but %d was expected\n", exit_status, test_info->exit_code);
       return 1;
     }
   }
+  return 0;
 }


### PR DESCRIPTION
Fixes some failing tests, not-building tests, ~and spuriously passing tests~ on AArch64. The tests depend on other work in addition to these fixes before they'll actually pass on AArch64, but this fills in missing testing infrastructure.

EDIT: I've split the `test_fault_handler` changes into a separate PR (#378) because they uncover brokenness that we need to fix separately while most of this infrastructure is strictly additive and needed to run more AArch64 tests.