### PR TITLE
runtime: fix `-Wsign-compare` warnings

### DIFF
--- a/runtime/libia2/include/ia2_compartment_init.inc
+++ b/runtime/libia2/include/ia2_compartment_init.inc
@@ -146,7 +146,7 @@ COMPARTMENT_IDENT(ia2_compartment_destructor)(void) {
 
   void (**fini_array)(void) = (void (**)(void))(((uint8_t *)&__ehdr_start) +
                                                 finalizers.fini_array_offset);
-  for (int i = 0; i < (finalizers.fini_array_size / sizeof(void *)); i++) {
+  for (size_t i = 0; i < (finalizers.fini_array_size / sizeof(void *)); i++) {
     fini_array[i]();
   }
   if (finalizers.fini_offset) {
@@ -199,7 +199,7 @@ void COMPARTMENT_IDENT(ia2_setup_destructors)(void) {
     fprintf(stderr, "Failed to set relro section writable: %d\n", res);
     exit(1);
   }
-  for (int i = 0; i < dynamic_phdr->p_memsz / sizeof(Elf64_Dyn); i++) {
+  for (size_t i = 0; i < dynamic_phdr->p_memsz / sizeof(Elf64_Dyn); i++) {
     if (dynamic[i].d_tag == DT_FINI || dynamic[i].d_tag == DT_FINI_ARRAY ||
         dynamic[i].d_tag == DT_FINI_ARRAYSZ) {
       uintptr_t dynamic_entry_addr = (uintptr_t)&dynamic[i].d_un.d_val;

--- a/runtime/libia2/include/permissive_mode.h
+++ b/runtime/libia2/include/permissive_mode.h
@@ -318,7 +318,7 @@ int elfaddr(const void *addr, Dl_info *info) {
   }
 
   best = NULL;
-  for (i = 0; i < fp->f_symcnt; i++) {
+  for (size_t i = 0; i < fp->f_symcnt; i++) {
     Elf64_Sym *sym = &fp->f_symtab[i];
     if (fp->f_strtab[sym->st_name] == '\0')
       continue;


### PR DESCRIPTION
Projects being rewritten and compiled may have warnings/errors like this turned on, so it's simpler to just fix them.

Note that this doesn't set `-Werror=sign-compare` in `cmake` because that'll apply to all of the tests, too.  We just want to make sure that included headers work under different possible warning/error configurations a project might set.