### PR TITLE
test_fault_handler: exit nonzero if expected segfault missing

### DIFF
--- a/runtime/libia2/include/test_fault_handler.h
+++ b/runtime/libia2/include/test_fault_handler.h
@@ -29,7 +29,7 @@
     asm volatile("" : : : "memory");                                           \
     volatile typeof(expr) _tmp = expr;                                         \
     printf("CHECK_VIOLATION: did not seg fault as expected\n");                \
-    _exit(0);                                                                  \
+    _exit(1);                                                                  \
     _tmp;                                                                      \
   })
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,7 +40,6 @@ endif()
 set_target_properties(check PROPERTIES FOLDER "tests")
 
 add_subdirectory(abi)
-add_subdirectory(destructors)
 # add_subdirectory(ffmpeg)
 add_subdirectory(header_includes)
 # add_subdirectory(libusb)
@@ -52,24 +51,26 @@ add_subdirectory(minimal_no_criterion)
 # TODO: support C++ namespaces
 #add_subdirectory(namespaces)
 add_subdirectory(recursion)
-add_subdirectory(ro_sharing)
 # We don't actually compile the `omit_wrappers` test, but it is picked up by LIT.
 add_subdirectory(shared_data)
-add_subdirectory(should_segfault)
-add_subdirectory(trusted_direct)
-add_subdirectory(untrusted_indirect)
-add_subdirectory(two_keys_minimal)
-add_subdirectory(two_shared_ranges)
 add_subdirectory(global_fn_ptr)
 add_subdirectory(rewrite_macros)
 add_subdirectory(sighandler)
 
-# TODO(#413): Fix these tests
-# add_subdirectory(heap_two_keys)
-# add_subdirectory(three_keys_minimal)
-
 # The following tests are not supported on ARM64 yet
 if (NOT LIBIA2_AARCH64)
+    # Expected to have compartment violations, but we aren't enforcing yet:
+    add_subdirectory(destructors)
+    add_subdirectory(ro_sharing)
+    add_subdirectory(should_segfault)
+    add_subdirectory(trusted_direct)
+    add_subdirectory(untrusted_indirect)
+    add_subdirectory(two_keys_minimal)
+    add_subdirectory(two_shared_ranges)
+    # TODO(#413): Fix these tests
+    # add_subdirectory(heap_two_keys)
+    # add_subdirectory(three_keys_minimal)
+
     # strange bug with indirect calls
     add_subdirectory(read_config)
     # ARM does not support threads yet

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,8 +63,11 @@ add_subdirectory(two_shared_ranges)
 add_subdirectory(global_fn_ptr)
 add_subdirectory(rewrite_macros)
 add_subdirectory(sighandler)
-add_subdirectory(heap_two_keys)
-add_subdirectory(three_keys_minimal)
+
+# TODO(#413): Fix these tests
+# add_subdirectory(heap_two_keys)
+# add_subdirectory(three_keys_minimal)
+
 # The following tests are not supported on ARM64 yet
 if (NOT LIBIA2_AARCH64)
     # strange bug with indirect calls

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -22,7 +22,8 @@ config.suffixes = ['.c']
 config.excludes = [entry.name for entry in os.scandir(os.path.dirname(os.path.abspath(__file__))) if entry.name not in [
     'global_fn_ptr',
     'header_includes',
-    'heap_two_keys',
+# TODO(#413)
+#    'heap_two_keys',
     'macro_attr',
     'minimal',
     'mmap_loop',


### PR DESCRIPTION
We previously tested for the printed message with FileCheck, but now our Criterion-based tests only care about exit codes.

This was hiding test failures on both AArch64 and x86_64.

Based on bisecting it appears the `three_keys_minimal` test has never worked but its failures have always been masked by the `test_fault_handler` bug that this fixes. I'll look into things more tomorrow.