### PR TITLE
rewriter: warn on multiple compile commands per src and truncate to first one (reopened #398)

### DIFF
--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -1029,7 +1029,14 @@ std::optional<Pkey> pkey_from_commands(std::function<std::optional<std::vector<C
     return {};
   }
 
+  if (comp_cmds.size() != 1) {
+    llvm::errs() << "warning: multiple compile commands for a single source file" << '\n'
+                 << "         truncating to first compile command" << '\n'
+                 << "         may not work properly" << '\n';
+    comp_cmds.resize(1);
+  }
   assert(comp_cmds.size() == 1);
+  
   auto cc_cmd = *comp_cmd_with_pkey;
 
   auto pkey_define = std::find_if(cc_cmd.CommandLine.begin(),


### PR DESCRIPTION
* Fixes #393.

We discussed this separately, and besides just cases like `dav1d` where this is done for templating reasons, this is also done in other places, I think for static and dynamic libraries maybe?  Given that, it's simpler to just use the first compile command and emit a warning about it.  We already emit warnings on other things that might be an issue (e.x. unsupported variadic function pointers), so I think this is okay.

I accidentally merged #398 into a non-`main` branch.  This PR is into `main` directly, and I'll merge it right away since #398 was already approved.