### PR TITLE
runtime: use `__attribute__((__noreturn__))` instead of `_Noreturn` to avoid errors

### DIFF
--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -306,7 +306,7 @@ int ia2_mprotect_with_tag(void *addr, size_t len, int prot, int tag);
 char *allocate_stack(int i);
 void verify_tls_padding(void);
 void ensure_pkeys_allocated(int *n_to_alloc);
-_Noreturn void ia2_reinit_stack_err(int i);
+__attribute__((__noreturn__)) void ia2_reinit_stack_err(int i);
 
 #define _IA2_INIT_RUNTIME(n)                                                   \
   int ia2_n_pkeys_to_alloc = n;                                                \

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -66,7 +66,7 @@ void ensure_pkeys_allocated(int *n_to_alloc) {
 }
 
 /* Forbid overwriting an existing stack. */
-_Noreturn void ia2_reinit_stack_err(int i) {
+__attribute__((__noreturn__)) void ia2_reinit_stack_err(int i) {
   printf("compartment %d in thread %d tried to allocate existing stack\n",
          i, gettid());
   exit(1);


### PR DESCRIPTION
`_Noreturn` doesn't exist before C11, and is deprecated in C23 (in favor or `[[noreturn]]`), so it's simpler just to use `__attribute__((__noreturn__))` since we don't know what C version the headers will be compiled with.