### PR TITLE
runtime: extract out `allocate_stack_0` to work around a "Local Exec" TLS model issue and prevent segfaulting

### DIFF
--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -338,6 +338,7 @@ static int ia2_mprotect_with_tag(void *addr, size_t len, int prot, int tag) {
 #endif
 #endif
 char *allocate_stack(int i);
+void allocate_stack_0();
 void verify_tls_padding(void);
 void ensure_pkeys_allocated(int *n_to_alloc);
 __attribute__((__noreturn__)) void ia2_reinit_stack_err(int i);
@@ -430,7 +431,7 @@ __attribute__((__noreturn__)) void ia2_reinit_stack_err(int i);
     verify_tls_padding();                                                      \
     COMPARTMENT_SAVE_AND_RESTORE(REPEATB(n, ALLOCATE_COMPARTMENT_STACK_AND_SETUP_TLS, nop_macro), n); \
     /* allocate an unprotected stack for the untrusted compartment */          \
-    ia2_stackptr_0[0] = allocate_stack(0);                                     \
+    allocate_stack_0();                                     \
   }                                                                            \
                                                                                \
   __attribute__((constructor)) static void ia2_init(void) {                    \

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -30,6 +30,10 @@ char *allocate_stack(int i) {
   return stack + STACK_SIZE - 8;
 }
 
+void allocate_stack_0() {
+  ia2_stackptr_0[0] = allocate_stack(0);
+}
+
 /* Confirm that stack pointers for compartments 0 and 1 are on separate */
 /* pages. */
 void verify_tls_padding(void) {


### PR DESCRIPTION
`allocate_stack_0` writes the allocated stack to `ia2_stackptr_0`. Previously, this was done inline in `init_stacks_and_setup_tls`, which is defined in the main compartment with `INIT_RUNTIME`, and thus may sometimes use the "Local Exec" TLS model and thus use a different thread-local address. Moving this to `allocate_stack_0` in `libia2` forces it to use the correct GOT thread local.

This is a workaround to #457, but doesn't actually fix the root issue, so I'm not sure if we should merge it instead of fixing #457 properly. But it does successfully prevent compartmentalized `dav1d` from segfaulting, and thus is included in #454.