### PR TITLE
runtime: use builtin `__{x86_64, aarch64}__` instead of `LIBIA2_{X86_64,AARCH64}`

### DIFF
--- a/cmake/ia2.cmake
+++ b/cmake/ia2.cmake
@@ -1,4 +1,4 @@
-if(LIBIA2_AARCH64)
+if (LIBIA2_AARCH64)
     set(UBSAN_FLAG "")
 else()
     set(UBSAN_FLAG "-fsanitize=undefined")

--- a/runtime/libia2/CMakeLists.txt
+++ b/runtime/libia2/CMakeLists.txt
@@ -5,10 +5,8 @@ add_library(libia2 ia2.c init.c threads.c main.c exit.c)
 target_compile_options(libia2 PRIVATE "-fPIC")
 
 if (LIBIA2_AARCH64)
-    target_compile_definitions(libia2 PUBLIC LIBIA2_AARCH64=1)
     target_compile_options(libia2 PUBLIC "-march=armv8.5-a+memtag" "-ffixed-x18")
 else()
-    target_compile_definitions(libia2 PUBLIC LIBIA2_X86_64=1)
 endif()
 
 if(LIBIA2_DEBUG)

--- a/runtime/libia2/exit.c
+++ b/runtime/libia2/exit.c
@@ -17,9 +17,9 @@ void _exit(int status);
 __asm__(
     ".global _exit\n"
     "_exit:\n"
-#if LIBIA2_X86_64
+#if __x86_64__
     "jmp exit\n"
-#elif LIBIA2_AARCH64
+#elif __aarch64__
     "b exit\n"
 #endif
 );
