### PR TITLE
libia2: WIP Make signal handler macro x86-only

### DIFF
--- a/runtime/libia2/include/ia2.h
+++ b/runtime/libia2/include/ia2.h
@@ -49,7 +49,10 @@
 #define IA2_CAST(func, ty) (ty) (void *) func
 #else
 #define IA2_DEFINE_WRAPPER(func) IA2_DEFINE_WRAPPER_##func
+
+#if defined(__x86_64__)
 #define IA2_SIGHANDLER(func) ia2_sighandler_##func
+
 /// Create a wrapped signal handler for `sa_sigaction`
 ///
 /// Wraps the given function with `pkey`, creating a handler for use with
@@ -59,9 +62,10 @@
 ///
 /// Creates a new function with `ia2_sighandler_` prepended to the given
 /// function name which should be registered with sigaction().
-#define IA2_DEFINE_SIGACTION(function, pkey)                                   \
-  void ia2_sighandler_##function(int, siginfo_t *, void *);                    \
-  _IA2_DEFINE_SIGNAL_HANDLER(function, pkey)
+#define IA2_DEFINE_SIGACTION(function, pkey)                                        \
+  __attribute__((naked)) void ia2_sighandler_##function(int, siginfo_t *, void *) { \
+  _IA2_DEFINE_SIGNAL_HANDLER(function, pkey)                                        \
+  }
 
 /// Create a wrapped signal handler for `sa_handler`
 ///
@@ -73,8 +77,10 @@
 /// Creates a new function with `ia2_sighandler_` prepended to the given
 /// function name which should be registered with sigaction().
 #define IA2_DEFINE_SIGHANDLER(function, pkey)                                  \
-  void ia2_sighandler_##function(int);                                         \
-  _IA2_DEFINE_SIGNAL_HANDLER(function, pkey)
+  __attribute__((naked)) void ia2_sighandler_##function(int) {                 \
+  _IA2_DEFINE_SIGNAL_HANDLER(function, pkey)                                   \
+  }
+#endif // __x86_64__
 
 /// Initialize the IA2 runtime, must only be invoked once per in a process
 ///

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -107,9 +107,7 @@ struct dl_phdr_info;
 /* clang-format off */
 #if defined(__x86_64__)
 #define _IA2_DEFINE_SIGNAL_HANDLER(function, pkey)    \
-    __asm__(".global ia2_sighandler_" #function "\n"  \
-            "ia2_sighandler_" #function ":\n"         \
-            "movq %rcx, %r10\n"                       \
+    __asm__("movq %rcx, %r10\n"                       \
             "movq %rdx, %r11\n"                       \
             "movq %rax, %r12\n"                       \
             "xorl %ecx, %ecx\n"                       \
@@ -119,13 +117,7 @@ struct dl_phdr_info;
             "movq %r12, %rax\n"                       \
             "movq %r11, %rdx\n"                       \
             "movq %r10, %rcx\n"                       \
-            "jmp " #function "\n")
-#elif defined(__aarch64__)
-#define _IA2_DEFINE_SIGNAL_HANDLER(function, tag)    \
-    __asm__(".global ia2_sighandler_" #function "\n" \
-            "ia2_sighandler_" #function ":\n"        \
-            "movz_shifted_tag_x18 " #tag "\n"        \
-            "b " #function "\n")
+            "jmp " #function "\n");
 #endif
 /* clang-format on */
 


### PR DESCRIPTION
edit: When I opened this PR I initially thought that we wouldn't need a signal handler wrapper for ARM but I think that's wrong and the wrapper we currently have is correct so I'll need to find a different way to make misusing IA2_DEFINE_WRAPPER an error.