### PR TITLE
Pass indirect call target in first register

### DIFF
--- a/runtime/libia2/include/ia2.h
+++ b/runtime/libia2/include/ia2.h
@@ -45,7 +45,7 @@
 #define IA2_ADDR(opaque) (void *)opaque
 #define IA2_AS_PTR(opaque) opaque
 #define IA2_FN(func) func
-#define IA2_CALL(opaque, id) opaque
+#define IA2_CALL(opaque, id, ...) opaque(__VA_ARGS__)
 #define IA2_CAST(func, ty) (ty) (void *) func
 #else
 #define IA2_DEFINE_WRAPPER(func) IA2_DEFINE_WRAPPER_##func
@@ -133,7 +133,7 @@
 
 /// Call an IA2 opaque function pointer, which should be in target compartment
 /// `id`
-#define IA2_CALL(opaque, id) _IA2_CALL(opaque, id, PKEY)
+#define IA2_CALL(opaque, id, ...) _IA2_CALL(opaque, id, PKEY, ##__VA_ARGS__)
 
 /// Get an IA2 opaque function pointer of type `ty` for the wrapper version of `func`
 ///

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -27,17 +27,11 @@ struct dl_phdr_info;
 /* Supress unused warning */
 #define __IA2_UNUSED __attribute__((__unused__))
 
