### PR TITLE
Tag accesses to stack pointer TLS locations in call gates

### DIFF
--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -355,6 +355,10 @@ static void emit_switch_stacks(AsmWriter &aw, int old_pkey, int new_pkey, Arch a
     add_asm_line(aw, "adrp x10, :gottprel:ia2_stackptr_"s + std::to_string(old_pkey));
     add_asm_line(aw, "ldr x10, [x10, #:gottprel_lo12:ia2_stackptr_"s + std::to_string(old_pkey) + "]");
     add_asm_line(aw, "add x10, x10, x9");
+    // Tag the pointer with the old pkey
+    if (old_pkey != 0) {
+            add_asm_line(aw, llvm::formatv("orr x10, x10, #{0:x}00000000000000", old_pkey));
+    }
     add_comment_line(aw, "Write old stack pointer to memory");
     // Keep the old stack pointer in x12
     add_asm_line(aw, "mov x12, sp");
@@ -364,6 +368,10 @@ static void emit_switch_stacks(AsmWriter &aw, int old_pkey, int new_pkey, Arch a
     add_asm_line(aw, "adrp x10, :gottprel:ia2_stackptr_"s + std::to_string(new_pkey));
     add_asm_line(aw, "ldr x10, [x10, #:gottprel_lo12:ia2_stackptr_"s + std::to_string(new_pkey) + "]");
     add_asm_line(aw, "add x10, x10, x9");
+    // Tag the pointer with the new pkey
+    if (new_pkey != 0) {
+            add_asm_line(aw, llvm::formatv("orr x10, x10, #{0:x}00000000000000", new_pkey));
+    }
     add_comment_line(aw, "Read new stack pointer from memory");
     add_asm_line(aw, "ldr x11, [x10]");
     add_asm_line(aw, "mov sp, x11");


### PR DESCRIPTION
We previously observed the following:
```
Thread 2.1 received signal SIGSEGV, Segmentation fault
Memory tag violation while accessing address 0x00007ffff7f92028
Allocation tag 0x2
Logical tag 0x0.
[Switching to Thread 1089820.1089820]
0x00007ffff57d0a6c in __wrap_recurse_dso ()
   from build-aarch64-compiler-rt/tests/recursion/librecursion_call_gates.so
(gdb) bt
#0  0x00007ffff57d0a6c in __wrap_recurse_dso ()
   from build-aarch64-compiler-rt/tests/recursion/librecursion_call_gates.so
#1  0x00007ffff7f9f944 in recurse_main ()
#2  0x00007ffff7f9f964 in fake_criterion_recursion_main ()
#3  0x00007ffff7fa153c in main ()
(gdb) disassemble 
Dump of assembler code for function __wrap_recurse_dso:
   0x00007ffff57d0a14 <+0>:	stp	x29, x30, [sp, #-16]!
   0x00007ffff57d0a18 <+4>:	mov	x29, sp
   0x00007ffff57d0a1c <+8>:	sub	sp, sp, #0x50
   0x00007ffff57d0a20 <+12>:	str	x19, [sp]
   0x00007ffff57d0a24 <+16>:	str	x20, [sp, #8]
   0x00007ffff57d0a28 <+20>:	str	x21, [sp, #16]
   0x00007ffff57d0a2c <+24>:	str	x22, [sp, #24]
   0x00007ffff57d0a30 <+28>:	str	x23, [sp, #32]
   0x00007ffff57d0a34 <+32>:	str	x24, [sp, #40]
   0x00007ffff57d0a38 <+36>:	str	x25, [sp, #48]
   0x00007ffff57d0a3c <+40>:	str	x26, [sp, #56]
   0x00007ffff57d0a40 <+44>:	str	x27, [sp, #64]
   0x00007ffff57d0a44 <+48>:	str	x28, [sp, #72]
   0x00007ffff57d0a48 <+52>:	mrs	x9, tpidr_el0
   0x00007ffff57d0a4c <+56>:	adrp	x10, 0x7ffff57ef000
   0x00007ffff57d0a50 <+60>:	ldr	x10, [x10, #4040]
   0x00007ffff57d0a54 <+64>:	add	x10, x10, x9
   0x00007ffff57d0a58 <+68>:	mov	x12, sp
   0x00007ffff57d0a5c <+72>:	str	x12, [x10]
   0x00007ffff57d0a60 <+76>:	adrp	x10, 0x7ffff57ef000
   0x00007ffff57d0a64 <+80>:	ldr	x10, [x10, #4072]
   0x00007ffff57d0a68 <+84>:	add	x10, x10, x9
=> 0x00007ffff57d0a6c <+88>:	ldr	x11, [x10]
   0x00007ffff57d0a70 <+92>:	mov	sp, x11
   0x00007ffff57d0a74 <+96>:	str	x0, [sp, #-16]!
   0x00007ffff57d0a78 <+100>:	bl	0x7ffff57d09a0 <__libia2_scrub_registers>
   0x00007ffff57d0a7c <+104>:	ldr	x0, [sp]
   0x00007ffff57d0a80 <+108>:	add	sp, sp, #0x10
   0x00007ffff57d0a84 <+112>:	mov	x18, #0x200000000000000     	// #144115188075855872
   0x00007ffff57d0a88 <+116>:	bl	0x7ffff57d07f0 <recurse_dso@plt>
   0x00007ffff57d0a8c <+120>:	mrs	x9, tpidr_el0
   0x00007ffff57d0a90 <+124>:	adrp	x10, 0x7ffff57ef000
   0x00007ffff57d0a94 <+128>:	ldr	x10, [x10, #4072]
   0x00007ffff57d0a98 <+132>:	add	x10, x10, x9
   0x00007ffff57d0a9c <+136>:	mov	x12, sp
```

These TLS accesses to load/save the stack pointer are untagged. I'm actually unsure how the first one of these succeeded, as it should have failed due to accessing `ia2_stackptr_1` without a tagged pointer.

For reference, this is the asm source of this call gate (before this PR):
```C
#include <ia2.h>
#include <scrub_registers.h>
void *ia2_fn_ptr;
asm(
    /* Wrapper for recurse_dso(int): */
    ".text\n"
    ".global __wrap_recurse_dso\n"
    ".type __wrap_recurse_dso, @function\n"
    "__wrap_recurse_dso:\n"
    "stp x29, x30, [sp, #-16]!\n"
    "mov x29, sp\n"
    "sub sp, sp, #80\n"
    "str x19, [sp, #0]\n"
    "str x20, [sp, #8]\n"
    "str x21, [sp, #16]\n"
    "str x22, [sp, #24]\n"
    "str x23, [sp, #32]\n"
    "str x24, [sp, #40]\n"
    "str x25, [sp, #48]\n"
    "str x26, [sp, #56]\n"
    "str x27, [sp, #64]\n"
    "str x28, [sp, #72]\n"
    /* Compute location to save old stack pointer in x10 */
    "mrs x9, tpidr_el0\n"
    "adrp x10, :gottprel:ia2_stackptr_1\n"
    "ldr x10, [x10, #:gottprel_lo12:ia2_stackptr_1]\n"
    "add x10, x10, x9\n"
    /* Write old stack pointer to memory */
    "mov x12, sp\n"
    "str x12, [x10]\n"
    /* Compute location to load new stack pointer in x10 */
    "adrp x10, :gottprel:ia2_stackptr_2\n"
    "ldr x10, [x10, #:gottprel_lo12:ia2_stackptr_2]\n"
    "add x10, x10, x9\n"
    /* Read new stack pointer from memory */
    "ldr x11, [x10]\n"
    "mov sp, x11\n"
    /* Preserve essential regs on stack */
    "str x0, [sp, #-16]!\n"
    /* Scrub non-essential regs */
    "bl __libia2_scrub_registers\n"
    /* Restore preserved regs */
    "ldr x0, [sp]\n"
    "add sp, sp, #16\n"
    "movz x18, #0x0200, LSL #48\n"
    /* Call wrapped function */
    "bl recurse_dso\n"
    /* Compute location to save old stack pointer in x10 */
    "mrs x9, tpidr_el0\n"
    "adrp x10, :gottprel:ia2_stackptr_2\n"
    "ldr x10, [x10, #:gottprel_lo12:ia2_stackptr_2]\n"
    "add x10, x10, x9\n"
    /* Write old stack pointer to memory */
    "mov x12, sp\n"
    "str x12, [x10]\n"
    /* Compute location to load new stack pointer in x10 */
    "adrp x10, :gottprel:ia2_stackptr_1\n"
    "ldr x10, [x10, #:gottprel_lo12:ia2_stackptr_1]\n"
    "add x10, x10, x9\n"
    /* Read new stack pointer from memory */
    "ldr x11, [x10]\n"
    "mov sp, x11\n"
    /* Scrub non-essential regs */
    "bl __libia2_scrub_registers\n"
    "movz x18, #0x0100, LSL #48\n"
    "ldr x19, [sp, #0]\n"
    "ldr x20, [sp, #8]\n"
    "ldr x21, [sp, #16]\n"
    "ldr x22, [sp, #24]\n"
    "ldr x23, [sp, #32]\n"
    "ldr x24, [sp, #40]\n"
    "ldr x25, [sp, #48]\n"
    "ldr x26, [sp, #56]\n"
    "ldr x27, [sp, #64]\n"
    "ldr x28, [sp, #72]\n"
    "add sp, sp, #80\n"
    "ldp x29, x30, [sp], #16\n"
    /* Return to the caller */
    "ret\n"
    ".size __wrap_recurse_dso, .-__wrap_recurse_dso\n"
    ".previous\n"
);
```