### PR TITLE
Fix ELF segment end computation

### DIFF
--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -391,7 +391,7 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
 
     struct AddressRange *relro_range = &shared_ranges[shared_range_count++];
     relro_range->start = (info->dlpi_addr + phdr.p_vaddr) & ~0xFFFUL;
-    relro_range->end = (relro_range->start + phdr.p_memsz + 0xFFFUL) & ~0xFFFUL;
+    relro_range->end = (info->dlpi_addr + phdr.p_vaddr + phdr.p_memsz + 0xFFFUL) & ~0xFFFUL;
 
     break;
   }

--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -429,7 +429,7 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
     int access_flags = segment_flags_to_access_flags(phdr.p_flags);
 
     Elf64_Addr start = (info->dlpi_addr + phdr.p_vaddr) & ~0xFFFUL;
-    Elf64_Addr seg_end = (start + phdr.p_memsz + 0xFFFUL) & ~0xFFFUL;
+    Elf64_Addr seg_end = (info->dlpi_addr + phdr.p_vaddr + phdr.p_memsz + 0xFFFUL) & ~0xFFFUL;
     while (start < seg_end) {
       Elf64_Addr cur_end = seg_end;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,7 +69,7 @@ if (NOT LIBIA2_AARCH64)
     add_subdirectory(two_shared_ranges)
     # TODO(#413): Fix these tests
     add_subdirectory(heap_two_keys)
-    # add_subdirectory(three_keys_minimal)
+    add_subdirectory(three_keys_minimal)
 
     # strange bug with indirect calls
     add_subdirectory(read_config)


### PR DESCRIPTION
ELF segment end computation was using the page-aligned start, not the virtual address start (which may not be page-aligned). This was resulting in not protecting the BSS section.