@@ -29,7 +29,7 @@ void exit(int status);
 __asm__(
     ".global exit\n"
     "exit:\n"
-#if LIBIA2_X86_64
+#if __x86_64__
     "pushq %rbp\n"
     "movq %rsp, %rbp\n"
     // Load the stack pointer for the shared compartment's stack.
@@ -44,7 +44,7 @@ __asm__(
     "subq $8, %rsp\n"
     // Call the real exit function.
     "call call_libc_exit\n"
-#elif LIBIA2_AARCH64
+#elif __aarch64__
     "stp x29, x30, [sp, #-16]!\n"
     // Load the stack pointer for the shared compartment's stack.
     "mrs x9, tpidr_el0\n"

--- a/runtime/libia2/exit.c
+++ b/runtime/libia2/exit.c
@@ -17,9 +17,9 @@ void _exit(int status);
 __asm__(
     ".global _exit\n"
     "_exit:\n"
-#if __x86_64__
+#if defined(__x86_64__)
     "jmp exit\n"
-#elif __aarch64__
+#elif defined(__aarch64__)
     "b exit\n"
 #endif
 );
@@ -29,7 +29,7 @@ void exit(int status);
 __asm__(
     ".global exit\n"
     "exit:\n"
-#if __x86_64__
+#if defined(__x86_64__)
     "pushq %rbp\n"
     "movq %rsp, %rbp\n"
     // Load the stack pointer for the shared compartment's stack.
@@ -44,7 +44,7 @@ __asm__(
     "subq $8, %rsp\n"
     // Call the real exit function.
     "call call_libc_exit\n"
-#elif __aarch64__
+#elif defined(__aarch64__)
     "stp x29, x30, [sp, #-16]!\n"
     // Load the stack pointer for the shared compartment's stack.
     "mrs x9, tpidr_el0\n"

--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -8,7 +8,7 @@
 #include "ia2_internal.h"
 #include "ia2.h"
 
-#if LIBIA2_X86_64
+#if __x86_64__
 
 __attribute__((__used__)) uint32_t ia2_get_pkru() {
   uint32_t pkru = 0;
@@ -81,7 +81,7 @@ size_t ia2_get_pkey() {
 }
 size_t ia2_get_tag(void) __attribute__((alias("ia2_get_pkey")));
 
-#elif LIBIA2_AARCH64
+#elif __aarch64__
 
 size_t ia2_get_x18(void) {
     size_t x18;

--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -8,7 +8,7 @@
 #include "ia2_internal.h"
 #include "ia2.h"
 
-#if __x86_64__
+#if defined(__x86_64__)
 
 __attribute__((__used__)) uint32_t ia2_get_pkru() {
   uint32_t pkru = 0;
@@ -81,7 +81,7 @@ size_t ia2_get_pkey() {
 }
 size_t ia2_get_tag(void) __attribute__((alias("ia2_get_pkey")));
 
-#elif __aarch64__
+#elif defined(__aarch64__)
 
 size_t ia2_get_x18(void) {
     size_t x18;

--- a/runtime/libia2/include/ia2_compartment_init.inc
+++ b/runtime/libia2/include/ia2_compartment_init.inc
@@ -66,7 +66,7 @@ __attribute__((constructor)) static void COMPARTMENT_IDENT(init_pkey)() {
       .shared_sections = shared_sections,
   };
 
-#if __x86_64__
+#if defined(__x86_64__)
   __asm__ volatile(
       /* Set PKRU to the compartment's value */
       "xorl %%ecx, %%ecx\n"
@@ -76,13 +76,13 @@ __attribute__((constructor)) static void COMPARTMENT_IDENT(init_pkey)() {
       :
       :
       : "rax", "rcx", "rdx");
-#elif __aarch64__
+#elif defined(__aarch64__)
   __asm__ volatile("movz_shifted_tag_x18 " XSTR(IA2_COMPARTMENT) "\n");
 #endif
 
   dl_iterate_phdr(protect_pages, &args);
 
-#if __x86_64__
+#if defined(__x86_64__)
   __asm__ volatile(
       /* Set PKRU to fully untrusted (no access) */
       "xorl %%ecx, %%ecx\n"
@@ -92,7 +92,7 @@ __attribute__((constructor)) static void COMPARTMENT_IDENT(init_pkey)() {
       :
       :
       : "rax", "rcx", "rdx");
-#elif __aarch64__
+#elif defined(__aarch64__)
   __asm__ volatile("movz_shifted_tag_x18 0\n");
 #endif
 

--- a/runtime/libia2/include/ia2_compartment_init.inc
+++ b/runtime/libia2/include/ia2_compartment_init.inc
@@ -66,7 +66,7 @@ __attribute__((constructor)) static void COMPARTMENT_IDENT(init_pkey)() {
       .shared_sections = shared_sections,
   };
 
-#if LIBIA2_X86_64
+#if __x86_64__
   __asm__ volatile(
       /* Set PKRU to the compartment's value */
       "xorl %%ecx, %%ecx\n"
@@ -76,13 +76,13 @@ __attribute__((constructor)) static void COMPARTMENT_IDENT(init_pkey)() {
       :
       :
       : "rax", "rcx", "rdx");
-#elif LIBIA2_AARCH64
+#elif __aarch64__
   __asm__ volatile("movz_shifted_tag_x18 " XSTR(IA2_COMPARTMENT) "\n");
 #endif
 
   dl_iterate_phdr(protect_pages, &args);
 
-#if LIBIA2_X86_64
+#if __x86_64__
   __asm__ volatile(
       /* Set PKRU to fully untrusted (no access) */
       "xorl %%ecx, %%ecx\n"
@@ -92,7 +92,7 @@ __attribute__((constructor)) static void COMPARTMENT_IDENT(init_pkey)() {
       :
       :
       : "rax", "rcx", "rdx");
-#elif LIBIA2_AARCH64
+#elif __aarch64__
   __asm__ volatile("movz_shifted_tag_x18 0\n");
 #endif
 

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -73,7 +73,7 @@ instead of `fn`. */
 
 /* clang-format can't handle inline asm in macros */
 /* clang-format off */
-#if __x86_64__
+#if defined(__x86_64__)
 #define _IA2_DEFINE_SIGNAL_HANDLER(function, pkey)    \
     __asm__(".global ia2_sighandler_" #function "\n"  \
             "ia2_sighandler_" #function ":\n"         \
@@ -88,7 +88,7 @@ instead of `fn`. */
             "movq %r11, %rdx\n"                       \
             "movq %r10, %rcx\n"                       \
             "jmp " #function "\n")
-#elif __aarch64__
+#elif defined(__aarch64__)
 #define _IA2_DEFINE_SIGNAL_HANDLER(function, tag)    \
     __asm__(".global ia2_sighandler_" #function "\n" \
             "ia2_sighandler_" #function ":\n"        \
@@ -169,7 +169,7 @@ asm(".macro movz_shifted_tag_x18 tag\n"
 
 #define IA2_ROUND_DOWN(x, y) ((x) & ~((y)-1))
 
-#if __x86_64__
+#if defined(__x86_64__)
 /* clang-format can't handle inline asm in macros */
 /* clang-format off */
 /* Allocate and protect the stack for this thread's i'th compartment. */
@@ -228,7 +228,7 @@ asm(".macro movz_shifted_tag_x18 tag\n"
         : "rdi", "rcx", "rdx", "r10", "r11", "r12");                           \
   }
 /* clang-format on */
-#elif __aarch64__
+#elif defined(__aarch64__)
 #warning "ALLOCATE_COMPARTMENT_STACK_AND_SETUP_TLS does not do stackptr reinit checking"
 #define ALLOCATE_COMPARTMENT_STACK_AND_SETUP_TLS(i)                            \
   {                                                                            \
@@ -268,7 +268,7 @@ asm(".macro movz_shifted_tag_x18 tag\n"
   }
 #endif
 
-#if __x86_64__
+#if defined(__x86_64__)
 #define return_stackptr_if_compartment(compartment)                            \
   if (pkru == PKRU(compartment)) {                                             \
     register void *out asm("rax");                                             \
@@ -280,7 +280,7 @@ asm(".macro movz_shifted_tag_x18 tag\n"
         :);                                                                    \
     return out;                                                                \
   }
-#elif __aarch64__
+#elif defined(__aarch64__)
 #warning "libia2 does not implement return_stackptr_if_compartment yet"
 #define return_stackptr_if_compartment(compartment)
 #endif
@@ -297,9 +297,9 @@ works as a reasonable signpost no-op. */
   void ia2_setup_destructors_##n(void);                                        \
   ia2_setup_destructors_##n();
 
-#if __aarch64__
+#if defined(__aarch64__)
 int ia2_mprotect_with_tag(void *addr, size_t len, int prot, int tag);
-#elif __x86_64__
+#elif defined(__x86_64__)
 /* We can't use an alias attribute since this points to a function outside the translation unit */
 #define ia2_mprotect_with_tag pkey_mprotect
 #endif

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -73,7 +73,7 @@ instead of `fn`. */
 
 /* clang-format can't handle inline asm in macros */
 /* clang-format off */
-#if LIBIA2_X86_64
+#if __x86_64__
 #define _IA2_DEFINE_SIGNAL_HANDLER(function, pkey)    \
     __asm__(".global ia2_sighandler_" #function "\n"  \
             "ia2_sighandler_" #function ":\n"         \
@@ -88,7 +88,7 @@ instead of `fn`. */
             "movq %r11, %rdx\n"                       \
             "movq %r10, %rcx\n"                       \
             "jmp " #function "\n")
-#elif LIBIA2_AARCH64
+#elif __aarch64__
 #define _IA2_DEFINE_SIGNAL_HANDLER(function, tag)    \
     __asm__(".global ia2_sighandler_" #function "\n" \
             "ia2_sighandler_" #function ":\n"        \
@@ -169,7 +169,7 @@ asm(".macro movz_shifted_tag_x18 tag\n"
 
 #define IA2_ROUND_DOWN(x, y) ((x) & ~((y)-1))
 
-#if LIBIA2_X86_64
+#if __x86_64__
 /* clang-format can't handle inline asm in macros */
 /* clang-format off */
 /* Allocate and protect the stack for this thread's i'th compartment. */
@@ -228,7 +228,7 @@ asm(".macro movz_shifted_tag_x18 tag\n"
         : "rdi", "rcx", "rdx", "r10", "r11", "r12");                           \
   }
 /* clang-format on */
-#elif LIBIA2_AARCH64
+#elif __aarch64__
 #warning "ALLOCATE_COMPARTMENT_STACK_AND_SETUP_TLS does not do stackptr reinit checking"
 #define ALLOCATE_COMPARTMENT_STACK_AND_SETUP_TLS(i)                            \
   {                                                                            \
@@ -268,7 +268,7 @@ asm(".macro movz_shifted_tag_x18 tag\n"
   }
 #endif
 
-#if LIBIA2_X86_64
+#if __x86_64__
 #define return_stackptr_if_compartment(compartment)                            \
   if (pkru == PKRU(compartment)) {                                             \
     register void *out asm("rax");                                             \
@@ -280,7 +280,7 @@ asm(".macro movz_shifted_tag_x18 tag\n"
         :);                                                                    \
     return out;                                                                \
   }
-#elif LIBIA2_AARCH64
+#elif __aarch64__
 #warning "libia2 does not implement return_stackptr_if_compartment yet"
 #define return_stackptr_if_compartment(compartment)
 #endif
@@ -297,9 +297,9 @@ works as a reasonable signpost no-op. */
   void ia2_setup_destructors_##n(void);                                        \
   ia2_setup_destructors_##n();
 
-#if LIBIA2_AARCH64
+#if __aarch64__
 int ia2_mprotect_with_tag(void *addr, size_t len, int prot, int tag);
-#elif LIBIA2_X86_64
+#elif __x86_64__
 /* We can't use an alias attribute since this points to a function outside the translation unit */
 #define ia2_mprotect_with_tag pkey_mprotect
 #endif

--- a/runtime/libia2/include/scrub_registers.h
+++ b/runtime/libia2/include/scrub_registers.h
@@ -1,4 +1,4 @@
-#if __x86_64__
+#if defined(__x86_64__)
 // This file defines the feature specific scrub routines.
 //
 // This is implemented via the fairly standard fallthrough approach, and
@@ -71,6 +71,6 @@ asm(".text\n"
     "jmp __libia2_scrub_registers_sse\n"
     "int3\n"
     ".previous\n");
-#elif __aarch64__
+#elif defined(__aarch64__)
 #warning "__libia2_scrub_registers is not implemented for aarch64 yet"
 #endif

--- a/runtime/libia2/include/scrub_registers.h
+++ b/runtime/libia2/include/scrub_registers.h
@@ -1,4 +1,4 @@
-#if LIBIA2_X86_64
+#if __x86_64__
 // This file defines the feature specific scrub routines.
 //
 // This is implemented via the fairly standard fallthrough approach, and
@@ -71,6 +71,6 @@ asm(".text\n"
     "jmp __libia2_scrub_registers_sse\n"
     "int3\n"
     ".previous\n");
-#elif LIBIA2_AARCH64
+#elif __aarch64__
 #warning "__libia2_scrub_registers is not implemented for aarch64 yet"
 #endif

--- a/runtime/libia2/include/test_fault_handler.h
+++ b/runtime/libia2/include/test_fault_handler.h
@@ -51,7 +51,7 @@ char *sighandler_sp __attribute__((section("ia2_shared_data"))) =
 // This function must be declared naked because it's not necessarily safe for it
 // to write to the stack in its prelude (the stack isn't written to when the
 // function itself is called because it's only invoked as a signal handler).
-#if LIBIA2_X86_64
+#if __x86_64__
 __attribute__((naked)) void handle_segfault(int sig) {
   // This asm must preserve %rdi which contains the argument since
   // print_mpk_message reads it
@@ -69,7 +69,7 @@ __attribute__((naked)) void handle_segfault(int sig) {
       "movq (%rsp), %rsp\n"
       "callq print_mpk_message");
 }
-#elif LIBIA2_AARCH64
+#elif __aarch64__
 #warning "Review test_fault_handler implementation after enabling x18 switching"
 void print_mpk_message(int sig);
 void handle_segfault(int sig) {

--- a/runtime/libia2/include/test_fault_handler.h
+++ b/runtime/libia2/include/test_fault_handler.h
@@ -51,7 +51,7 @@ char *sighandler_sp __attribute__((section("ia2_shared_data"))) =
 // This function must be declared naked because it's not necessarily safe for it
 // to write to the stack in its prelude (the stack isn't written to when the
 // function itself is called because it's only invoked as a signal handler).
-#if __x86_64__
+#if defined(__x86_64__)
 __attribute__((naked)) void handle_segfault(int sig) {
   // This asm must preserve %rdi which contains the argument since
   // print_mpk_message reads it
@@ -69,7 +69,7 @@ __attribute__((naked)) void handle_segfault(int sig) {
       "movq (%rsp), %rsp\n"
       "callq print_mpk_message");
 }
-#elif __aarch64__
+#elif defined(__aarch64__)
 #warning "Review test_fault_handler implementation after enabling x18 switching"
 void print_mpk_message(int sig);
 void handle_segfault(int sig) {

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -45,7 +45,7 @@ void verify_tls_padding(void) {
 
 /* Ensure that all required pkeys are allocated or no-op on aarch64. */
 void ensure_pkeys_allocated(int *n_to_alloc) {
-#if __x86_64__
+#if defined(__x86_64__)
   if (*n_to_alloc != 0) {
     for (int pkey = 1; pkey <= *n_to_alloc; pkey++) {
       int allocated = pkey_alloc(0, 0);

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -45,7 +45,7 @@ void verify_tls_padding(void) {
 
 /* Ensure that all required pkeys are allocated or no-op on aarch64. */
 void ensure_pkeys_allocated(int *n_to_alloc) {
-#if LIBIA2_X86_64
+#if __x86_64__
   if (*n_to_alloc != 0) {
     for (int pkey = 1; pkey <= *n_to_alloc; pkey++) {
       int allocated = pkey_alloc(0, 0);

--- a/runtime/libia2/main.c
+++ b/runtime/libia2/main.c
@@ -11,7 +11,7 @@ int __wrap_main(int argc, char **argv);
 __asm__(
     ".global __wrap_main\n"
     "__wrap_main:\n"
-#if __x86_64__
+#if defined(__x86_64__)
     "pushq %rbp\n"
     "movq %rsp, %rbp\n"
     // Save the old stack pointer in main_sp.
@@ -41,7 +41,7 @@ __asm__(
     "mov %r10,%rax\n"
     "popq %rbp\n"
     "ret\n"
-#elif __aarch64__
+#elif defined(__aarch64__)
     // prologue
     "stp x29, x30, [sp, #-16]!\n"
     "mov x29, sp\n"

--- a/runtime/libia2/main.c
+++ b/runtime/libia2/main.c
@@ -11,7 +11,7 @@ int __wrap_main(int argc, char **argv);
 __asm__(
     ".global __wrap_main\n"
     "__wrap_main:\n"
-#if LIBIA2_X86_64
+#if __x86_64__
     "pushq %rbp\n"
     "movq %rsp, %rbp\n"
     // Save the old stack pointer in main_sp.
@@ -41,7 +41,7 @@ __asm__(
     "mov %r10,%rax\n"
     "popq %rbp\n"
     "ret\n"
-#elif LIBIA2_AARCH64
+#elif __aarch64__
     // prologue
     "stp x29, x30, [sp, #-16]!\n"
     "mov x29, sp\n"

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -29,7 +29,7 @@ void *ia2_thread_begin(void *arg) {
    * data. */
   /*  sigaltstack(&alt_stack, NULL); */
 
-#if LIBIA2_X86_64
+#if __x86_64__
   /* Determine the current compartment so know which stack to use. */
   uint32_t pkru = 0;
   __asm__ volatile(
@@ -69,7 +69,7 @@ void *ia2_thread_begin(void *arg) {
       : "rdi");
   /* clang-format on */
   return result;
-#elif LIBIA2_AARCH64
+#elif __aarch64__
 #warning "libia2 does not implement ia2_thread_begin yet"
   __builtin_trap();
 #endif

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -29,7 +29,7 @@ void *ia2_thread_begin(void *arg) {
    * data. */
   /*  sigaltstack(&alt_stack, NULL); */
 
-#if __x86_64__
+#if defined(__x86_64__)
   /* Determine the current compartment so know which stack to use. */
   uint32_t pkru = 0;
   __asm__ volatile(
@@ -69,7 +69,7 @@ void *ia2_thread_begin(void *arg) {
       : "rdi");
   /* clang-format on */
   return result;
-#elif __aarch64__
+#elif defined(__aarch64__)
 #warning "libia2 does not implement ia2_thread_begin yet"
   __builtin_trap();
 #endif

--- a/runtime/partition-alloc/CMakeLists.txt
+++ b/runtime/partition-alloc/CMakeLists.txt
@@ -90,7 +90,7 @@ target_include_directories(partition-alloc_unpadded BEFORE
     ${EXTERNAL_DIR}/chromium/src)
 
 # Propagage ARM64 define
-if(LIBIA2_AARCH64)
+if (LIBIA2_AARCH64)
     target_compile_options(partition-alloc_unpadded
     PRIVATE
         "-DARCH_CPU_ARM64"


### PR DESCRIPTION
After seeing @randomPoison run into this same issue that I ran into as well, and since @fw-immunant said we probably don't need our own `LIBIA2_{X86_64,AARCH64}` macros and can use the builtin `__{x86_64,aarch64}__` macros, I thought it'd be simpler to fix this here in ia2 vs. handle defining them in the correct places in `dav1d`'s `meson.build`s.

`dav1d` also uses `-Wundef`, so `#if`/`#elif`s directly on `__{x86_64,aarch64}__` warn about being undefined on the other architecture, so I changed them all to `#if`/`#elif` `define(...)`.  I could use `#ifdef ...` and then `#elif defined(...)`, but for consistency between the two, I just stuck to using `defined` in both places.