### PR TITLE
ci: run CI on all PRs, not just PRs to `main`, so we can stack PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
       - main
       - github-actions*
   pull_request:
-    branches:
-      - main
 
 jobs:
   test-on-pkru-enabled-host:


### PR DESCRIPTION
I noticed CI wasn't running on stacked PRs, so this runs CI on all PRs so that stacked PRs work.  I'm not sure if there was a reason for only running CI on PRs into `main`, but I'd prefer if we changed it.