### PR TITLE
Add support for literal zero in `FnPtrNull` rewriter pass

### DIFF
--- a/tests/rewrite_fn_ptr_eq/main.c
+++ b/tests/rewrite_fn_ptr_eq/main.c
@@ -27,8 +27,12 @@ Test(rewrite_fn_ptr_eq, main) {
     int res;
     int *y = &res;
     void *x = NULL;
+    // REWRITER: bin_op fn = IA2_FN(add);
     bin_op fn = add;
+    // REWRITER: bin_op fn2 = { NULL };
     bin_op fn2 = NULL;
+    // REWRITER: bin_op fn3 = { 0 };
+    bin_op fn3 = 0;
 
     // Check that pointers for types other than functions are not rewritten
     // REWRITER: if (y) { }
@@ -78,4 +82,28 @@ Test(rewrite_fn_ptr_eq, main) {
     if (y || !fn) { }
     // REWRITER: if (x && IA2_ADDR(fn) && y) { }
     if (x && fn && y) { }
+
+    // REWRITER: fn = (typeof(fn)) { NULL };
+    fn = NULL;
+
+    // the next test doesn't use NULL so the rewriter output shouldn't rely on it either
+//#undef NULL
+    // REWRITER: fn = (typeof(fn)) { 0 };
+    fn = 0;
+
+    // check that literal zeroes aren't rewritten if not cast to function pointers
+    // REWRITER: res = 0;
+    res = 0;
+
+    // REWRITER: if (IA2_ADDR(fn) == 0) { }
+    if (fn == 0) { }
+
+    // REWRITER: if (IA2_ADDR(mod.fn) == 0) { }
+    if (mod.fn == 0) { }
+
+    // REWRITER: if (IA2_ADDR(fn) == 0) { }
+    if (fn == (typeof(fn))0) { }
+
+    // REWRITER: if (IA2_ADDR(mod.fn) == 0) { }
+    if (mod.fn == (typeof(fn))0) { }
 }

--- a/tests/rewrite_fn_ptr_eq/main.c
+++ b/tests/rewrite_fn_ptr_eq/main.c
@@ -31,8 +31,6 @@ Test(rewrite_fn_ptr_eq, main) {
     bin_op fn = add;
     // REWRITER: bin_op fn2 = { NULL };
     bin_op fn2 = NULL;
-    // REWRITER: bin_op fn3 = { 0 };
-    bin_op fn3 = 0;
 
     // Check that pointers for types other than functions are not rewritten
     // REWRITER: if (y) { }
@@ -86,8 +84,11 @@ Test(rewrite_fn_ptr_eq, main) {
     // REWRITER: fn = (typeof(fn)) { NULL };
     fn = NULL;
 
-    // the next test doesn't use NULL so the rewriter output shouldn't rely on it either
-//#undef NULL
+    // the following tests don't use NULL so the rewriter output shouldn't rely on it either
+#undef NULL
+    // REWRITER: bin_op fn3 = { 0 };
+    bin_op fn3 = 0;
+
     // REWRITER: fn = (typeof(fn)) { 0 };
     fn = 0;
 

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -404,7 +404,9 @@ public:
 
     auto fn_ptr_typedef = hasType(typedefNameDecl(hasType(fn_ptr)));
 
-    auto null_expr = implicitCastExpr(ignoringParenCasts(nullPointerConstant()))
+    auto zero_literal = integerLiteral(equals(0));
+    auto null_macro = nullPointerConstant();
+    auto null_expr = implicitCastExpr(ignoringParenCasts(anyOf(null_macro, zero_literal)))
                          .bind("nullExpr");
 
     auto null_fn_ptr = varDecl(hasInitializer(null_expr),

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -404,7 +404,7 @@ public:
 
     auto fn_ptr_typedef = hasType(typedefNameDecl(hasType(fn_ptr)));
 
-    auto zero_literal = integerLiteral(equals(0));
+    auto zero_literal = integerLiteral(equals(0)).bind("literalZero");
     auto null_macro = nullPointerConstant();
     auto null_expr = implicitCastExpr(ignoringParenCasts(anyOf(null_macro, zero_literal)))
                          .bind("nullExpr");
@@ -420,6 +420,7 @@ public:
     refactorer.addMatcher(assign_null, this);
   }
   virtual void run(const MatchFinder::MatchResult &result) {
+    bool spelled_as_zero = result.Nodes.getNodeAs<clang::IntegerLiteral>("literalZero");
     // The two matchers both have a nullExpr node so this getNodeAs can't fail
     auto *null_fn_ptr = result.Nodes.getNodeAs<clang::Expr>("nullExpr");
     assert(null_fn_ptr != nullptr);
@@ -438,6 +439,9 @@ public:
     Filename filename = get_expansion_filename(loc, sm);
 
     std::string new_expr = "{ NULL }";
+    if (spelled_as_zero) {
+        new_expr = "{ 0 }";
+    }
     // If the matcher found an assignment add the type of the LHS variable to
     // new_expr
     if (auto *lhs_ptr = result.Nodes.getNodeAs<clang::Expr>("ptrLHS")) {
@@ -445,7 +449,7 @@ public:
           clang::CharSourceRange::getTokenRange(lhs_ptr->getSourceRange());
       auto lhs_binding =
           clang::Lexer::getSourceText(char_range, sm, ctxt.getLangOpts());
-      new_expr = "(typeof("s + lhs_binding.str() + ")) { NULL }";
+      new_expr = "(typeof("s + lhs_binding.str() + ")) " + new_expr;
     }
 
     clang::CharSourceRange expansion_range = sm.getExpansionRange(loc);


### PR DESCRIPTION
We previously assumed that initializing, assigning or comparing function pointers with `NULL` would not use an integer literal. @randomPoison hit this issue with zlib so this PR adds support for those cases and new tests. It also takes into account the cases with and without a cast on the zero. I've covered most of the new cases, except comparisons since those interact with AST matchers in `FnPtrEq` so I'm thinking about the best way to handle them. Closes #411 and #412.