### PR TITLE
rewriter: Define call gates for function pointers in source defining the pointee

### DIFF
--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -979,7 +979,7 @@ std::string emit_asm_wrapper(AbiSignature &sig,
 
   add_comment_line(aw, "Wrapper for "s + sig_string(sig, target_name) + ":");
   add_asm_line(aw, ".text");
-  if (!as_macro) {
+  if (kind != WrapperKind::PointerToStatic) {
     add_asm_line(aw, ".global "s + wrapper_name);
   } else {
     add_asm_line(aw, ".local "s + wrapper_name);

--- a/tools/rewriter/GenCallAsm.h
+++ b/tools/rewriter/GenCallAsm.h
@@ -10,6 +10,8 @@ enum class WrapperKind {
   Direct,
   // Indirect call through a pointer sent to another compartment
   Pointer,
+  // Indirect call through a pointer sent to another compartment
+  PointerToStatic,
   // Indirect call through a pointer received from another compartment
   IndirectCallsite,
 };

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -1457,7 +1457,11 @@ int main(int argc, const char **argv) {
       macros_defining_wrappers += asm_wrapper;
       macros_defining_wrappers += ");\n";
 
-      /* Invoke the macro we just defined in the source file defining the target function */
+      /*
+       * Invoke IA2_DEFINE_WRAPPER from ia2.h in the source file defining the
+       * target function. This expands to the IA2_DEFINE_WRAPPER_* macro we just
+       * defined
+       */
       auto filename = fn_decl_pass.fn_definitions[fn_name];
       std::ofstream source_file(filename, std::ios::app);
       source_file << "IA2_DEFINE_WRAPPER(" << fn_name << ")\n";
@@ -1498,6 +1502,11 @@ int main(int argc, const char **argv) {
 
         header_out << "extern " << opaque << " " << wrapper_name << ";\n";
 
+        /*
+         * Invoke IA2_DEFINE_WRAPPER from ia2.h in the source file defining the
+         * target function. This expands to the IA2_DEFINE_WRAPPER_* macro we just
+         * defined
+         */
         source_file << "IA2_DEFINE_WRAPPER(" << fn_name << ")\n";
       }
     }


### PR DESCRIPTION
We previously defined call gates for pointers to static functions by appending a macro to the rewritten source files. In that case we had to do this because the static function may not be referenced from outside the translation unit. For pointers to globally-visible functions we defined the call gates in the call gate .so for simplicity. This commit changes the latter call gates so they're defined like the former. This change simplifies control-flow since the call gate no longer requires cross-DSO calls and makes it possible to support programs that are intended to be compiled with -fvisibility=hidden since functions that may have hidden visibility are only referenced by call gates within the DSO that defines them. Partially addresses #435.