### PR TITLE
Canonicalize input paths in source rewriter

### DIFF
--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -72,13 +72,13 @@ struct DirectoryParser : public llvm::cl::parser<std::string> {
       llvm::errs() << "error: directory does not exist: " << dir << "\n";
       return true; // true on error
     }
-    auto ec = llvm::sys::fs::make_absolute(dir);
+    llvm::SmallString<PATH_MAX> real_path;
+    auto ec = llvm::sys::fs::real_path(dir, real_path);
     if (ec) {
       llvm::errs() << ec.message() << '\n';
       return true;
     }
-    llvm::sys::path::remove_dots(dir, true);
-    Value = std::string(dir);
+    Value = std::string(real_path);
     return false;
   }
 };

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -77,6 +77,7 @@ struct DirectoryParser : public llvm::cl::parser<std::string> {
       llvm::errs() << ec.message() << '\n';
       return true;
     }
+    llvm::sys::path::remove_dots(dir, true);
     Value = std::string(dir);
     return false;
   }


### PR DESCRIPTION
Make `RootDirectory` and `OutputDirectory` canonical paths immediately after reading CLI args.  #432 makes them absolute, but we need them to be fully canonical to reliably compare.