### PR TITLE
Disable more header defs when IA2_ENABLE=0

### DIFF
--- a/runtime/libia2/include/ia2.h
+++ b/runtime/libia2/include/ia2.h
@@ -142,7 +142,6 @@
 /// the type of `IA2_FN(func)` are ABI-compatible since no extra type-checking is
 /// done.
 #define IA2_CAST(func, ty) (ty) { (void *)IA2_FN_ADDR(func) }
-#endif // !IA2_ENABLE
 
 /// Convert a compartment pkey to a PKRU register value
 #define PKRU(pkey) (~((3U << (2 * pkey)) | 3))
@@ -160,3 +159,5 @@ size_t ia2_get_pkey();
 #ifdef __cplusplus
 }
 #endif
+
+#endif // !IA2_ENABLE

--- a/runtime/libia2/include/ia2_compartment_init.inc
+++ b/runtime/libia2/include/ia2_compartment_init.inc
@@ -10,7 +10,10 @@
 #include <string.h>
 #include <sys/mman.h>
 
+#if IA2_ENABLE
 #include <ia2_internal.h>
+#endif // IA2_ENABLE
+
 #include <ia2.h>
 
 #ifndef IA2_COMPARTMENT_LIBRARIES


### PR DESCRIPTION
This fixes issues I ran into when trying to run the source rewriter on zlib (https://github.com/immunant/zlib). `ia2.h` was not importing `ia2_internal.h` when `IA2_ENABLE=0`, but `ia2_compartment_init.inc` was importing it unconditionally. It seems like we don't want `ia2_internah.h` imported when running the source rewriter, and the rewriter specifically sets `-DIA2_ENABLE=0` to make sure that IA2 internals don't get included in the source files.

I then also hit a similar issue with some of the symbols defined in `ia2.h`, so I moved those inside the `#if IA2_ENABLE` block so that they won't be defined when the source rewriter runs.