### PR TITLE
Label /proc/pid/maps entries in permissive mode logs

### DIFF
--- a/runtime/libia2/include/permissive_mode.h
+++ b/runtime/libia2/include/permissive_mode.h
@@ -465,6 +465,8 @@ __attribute__((constructor)) void permissive_mode_init(void) {
   install_permissive_mode_handler();
 }
 
+void __real_free(void *ptr);
+
 extern uintptr_t ia2_stacks[16];
 extern uintptr_t tls_addr[16][2];
 
@@ -526,7 +528,7 @@ void log_memory_map(void) {
   }
 
 cleanup:
-  // free(line);
+  __real_free(line);
   fclose(log);
   fclose(maps);
 }

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -1,3 +1,4 @@
+#include "ia2.h"
 #include "ia2_internal.h"
 #include <sys/auxv.h>
 #include <sys/prctl.h>
@@ -12,7 +13,8 @@
 extern __thread void *ia2_stackptr_0[PAGE_SIZE / sizeof(void *)]
     __attribute__((aligned(4096)));
 
-char *ia2_stacks[16] = {0};
+char *ia2_stacks[16] IA2_SHARED_DATA = {0};
+
 /* Allocate a fixed-size stack and protect it with the ith pkey. */
 /* Returns the top of the stack, not the base address of the allocation. */
 char *allocate_stack(int i) {

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -13,7 +13,7 @@
 extern __thread void *ia2_stackptr_0[PAGE_SIZE / sizeof(void *)]
     __attribute__((aligned(4096)));
 
-char *ia2_stacks[16] IA2_SHARED_DATA = {0};
+uintptr_t ia2_stacks[16] IA2_SHARED_DATA = {0};
 
 /* Allocate a fixed-size stack and protect it with the ith pkey. */
 /* Returns the top of the stack, not the base address of the allocation. */
@@ -35,7 +35,7 @@ char *allocate_stack(int i) {
   /* Tag the allocated stack pointer so it is accessed with the right pkey */
   stack = (char *)((uint64_t)stack | (uint64_t)i << 56);
 #endif
-  ia2_stacks[i] = stack;
+  ia2_stacks[i] = (uintptr_t) stack;
 #ifdef __aarch64__
   return stack + STACK_SIZE - 16;
 #elif defined(__x86_64__)

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -12,6 +12,7 @@
 extern __thread void *ia2_stackptr_0[PAGE_SIZE / sizeof(void *)]
     __attribute__((aligned(4096)));
 
+char *ia2_stacks[16] = {0};
 /* Allocate a fixed-size stack and protect it with the ith pkey. */
 /* Returns the top of the stack, not the base address of the allocation. */
 char *allocate_stack(int i) {
@@ -32,6 +33,7 @@ char *allocate_stack(int i) {
   /* Tag the allocated stack pointer so it is accessed with the right pkey */
   stack = (char *)((uint64_t)stack | (uint64_t)i << 56);
 #endif
+  ia2_stacks[i] = stack;
 #ifdef __aarch64__
   return stack + STACK_SIZE - 16;
 #elif defined(__x86_64__)


### PR DESCRIPTION
* Fixes #405.

This removes unnecessary info from the /proc/pid/maps entries in the permissive mode logs and labels the compartment stacks in the column with file paths. Still a WIP since this only labels the first thread's stacks. Aside from the stacks created by other threads, we could also label compartment heaps, compartment TLS regions (not sure if there's one per thread or just one per DSO?).