### PR TITLE
rewriter: Redeclare static functions that have their address taken with used

### DIFF
--- a/runtime/libia2/include/ia2.h
+++ b/runtime/libia2/include/ia2.h
@@ -49,7 +49,7 @@
 #define IA2_CAST(func, ty) (ty) (void *) func
 #else
 #define IA2_DEFINE_WRAPPER(func) \
-    typeof(func) func __attribute__((__used__)); \
+    __attribute__((__used__)) typeof(func) func; \
     IA2_DEFINE_WRAPPER_##func
 #define IA2_SIGHANDLER(func) ia2_sighandler_##func
 /// Create a wrapped signal handler for `sa_sigaction`

--- a/runtime/libia2/include/ia2.h
+++ b/runtime/libia2/include/ia2.h
@@ -48,7 +48,9 @@
 #define IA2_CALL(opaque, id) opaque
 #define IA2_CAST(func, ty) (ty) (void *) func
 #else
-#define IA2_DEFINE_WRAPPER(func) IA2_DEFINE_WRAPPER_##func
+#define IA2_DEFINE_WRAPPER(func) \
+    typeof(func) func __attribute__((__used__)); \
+    IA2_DEFINE_WRAPPER_##func
 #define IA2_SIGHANDLER(func) ia2_sighandler_##func
 /// Create a wrapped signal handler for `sa_sigaction`
 ///

--- a/runtime/libia2/include/ia2.h
+++ b/runtime/libia2/include/ia2.h
@@ -49,7 +49,7 @@
 #define IA2_CAST(func, ty) (ty) (void *) func
 #else
 #define IA2_DEFINE_WRAPPER(func) \
-    __attribute__((__used__)) typeof(func) func; \
+    __attribute__((__used__)) static void *keep_##func = (void *)func; \
     IA2_DEFINE_WRAPPER_##func
 #define IA2_SIGHANDLER(func) ia2_sighandler_##func
 /// Create a wrapped signal handler for `sa_sigaction`

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ add_subdirectory(shared_data)
 add_subdirectory(global_fn_ptr)
 add_subdirectory(rewrite_macros)
 add_subdirectory(sighandler)
+add_subdirectory(static_addr_taken)
 
 # The following tests are not supported on ARM64 yet
 if (NOT LIBIA2_AARCH64)

--- a/tests/static_addr_taken/CMakeLists.txt
+++ b/tests/static_addr_taken/CMakeLists.txt
@@ -1,5 +1,6 @@
 define_shared_lib(
     SRCS lib.c
+    NEEDS_LD_WRAP
     PKEY 2
 )
 

--- a/tests/static_addr_taken/CMakeLists.txt
+++ b/tests/static_addr_taken/CMakeLists.txt
@@ -1,0 +1,13 @@
+define_shared_lib(
+    SRCS lib.c
+    PKEY 2
+)
+
+define_test(
+    SRCS main.c
+    NEEDS_LD_WRAP
+    PKEY 1
+    CRITERION_TEST
+)
+
+define_ia2_wrapper()

--- a/tests/static_addr_taken/include/static_fns.h
+++ b/tests/static_addr_taken/include/static_fns.h
@@ -1,0 +1,10 @@
+#pragma once
+
+typedef void (*fn_ptr_ty)(void);
+
+static void inline_noop(void) {
+    printf("called %s defined in header\n", __func__);
+}
+
+fn_ptr_ty *get_ptrs_in_main(void);
+fn_ptr_ty *get_ptrs_in_lib(void);

--- a/tests/static_addr_taken/lib.c
+++ b/tests/static_addr_taken/lib.c
@@ -2,7 +2,7 @@
 #include <criterion/logging.h>
 #include <ia2.h>
 
-#include <test_fault_handler.h>
+//#include <test_fault_handler.h>
 
 #define IA2_COMPARTMENT 2
 #include <ia2_compartment_init.inc>

--- a/tests/static_addr_taken/lib.c
+++ b/tests/static_addr_taken/lib.c
@@ -1,0 +1,40 @@
+#include <criterion/criterion.h>
+#include <criterion/logging.h>
+#include <ia2.h>
+
+#include <test_fault_handler.h>
+
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>
+
+#include "static_fns.h"
+
+static void duplicate_noop(void) {
+    printf("called %s in library\n", __func__);
+}
+
+static void identical_name(void) {
+    static int x = 4;
+    printf("%s in library read x = %d\n", __func__, x);
+}
+
+static fn_ptr_ty ptrs[3] IA2_SHARED_DATA = {
+    inline_noop, duplicate_noop, identical_name
+};
+
+fn_ptr_ty *get_ptrs_in_lib(void) {
+    return ptrs;
+}
+
+Test(static_addr_taken, call_ptrs_in_lib) {
+    for (int i = 0; i < 3; i++) {
+        ptrs[i]();
+    }
+}
+
+Test(static_addr_taken, call_ptr_from_main) {
+    fn_ptr_ty *main_ptrs = get_ptrs_in_main();
+    for (int i = 0; i < 3; i++) {
+        main_ptrs[i]();
+    }
+}

--- a/tests/static_addr_taken/main.c
+++ b/tests/static_addr_taken/main.c
@@ -2,8 +2,8 @@
 #include <criterion/logging.h>
 #include <ia2.h>
 
-#define IA2_DEFINE_TEST_HANDLER
-#include <test_fault_handler.h>
+//#define IA2_DEFINE_TEST_HANDLER
+//#include <test_fault_handler.h>
 
 INIT_RUNTIME(2);
 #define IA2_COMPARTMENT 1
@@ -11,7 +11,9 @@ INIT_RUNTIME(2);
 
 #include "static_fns.h"
 
-static void duplicate_noop(void) {
+#define LOCAL static
+
+LOCAL void duplicate_noop(void) {
     printf("called %s in main binary\n", __func__);
 }
 

--- a/tests/static_addr_taken/main.c
+++ b/tests/static_addr_taken/main.c
@@ -1,0 +1,42 @@
+#include <criterion/criterion.h>
+#include <criterion/logging.h>
+#include <ia2.h>
+
+#define IA2_DEFINE_TEST_HANDLER
+#include <test_fault_handler.h>
+
+INIT_RUNTIME(2);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
+
+#include "static_fns.h"
+
+static void duplicate_noop(void) {
+    printf("called %s in main binary\n", __func__);
+}
+
+static void identical_name(void) {
+    static int x = 3;
+    printf("%s in main binary read x = %d\n", __func__, x);
+}
+
+static fn_ptr_ty ptrs[3] IA2_SHARED_DATA = {
+    inline_noop, duplicate_noop, identical_name
+};
+
+fn_ptr_ty *get_ptrs_in_main(void) {
+    return ptrs;
+}
+
+Test(static_addr_taken, call_ptrs_in_main) {
+    for (int i = 0; i < 3; i++) {
+        ptrs[i]();
+    }
+}
+
+Test(static_addr_taken, call_ptr_from_lib) {
+    fn_ptr_ty *lib_ptrs = get_ptrs_in_lib();
+    for (int i = 0; i < 3; i++) {
+        lib_ptrs[i]();
+    }
+}


### PR DESCRIPTION
When we make call gates for static functions that have their address taken, the static function is only referenced from the asm for the call gate. Compiling with optimizations may get rid of the static functions unless they are marked with `__attribute__((__used__))`. The rewriter previously prepended this attribute in this case to avoid that. This commit removes the prepended attribute and instead redeclares these functions with that attribute. Closes #414 and fixes a test added for #428.