### PR TITLE
cmake: Disable PartitionAlloc on ARM

### DIFF
--- a/cmake/ia2.cmake
+++ b/cmake/ia2.cmake
@@ -69,7 +69,12 @@ function(add_ia2_compartment NAME TYPE)
     target_link_options(${NAME} PRIVATE ${UBSAN_FLAG})
   endif()
 
-  target_link_libraries(${NAME} PRIVATE dl libia2 partition-alloc)
+  if (LIBIA2_AARCH64)
+      set(ALLOCATOR_LIB "")
+  else()
+      set(ALLOCATOR_LIB "partition-alloc")
+  endif()
+  target_link_libraries(${NAME} PRIVATE dl libia2 ${ALLOCATOR_LIB})
   target_link_options(${NAME} PRIVATE "-Wl,--export-dynamic")
 
   target_link_libraries(${NAME} PRIVATE ${ARG_LIBRARIES})


### PR DESCRIPTION
PartitionAlloc needs to be built with -ffixed-x18 on ARM to avoid clobbering x18. However linking it in also pulls in libstdc++ which can also clobber x18 so this commit just disables PartitionAlloc on ARM for now. It shouldn't be too hard to build LLVM's libc++ with -ffixed-x18 since that's what Android uses so we should probably just do that when we want to re-enable PA.