### PR TITLE
tests: replace `fake_criterion_tests` section with `__attribute__((constructor))`s adding to a linked list, fixing the padding bug

### DIFF
--- a/misc/test_runner/include/ia2_test_runner.h
+++ b/misc/test_runner/include/ia2_test_runner.h
@@ -17,10 +17,15 @@ typedef void (*ia2_test_fn)(void);
 #endif
 
 struct fake_criterion_test {
+  const char *suite;
+  const char *name;
   ia2_test_fn test;
   ia2_test_fn init;
   int exit_code;
 };
+
+#define _STRINGIFY(a) #a
+#define STRINGIFY(a) _STRINGIFY(a)
 
 /*
  * Placing IA2_{BEGIN,END}_NO_WRAP between the function declaration stops the rewriter from creating a
@@ -28,14 +33,16 @@ struct fake_criterion_test {
  * that reference it like the RHS when initializing struct fake_criterion_test's test field. The
  * last line of this macro is the start of the test function's definition and should be followed by { }
  */
-#define Test(suite, name, ...)                                                                                                 \
-  IA2_BEGIN_NO_WRAP                                                                                                            \
-  void fake_criterion_##suite##_##name(void);                                                                                  \
-  IA2_END_NO_WRAP                                                                                                              \
-  __attribute__((__section__("fake_criterion_tests"))) struct fake_criterion_test fake_criterion_##suite##_##name##_##test = { \
-      .test = fake_criterion_##suite##_##name,                                                                                 \
-      ##__VA_ARGS__};                                                                                                          \
-  void fake_criterion_##suite##_##name(void)
+#define Test(suite_, name_, ...)                                                                                                 \
+  IA2_BEGIN_NO_WRAP                                                                                                              \
+  void fake_criterion_##suite_##_##name_(void);                                                                                  \
+  IA2_END_NO_WRAP                                                                                                                \
+  __attribute__((__section__("fake_criterion_tests"))) struct fake_criterion_test fake_criterion_##suite_##_##name_##_##test = { \
+      .suite = STRINGIFY(suite_),                                                                                                \
+      .name = STRINGIFY(name_),                                                                                                  \
+      .test = fake_criterion_##suite_##_##name_,                                                                                 \
+      ##__VA_ARGS__};                                                                                                            \
+  void fake_criterion_##suite_##_##name_(void)
 
 #define cr_log_info(f, ...) printf(f "\n", ##__VA_ARGS__)
 #define cr_log_error(f, ...) fprintf(stderr, f "\n", ##__VA_ARGS__)

--- a/misc/test_runner/include/ia2_test_runner.h
+++ b/misc/test_runner/include/ia2_test_runner.h
@@ -1,10 +1,10 @@
 #pragma once
+#include <assert.h>
 #include <ia2.h>
-#include <stdio.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <assert.h>
 
 /*
  * Tests should include this header without defining the following macro to avoid rewriting function
@@ -53,14 +53,14 @@ struct fake_criterion_test {
  * Configure the signal handler to expect an mpk violation when `expr` is evaluated. If `expr`
  * doesn't trigger a fault, the process exits with a non-zero exit status.
  */
-#define CHECK_VIOLATION(expr)                                                  \
-  ({                                                                           \
-    expect_fault = true;                                                       \
-    asm volatile("" : : : "memory");                                           \
-    volatile typeof(expr) _tmp = expr;                                         \
-    printf("CHECK_VIOLATION: did not seg fault as expected\n");                \
-    _exit(1);                                                                  \
-    _tmp;                                                                      \
+#define CHECK_VIOLATION(expr)                                   \
+  ({                                                            \
+    expect_fault = true;                                        \
+    asm volatile("" : : : "memory");                            \
+    volatile typeof(expr) _tmp = expr;                          \
+    printf("CHECK_VIOLATION: did not seg fault as expected\n"); \
+    _exit(1);                                                   \
+    _tmp;                                                       \
   })
 
 extern bool expect_fault;

--- a/misc/test_runner/test_runner.c
+++ b/misc/test_runner/test_runner.c
@@ -45,7 +45,7 @@ __attribute__((naked)) void handle_segfault(int sig) {
 #warning "Review test_fault_handler implementation after enabling x18 switching"
 void print_mpk_message(int sig);
 void handle_segfault(int sig) {
-    print_mpk_message(sig);
+  print_mpk_message(sig);
 }
 #endif
 
@@ -109,7 +109,7 @@ int main() {
       perror("waitpid");
       return 2;
     }
-    if WIFSIGNALED(stat) {
+    if WIFSIGNALED (stat) {
       fprintf(stderr, "forked test child was terminated by signal %d\n", WTERMSIG(stat));
       return 1;
     }

--- a/misc/test_runner/test_runner.c
+++ b/misc/test_runner/test_runner.c
@@ -8,8 +8,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-extern struct fake_criterion_test __start_fake_criterion_tests;
-extern struct fake_criterion_test __stop_fake_criterion_tests;
+struct fake_criterion_test *fake_criterion_tests IA2_SHARED_DATA = NULL;
 
 /* This is shared data to allow checking for violations from different compartments */
 bool expect_fault IA2_SHARED_DATA = false;
@@ -83,12 +82,8 @@ int main() {
    * invocation of the Test macro
    */
   sigaction(SIGSEGV, &act, NULL);
-  struct fake_criterion_test *test_info = &__start_fake_criterion_tests;
-  for (; test_info < &__stop_fake_criterion_tests; test_info++) {
+  for (struct fake_criterion_test *test_info = fake_criterion_tests; test_info; test_info = test_info->next) {
     fprintf(stderr, "running suite '%s' test '%s'...\n", test_info->suite, test_info->name);
-    if (!test_info->test) {
-      break;
-    }
     pid_t pid = fork();
     bool in_child = pid == 0;
     if (in_child) {

--- a/misc/test_runner/test_runner.c
+++ b/misc/test_runner/test_runner.c
@@ -85,6 +85,7 @@ int main() {
   sigaction(SIGSEGV, &act, NULL);
   struct fake_criterion_test *test_info = &__start_fake_criterion_tests;
   for (; test_info < &__stop_fake_criterion_tests; test_info++) {
+    fprintf(stderr, "running suite '%s' test '%s'...\n", test_info->suite, test_info->name);
     if (!test_info->test) {
       break;
     }


### PR DESCRIPTION

* Fixes #473.


The previous way of appending `struct fake_criterion_test`s by putting them into a section was buggy because extra padding was added between the elements in the section, so iterating through them from `__{start,stop}_fake_criterion_tests` didn't work correctly.

This new way uses `__attribute__((constructor))` to add each `struct fake_criterion_test` to a singly linked list. A singly linked list is used for simplicity, though it does mean the tests are run in reverse order within a file, but I don't really think the test order should matter, so this should be okay.

I also added the suite and test name to `struct fake_criterion_test` and print them out when running tests, which was helpful in distinguishing which tests were being run.