### PR TITLE
rewriter: skip copying files if the output file is the same file to avoid truncating them

### DIFF
--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -994,9 +994,11 @@ std::set<llvm::SmallString<256>> copy_files(std::vector<std::unique_ptr<clang::A
           assert(mkdir_rc == 0);
         }
 
-        std::ifstream src(input_file.str().str(), std::ios::binary);
-        std::ofstream dst(output_file.str().str(), std::ios::binary);
-        dst << src.rdbuf();
+        if (llvm::sys::fs::equivalent(input_file, output_file)) {
+          llvm::errs() << "skipping copying file to itself: " << input_file << "\n";
+          continue;
+        }
+        llvm::sys::fs::copy_file(input_file, output_file);
       }
     }
   }


### PR DESCRIPTION
* Fixes #367.

This fixes #367 in that the files are no longer truncated, but a clearer error message is printed instead.  This doesn't fix the root cause of #367, which probably has more to do with #368 and the `compile_commands.json` not getting read correctly, but it does fix the alarming behavior of deleting the contents of a ton of files.