-/*
- * When IA2_CALL has caller pkey = 0, it just casts the opaque struct to an fn
- * ptr. Otherwise it sets ia2_fn_ptr to the opaque struct's value then calls
- * an indirect call gate depending on the opaque struct's type.
- */
-#define __IA2_CALL(opaque, id, pkey)                                           \
+#define __IA2_CALL(opaque, id, pkey, ...)                                      \
   ({                                                                           \
-    ia2_fn_ptr = opaque.ptr;                                                   \
-    (IA2_TYPE_##id) & __ia2_indirect_callgate_##id##_pkey_##pkey;              \
+    ((IA2_TYPE_##id) & __ia2_indirect_callgate_##id##_pkey_##pkey)(opaque.ptr, ##__VA_ARGS__); \
   })
-#define _IA2_CALL(opaque, id, pkey) __IA2_CALL(opaque, id, pkey)
+#define _IA2_CALL(opaque, id, pkey, ...) __IA2_CALL(opaque, id, pkey, ##__VA_ARGS__)
 
 /* clang-format off */
 #define REPEATB0(fn, basefn) basefn(0)

--- a/tests/abi/include/abi.h
+++ b/tests/abi/include/abi.h
@@ -26,3 +26,4 @@ void arg_in_memory(struct in_memory im);
 struct in_memory ret_in_memory(int x);
 
 typedef struct in_memory(*fn_ptr_ret_in_mem)(int);
+typedef void(*fn_ptr_many_args)(int, int, int, int, int, int, int, int, int, int);

--- a/tests/abi/main.c
+++ b/tests/abi/main.c
@@ -29,4 +29,7 @@ Test(abi, main) {
 
     fn_ptr_ret_in_mem fn = ret_in_memory;
     im = fn(1);
+
+    fn_ptr_many_args fn2 = many_args;
+    fn2(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 }

--- a/tests/read_config/main.c
+++ b/tests/read_config/main.c
@@ -120,7 +120,7 @@ Test(read_config, main) {
     // This function pointer may come from the plugin, so drop from pkey 1 to
     // pkey 0 before calling it. If the function is in the built-in module,
     // it'll have a wrapper from pkey 0 to pkey 1.
-    // REWRITER: IA2_CALL((opt->parse), _ZTSPFvPcPvE)(delim + 1, &shared_entry.value);
+    // REWRITER: IA2_CALL((opt->parse), _ZTSPFvPcPvE, delim + 1, &shared_entry.value);
     (opt->parse)(delim + 1, &shared_entry.value);
     // Copy the value from the shared entry to the main binary's stack.
     entries[idx].value = shared_entry.value;

--- a/tests/rewrite_macros/include/lib.h
+++ b/tests/rewrite_macros/include/lib.h
@@ -32,7 +32,7 @@ extern struct event_actions actions;
 #if PRE_REWRITER
 #define call_add_event(evt) (actions.add)(evt)
 #else
-#define call_add_event(evt) IA2_CALL(actions.add, _ZTSPFbP5eventE)(evt)
+#define call_add_event(evt) IA2_CALL(actions.add, _ZTSPFbP5eventE, evt)
 #endif
 
 struct event *get_event();

--- a/tests/rewrite_macros/main.c
+++ b/tests/rewrite_macros/main.c
@@ -20,7 +20,8 @@ Test(rewrite_macros, main) {
 
     struct event *evt = get_event();
     // Test that the FnPtrCall pass can rewrite simple macros
-    // add_event(evt);
+    // REWRITER: IA2_CALL(add_event, _ZTSPFbP5eventE, evt);
+    add_event(evt);
     // REWRITER: IA2_CALL(actions.add, _ZTSPFbP5eventE, evt);
     actions.add(evt);
 

--- a/tests/rewrite_macros/main.c
+++ b/tests/rewrite_macros/main.c
@@ -20,9 +20,8 @@ Test(rewrite_macros, main) {
 
     struct event *evt = get_event();
     // Test that the FnPtrCall pass can rewrite simple macros
-    // REWRITER: IA2_CALL(add_event, _ZTSPFbP5eventE)(evt);
-    add_event(evt);
-    // REWRITER: IA2_CALL(actions.add, _ZTSPFbP5eventE)(evt);
+    // add_event(evt);
+    // REWRITER: IA2_CALL(actions.add, _ZTSPFbP5eventE, evt);
     actions.add(evt);
 
     bool(*fn)(struct event *evt) = add_event;
@@ -34,6 +33,6 @@ Test(rewrite_macros, main) {
     // REWRITER: if (IA2_ADDR(fn) == IA2_ADDR(actions.add)) {}
     if (fn == actions.add) {}
 
-    // REWRITER: IA2_CALL(fn, _ZTSPFbP5eventE)(evt);
+    // REWRITER: IA2_CALL(fn, _ZTSPFbP5eventE, evt);
     fn(evt);
 }

--- a/tests/simple1/main.c
+++ b/tests/simple1/main.c
@@ -82,7 +82,7 @@ Test(simple1, main) {
     // untrusted since libsimple1 sets the value of exit_hook_fn. If
     // exit_hook_fn were to point to a function defined in this binary, it must
     // be a wrapped function with an untrusted caller and callee with pkey 0.
-    // REWRITER: IA2_CALL(exit_hook_fn, _ZTSPFvvE)();
+    // REWRITER: IA2_CALL(exit_hook_fn, _ZTSPFvvE);
     exit_hook_fn();
   }
 }

--- a/tests/trusted_indirect/main.c
+++ b/tests/trusted_indirect/main.c
@@ -36,16 +36,16 @@ void call_fn_ptr() {
     uint32_t x = 987234;
     uint32_t y = 142151;
     // This calls `f.op` with and without parentheses to ensure the rewriter handles both
-    // REWRITER: uint32_t res1 = IA2_CALL(f.op, _ZTSPFjjjE)(x, y);
+    // REWRITER: uint32_t res1 = IA2_CALL(f.op, _ZTSPFjjjE, x, y);
     uint32_t res1 = f.op(x, y);
     // REWRITER: f.op = IA2_FN(multiply);
     f.op = multiply;
-    // REWRITER: uint32_t res2 = IA2_CALL((f.op), _ZTSPFjjjE)(x, y);
+    // REWRITER: uint32_t res2 = IA2_CALL((f.op), _ZTSPFjjjE, x, y);
     uint32_t res2 = (f.op)(x, y);
     cr_assert_eq(res2, 2897346862);
     // REWRITER: f.op = IA2_FN(divide);
     f.op = divide;
-    // REWRITER: uint32_t res3 = IA2_CALL(f.op, _ZTSPFjjjE)(x, y);
+    // REWRITER: uint32_t res3 = IA2_CALL(f.op, _ZTSPFjjjE, x, y);
     uint32_t res3 = f.op(x, y);
     cr_assert_eq(res3, 6);
 }
@@ -63,7 +63,7 @@ void do_test() {
 
     static uint32_t secret = 34;
     leak_secret_address(&secret);
-    // REWRITER: IA2_CALL((f.op), _ZTSPFjjjE)(0, 0);
+    // REWRITER: IA2_CALL((f.op), _ZTSPFjjjE, 0, 0);
     (f.op)(0, 0);
 }
 

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -42,11 +42,6 @@ const std::array<const char *, 10> aarch64_preserved_registers = {"x19", "x20", 
                                                                   "x25", "x26", "x27",
                                                                   "x28"};
 
-static size_t stack_arg_count(const std::vector<ArgLocation> &args) {
-  return std::count_if(args.begin(), args.end(),
-                       [](auto &x) { return x.is_stack(); });
-}
-
 static size_t reg_arg_count(const std::vector<ArgLocation> &args) {
   return std::count_if(args.begin(), args.end(),
                        [](auto &x) { return !x.is_stack(); });

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -42,6 +42,16 @@ const std::array<const char *, 10> aarch64_preserved_registers = {"x19", "x20", 
                                                                   "x25", "x26", "x27",
                                                                   "x28"};
 
+static size_t stack_arg_count(const std::vector<ArgLocation> &args) {
+  return std::count_if(args.begin(), args.end(),
+                       [](auto &x) { return x.is_stack(); });
+}
+
+static size_t reg_arg_count(const std::vector<ArgLocation> &args) {
+  return std::count_if(args.begin(), args.end(),
+                       [](auto &x) { return !x.is_stack(); });
+}
+
 /// Compute abi locations for parameters of a C-abi function, given its sequence
 /// of argument kinds.
 std::vector<ArgLocation> allocate_param_locations(const AbiSignature &func, Arch arch, size_t *stack_arg_size_out) {
@@ -493,7 +503,11 @@ static void x86_emit_intermediate_pkru(AsmWriter &aw, uint32_t caller_pkey, uint
   add_asm_line(aw, restoreline2);
 }
 
-static void emit_copy_args(AsmWriter &aw, const std::vector<ArgLocation> &args, size_t stack_return_size, size_t stack_return_padding, int stack_alignment, size_t stack_arg_size, size_t stack_arg_padding, uint32_t caller_pkey, Arch arch) {
+static void emit_copy_args(AsmWriter &aw, const std::vector<ArgLocation> &args,
+                           const std::optional<std::vector<ArgLocation>> &wrapper_args,
+                           size_t stack_return_size, size_t stack_return_padding, int stack_alignment, 
+                           size_t stack_arg_size, size_t stack_arg_padding, size_t wrapper_stack_arg_size, 
+                           uint32_t caller_pkey, Arch arch) {
   if (arch == Arch::X86) {
     // When returning via memory, the address of the return value is passed in
     // rdi. Since this memory belongs to the caller, we first allocate space for
@@ -537,11 +551,35 @@ static void emit_copy_args(AsmWriter &aw, const std::vector<ArgLocation> &args, 
       // args
       size_t offset =
           stack_arg_size + stack_arg_padding + ((x86_preserved_registers.size() + 1) * 8);
+      offset += wrapper_stack_arg_size - stack_arg_size;
       for (int i = 0; i < stack_arg_size; i += 8) {
         // The index into the caller's stack is backwards since pushq will copy to
         // the compartment's stack from the highest addresses to the lowest.
         add_asm_line(aw,
                      "pushq " + std::to_string(offset - i) + "(%rax)");
+      }
+    }
+
+    if (wrapper_args) {
+      add_comment_line(aw, "Copy arguments into the correct registers");
+      auto src_arg = wrapper_args->begin();
+      auto dest_arg = args.begin();
+      if (stack_return_size > 0) {
+        src_arg++;
+        dest_arg++;
+      }
+      
+      add_asm_line(aw, "movq %"s + src_arg->as_str() + ", %r12");
+      src_arg++;
+      for (; dest_arg != args.end(); src_arg++, dest_arg++) {
+        if (!dest_arg->is_stack()) {
+          if (src_arg->is_stack()) {
+            size_t offset = (x86_preserved_registers.size() + 1) * 8 + src_arg->stack_offset();
+            add_asm_line(aw, "movq %"s + dest_arg->as_str() + ", " + std::to_string(offset) + "(%rax)");
+          } else {
+            add_asm_line(aw, "movq %"s + src_arg->as_str() + ", %"s + dest_arg->as_str());
+          }
+        }
       }
     }
   } else if (arch == Arch::Aarch64) {
@@ -587,6 +625,7 @@ static void emit_copy_args(AsmWriter &aw, const std::vector<ArgLocation> &args, 
       add_comment_line(
           aw, "Copy stack arguments from the caller's stack to the compartment");
       size_t src_offset = ((aarch64_preserved_registers.size() + 2) * 8);
+      src_offset += wrapper_stack_arg_size - stack_arg_size;
       emit_memcpy(aw, stack_arg_size, "sp", "x12", "x9", src_offset, arch);
     }
 
@@ -611,17 +650,29 @@ static void emit_copy_args(AsmWriter &aw, const std::vector<ArgLocation> &args, 
         indirect_arg_current_offset += arg.size();
       }
     }
-  }
-}
 
-static void emit_load_fn_ptr(AsmWriter &aw, Arch arch) {
-  if (arch == Arch::X86) {
-    add_asm_line(aw, "movq ia2_fn_ptr@GOTPCREL(%rip), %r12");
-    add_asm_line(aw, "movq (%r12), %r12");
-  } else if (arch == Arch::Aarch64) {
-    add_asm_line(aw, "adrp x9, ia2_fn_ptr");
-    add_asm_line(aw, "add x9, x9, #:lo12:ia2_fn_ptr");
-    add_asm_line(aw, "ldr x9, [x9]");
+    if (wrapper_args) {
+      add_comment_line(aw, "Copy arguments into the correct registers");
+      auto src_arg = wrapper_args->begin();
+      auto dest_arg = args.begin();
+      if (stack_return_size > 0) {
+        src_arg++;
+        dest_arg++;
+      }
+
+      add_asm_line(aw, "mov x9, "s + src_arg->as_str());
+      src_arg++;
+      for (; dest_arg != args.end(); src_arg++, dest_arg++) {
+        if (!dest_arg->is_stack()) {
+          if (src_arg->is_stack()) {
+            size_t offset = (aarch64_preserved_registers.size() + 2) * 8 + src_arg->stack_offset();
+            add_asm_line(aw, "ldr "s + dest_arg->as_str() + ", [x12, #" + std::to_string(offset) + "]");
+          } else {
+            add_asm_line(aw, "mov "s + dest_arg->as_str() + ", "s + src_arg->as_str());
+          }
+        }
+      }
+    }
   }
 }
 
@@ -694,7 +745,9 @@ static void emit_copy_stack_returns(AsmWriter &aw, size_t stack_return_size, siz
   }
 }
 
-static void emit_scrub_regs(AsmWriter &aw, uint32_t pkey, const std::vector<ArgLocation> &locs, bool preserve_regs, Arch arch) {
+static void emit_scrub_regs(AsmWriter &aw, uint32_t pkey, const std::vector<ArgLocation> &locs, bool indirect, Arch arch) {
+  bool preserve_regs = reg_arg_count(locs) > 0 || indirect;
+
   // Handles register scrubbing for calls into/out of protected compartments.
   // After call: Preserves return values by pushing them to the stack before scrubbing.
   // Before call: Saves argument registers in a similar manner.
@@ -711,6 +764,11 @@ static void emit_scrub_regs(AsmWriter &aw, uint32_t pkey, const std::vector<ArgL
             emit_reg_push(aw, loc);
           }
         }
+
+        if (indirect) {
+          // Save the function pointer argument
+          add_asm_line(aw, "pushq %r12");
+        }
       }
 
       // Scrub all registers except rsp.
@@ -722,6 +780,11 @@ static void emit_scrub_regs(AsmWriter &aw, uint32_t pkey, const std::vector<ArgL
       if (preserve_regs) {
         // Restore saved regs
         add_comment_line(aw, "Restore preserved regs");
+        if (indirect) {
+          // Restore the function pointer argument
+          add_asm_line(aw, "popq %r12");
+        }
+
         for (auto loc = locs.rbegin(); loc != locs.rend(); loc++) {
           if (!loc->is_stack()) {
             emit_reg_pop(aw, *loc);
@@ -732,6 +795,9 @@ static void emit_scrub_regs(AsmWriter &aw, uint32_t pkey, const std::vector<ArgL
   } else if (arch == Arch::Aarch64) {
     auto regs_64bit = std::vector<std::string>();
     auto regs_128bit = std::vector<std::string>();
+    if (indirect) {
+      regs_64bit.push_back("x9");
+    }
     for (auto loc : locs) {
       if (!loc.is_stack() && loc.is_allocated()) {
         // loc is not allocated to a register if it is an indirect return on
@@ -843,7 +909,8 @@ static void emit_return(AsmWriter &aw) {
   add_asm_line(aw, "ret");
 }
 
-std::string emit_asm_wrapper(AbiSignature &sig,
+std::string emit_asm_wrapper(AbiSignature sig,
+                             std::optional<AbiSignature> wrapper_sig,
                              const std::string &wrapper_name,
                              const std::optional<std::string> target_name,
                              WrapperKind kind, int caller_pkey, int target_pkey,
@@ -852,14 +919,17 @@ std::string emit_asm_wrapper(AbiSignature &sig,
   // Small sanity check
   assert(caller_pkey != target_pkey);
 
-  size_t stack_arg_size = 0;
   AsmWriter aw = get_asmwriter(as_macro);
+
+  size_t stack_arg_size = 0;
   auto args = allocate_param_locations(sig, arch, &stack_arg_size);
-  size_t stack_arg_count = std::count_if(args.begin(), args.end(),
-                                         [](auto &x) { return x.is_stack(); });
+  std::optional<std::vector<ArgLocation>> wrapper_args;
+  size_t wrapper_stack_arg_size = stack_arg_size;
+  if (wrapper_sig) {
+    wrapper_args = {allocate_param_locations(*wrapper_sig, arch, &wrapper_stack_arg_size)};
+  }
   size_t unaligned = stack_arg_size % 8;
   size_t stack_arg_padding = unaligned != 0 ? 8 - unaligned : 0;
-  size_t reg_arg_count = args.size() - stack_arg_count;
 
   llvm::errs() << "Generating wrapper for " << sig_string(sig, target_name) << "\n";
   auto rets = allocate_return_locations(sig, arch);
@@ -1000,13 +1070,9 @@ std::string emit_asm_wrapper(AbiSignature &sig,
 
   emit_switch_stacks(aw, caller_pkey, target_pkey, arch);
 
-  emit_copy_args(aw, args, stack_return_size, stack_return_padding, stack_alignment, stack_arg_size, stack_arg_padding, caller_pkey, arch);
+  emit_copy_args(aw, args, wrapper_args, stack_return_size, stack_return_padding, stack_alignment, stack_arg_size, stack_arg_padding, wrapper_stack_arg_size, caller_pkey, arch);
 
-  emit_scrub_regs(aw, caller_pkey, args, reg_arg_count > 0, arch);
-
-  if (kind == WrapperKind::IndirectCallsite) {
-    emit_load_fn_ptr(aw, arch);
-  }
+  emit_scrub_regs(aw, caller_pkey, args, kind == WrapperKind::IndirectCallsite, arch);
 
   emit_set_pkru(aw, target_pkey, arch);
 
@@ -1022,7 +1088,7 @@ std::string emit_asm_wrapper(AbiSignature &sig,
 
   emit_switch_stacks(aw, target_pkey, caller_pkey, arch);
 
-  emit_scrub_regs(aw, target_pkey, rets, true, arch);
+  emit_scrub_regs(aw, target_pkey, rets, false, arch);
 
   emit_set_return_pkru(aw, caller_pkey, arch);
 

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -574,8 +574,12 @@ static void emit_copy_args(AsmWriter &aw, const std::vector<ArgLocation> &args,
       for (; dest_arg != args.end(); src_arg++, dest_arg++) {
         if (!dest_arg->is_stack()) {
           if (src_arg->is_stack()) {
-            size_t offset = (x86_preserved_registers.size() + 1) * 8 + src_arg->stack_offset();
-            add_asm_line(aw, "movq %"s + dest_arg->as_str() + ", " + std::to_string(offset) + "(%rax)");
+            size_t offset = (x86_preserved_registers.size() + 1) * 8 + stack_arg_padding + src_arg->stack_offset() + src_arg->size();
+            size_t align = std::max(src_arg->align(), (size_t)8);
+            if (offset % align != 0) {
+              offset += align - (offset % align);
+            }
+            add_asm_line(aw, "movq "s + std::to_string(offset) + "(%rax), %" + dest_arg->as_str());
           } else {
             add_asm_line(aw, "movq %"s + src_arg->as_str() + ", %"s + dest_arg->as_str());
           }

--- a/tools/rewriter/GenCallAsm.h
+++ b/tools/rewriter/GenCallAsm.h
@@ -29,7 +29,8 @@ enum class Arch {
 // which must be valid to pass to the `PKRU` macro in ia2.h.
 // \p as_macro determines if the wrappers for direct calls is emitted as a
 // macro. Indirect calls are unconditionally emitted as macros.
-std::string emit_asm_wrapper(AbiSignature &sig,
+std::string emit_asm_wrapper(AbiSignature sig,
+                             std::optional<AbiSignature> wrapper_sig,
                              const std::string &wrapper_name,
                              const std::optional<std::string> target_name,
                              WrapperKind kind, int caller_pkey, int target_pkey,

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -524,7 +524,7 @@ public:
       assert(fn_ptr_ty);
       auto dest_fn_ty = fn_ptr_ty->getPointeeType()->getAs<clang::FunctionProtoType>();
       assert(dest_fn_ty);
-      auto args = dest_fn_ty->param_types().vec();
+      std::vector<clang::QualType> args = {dest_fn_ty->param_type_begin(), dest_fn_ty->param_type_end()};
       args.insert(args.begin(), ctxt.VoidPtrTy);
       auto wrap_fn_ty = ctxt.getFunctionType(dest_fn_ty->getReturnType(), args, dest_fn_ty->getExtProtoInfo());
       auto wrap_fn_ptr_ty = ctxt.getPointerType(wrap_fn_ty);

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -502,7 +502,7 @@ public:
       return;
     }
 
-    clang::SourceLocation loc = fn_ptr_call->getExprLoc();
+    clang::SourceLocation loc = fn_ptr_expr->getExprLoc();
     Filename filename = get_filename(loc, sm);
     if (should_not_modify_file(filename)) {
       return;
@@ -541,7 +541,7 @@ public:
 
     // This check must come after modifying the maps in this pass but before the
     // Replacement is added
-    if (in_macro_expansion(loc, sm)) {
+    if (in_fn_like_macro(loc, sm)) {
       auto expansion_file = get_expansion_filename(loc, sm);
       auto expansion_line = sm.getExpansionLineNumber(loc);
       auto spelling_line = sm.getSpellingLineNumber(loc);
@@ -574,6 +574,12 @@ public:
 
     auto char_range = 
         clang::CharSourceRange::getTokenRange(fn_ptr_call->getSourceRange());
+
+    if (in_macro_expansion(char_range.getBegin(), sm)) {
+      filename = get_expansion_filename(char_range.getBegin(), sm);
+      auto expanded_char_range = sm.getExpansionRange(char_range.getBegin());
+      char_range = clang::CharSourceRange::getTokenRange(expanded_char_range.getBegin(), char_range.getEnd());
+    }
 
     Replacement old_r{sm, char_range, new_expr};
     Replacement r = replace_new_file(filename, old_r);


### PR DESCRIPTION
Rather than pass the indirect call target in a global static, this change passes the target in the first parameter register to the wrapper. The wrapper then shifts the remaining parameters so that the callee receives the correct parameters.