### PR TITLE
ci: try freeing space up by deleting LLVM libs after building Clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,8 @@ jobs:
           df -h /
           cd -
           ./build.sh
+          # free up space used by libs; our desired clang binary statically links them
+          rm -rf build/lib/*.a
       - name: Test ARM build
         run: |
           LLVM_DIR=`llvm-config-15 --cmakedir`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,9 @@ jobs:
         id: cache-clang
         uses: actions/cache@v4
         with:
-          path: llvm-project/build/bin
+          path: |
+            llvm-project/build/bin
+            llvm-project/build/lib/clang
           key: ${{ runner.os }}-clang
       - name: Check out Clang
         if: steps.cache-clang.outputs.cache-hit != 'true'


### PR DESCRIPTION
Running out of disk space to create the cache archive may be why our caching is not working.