### PR TITLE
Fix stack tagging on AArch64

### DIFF
--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -281,11 +281,12 @@ asm(".macro movz_shifted_tag_x18 tag\n"
         "mov x10, sp\n"                                                        \
         /* switch to old stack */                                              \
         "mov sp, x9\n"                                                         \
-        /* calculate location to save pointer to newly allocated stack */      \
+        /* calculate location to save addr of newly allocated stack */         \
         "mrs x12, tpidr_el0\n"                                                 \
         "adrp x11, :gottprel:ia2_stackptr_" #i "\n"                            \
         "ldr x11, [x11, #:gottprel_lo12:ia2_stackptr_" #i "]\n"                \
         "add x11, x11, x12\n"                                                  \
+        "orr x11, x11, x18\n"                                                  \
         /* write newly allocated stack to ia2_stackptr_i */                    \
         "str x10, [x11]\n"                                                     \
         :                                                                      \

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -28,6 +28,10 @@ char *allocate_stack(int i) {
       exit(-1);
     }
   }
+#ifdef __aarch64__
+  /* Tag the allocated stack pointer so it is accessed with the right pkey */
+  stack = (char *)((uint64_t)stack | (uint64_t)i << 56);
+#endif
   /* Each stack frame start + 8 is initially 16-byte aligned. */
   return stack + STACK_SIZE - 8;
 }

--- a/runtime/libia2/main.c
+++ b/runtime/libia2/main.c
@@ -67,13 +67,13 @@ __asm__(
     "mov sp, x9\n"
 
     // Set x18 tag to 1
-    "movz x18, #0x0100, LSL #48\n"
+    "movz_shifted_tag_x18 1\n"
 
     // Call the real main function
     "bl __real_main\n"
 
     // Set x18 tag to 0
-    "movz x18, #0x0000, LSL #48\n"
+    "movz_shifted_tag_x18 0\n"
 
     // Restore the old stack pointer
     "adrp x9, main_sp\n"

--- a/runtime/libia2/main.c
+++ b/runtime/libia2/main.c
@@ -49,6 +49,9 @@ __asm__(
     // Save old stack pointer in main_sp
     "adrp x9, main_sp\n"
     "add x9, x9, #:lo12:main_sp\n"
+    // Tag x9 with compartment 1
+    "orr x9, x9, #0x100000000000000\n"
+
     "str x29, [x9]\n"
 
     // Load the new stack pointer
@@ -56,6 +59,10 @@ __asm__(
     "mrs x9, tpidr_el0\n"
     "add x9, x9, #:tprel_hi12:ia2_stackptr_1\n"
     "add x9, x9, #:tprel_lo12_nc:ia2_stackptr_1\n"
+
+    // Tag x9 with compartment 1
+    "orr x9, x9, #0x100000000000000\n"
+
     "ldr x9, [x9]\n"
     "mov sp, x9\n"
 
@@ -71,6 +78,10 @@ __asm__(
     // Restore the old stack pointer
     "adrp x9, main_sp\n"
     "add x9, x9, #:lo12:main_sp\n"
+
+    // Tag x9 with compartment 1
+    "orr x9, x9, #0x100000000000000\n"
+
     "ldr x9, [x9]\n"
     "mov sp, x9\n"
 


### PR DESCRIPTION
~We weren't tagging the entire requested region but only its first page (which also impacted protection of non-stack pages).~ (Fixed separately.)

After allocating and tagging a fresh compartment stack, we returned an untagged pointer to it, which led to MTE violations. I was surprised by this because the violations I observed seemed to come from `sp`-relative accesses, which I thought would not perform MTE checks, but they did anyway--it would be good to write a test program to characterize exactly which instructions do and don't perform MTE checks.

In addition, we need to apply tags for the access to TLS when accessing `ia2_stackptr_N`.