### PR TITLE
rewriter: support the 6 x86 param regs for post condition functions

### DIFF
--- a/tests/post_condition/Output/dav1d.out
+++ b/tests/post_condition/Output/dav1d.out
@@ -1,1 +1,2 @@
 dav1d_get_picture post condition ran
+negative stride

--- a/tests/post_condition/dav1d.c
+++ b/tests/post_condition/dav1d.c
@@ -11,6 +11,9 @@ int dav1d_get_picture(Dav1dContext *const c, Dav1dPicture *const out) {
     return 0;
 }
 
-void dav1d_get_picture_post_condition() {
+void dav1d_get_picture_post_condition(Dav1dContext *const c, Dav1dPicture *const out) {
     cr_log_info("dav1d_get_picture post condition ran");
+    if (out->stride[0] < 0) {
+        cr_log_info("negative stride");
+    }
 }

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -1037,6 +1037,8 @@ std::string emit_asm_wrapper(AbiSignature &sig,
   add_asm_line(aw, ".type "s + wrapper_name + ", @function");
   add_asm_line(aw, wrapper_name + ":");
 
+  // Note that when there's a post condition call,
+  // the prologue needs to undo the `pushq`s added in `emit_prologue` to save the register params.
   emit_prologue(aw, caller_pkey, target_pkey, arch, target_post_condition_name.has_value());
 
   if (arch == Arch::X86) {

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -494,6 +494,10 @@ static void emit_prologue(AsmWriter &aw, uint32_t caller_pkey, uint32_t target_p
       // TODO(performance): We could store by pairs (STP)
       add_asm_line(aw, "str "s + aarch64_preserved_registers[i] + ", [sp, #" + std::to_string(i * 8) + "]");
     }
+
+    if (save_param_regs) {
+      llvm::report_fatal_error("--enable-dav1d_get_picture-post-condition is not yet supported on aarch64");
+    }
   }
 }
 


### PR DESCRIPTION
This is done by pushing the param regs onto the stack in the prologue (if there's a post condition function), and then popping them before we call the post condition function.

Next we'll work on supporting more than the 6 param regs, as well as passing the return value.