### PR TITLE
Fix propagation of partition-alloc link options

### DIFF
--- a/cmake/ia2.cmake
+++ b/cmake/ia2.cmake
@@ -119,6 +119,7 @@ function(pad_tls_library INPUT OUTPUT)
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/unpadded"
     OUTPUT_NAME "${OUTPUT}"
   )
+  target_link_options(${OUTPUT} INTERFACE $<TARGET_PROPERTY:${INPUT},INTERFACE_LINK_OPTIONS>)
 endfunction()
 
 # Create a fake target that builds the given sources

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,7 +68,7 @@ if (NOT LIBIA2_AARCH64)
     add_subdirectory(two_keys_minimal)
     add_subdirectory(two_shared_ranges)
     # TODO(#413): Fix these tests
-    # add_subdirectory(heap_two_keys)
+    add_subdirectory(heap_two_keys)
     # add_subdirectory(three_keys_minimal)
 
     # strange bug with indirect calls

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -22,8 +22,7 @@ config.suffixes = ['.c']
 config.excludes = [entry.name for entry in os.scandir(os.path.dirname(os.path.abspath(__file__))) if entry.name not in [
     'global_fn_ptr',
     'header_includes',
-# TODO(#413)
-#    'heap_two_keys',
+    'heap_two_keys',
     'macro_attr',
     'minimal',
     'mmap_loop',


### PR DESCRIPTION
The partition-alloc module exported public linker options, but this was not propagated through the padded version of the library. This change propagates PUBLIC LINK_OPTIONS from partition-alloc to its consumers.