### PR TITLE
Add documentation for linker errors around `static` functions and linker scripts

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -184,14 +184,17 @@ IA2_CAST(func, ty) // Get a struct of type `ty` pointing to `func`'s wrapper
 
 ## `static` Function Pointers
 
-If a `static` function is used as an address-taken function for cross-compartment calls, then the rewriter needs to add `__attribute__((used))` to the function declaration in order for it to link correctly with the generated callgates. Normally the rewriter can achieve this, but if the `static` keyword comes from a macro the rewriter will not be able to insert the attribute. For example:
+If a `static` function is used as an address-taken function for
+cross-compartment calls, then the rewriter needs to add `__attribute__((used))`
+to the function declaration in order for it to link correctly with the generated
+callgates. Normally the rewriter can achieve this, but if the `static` keyword
+comes from a macro the rewriter will not be able to insert the attribute. For
+example:
 
 ```c
 #define local static
 local void function() {}
 ```
-
-The same issue can happen when using 
 
 If this pattern occurs in your code, you can remove the `static` modifier or add
 `__attribute__((used))` manually post-rewriter.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -298,6 +298,6 @@ If you're seeing errors along the lines of:
 
 Then IA2 needs `foo` to not be marked local.
 
-Note also that an `__attribute__((visibility ("hidden")))` annotation can have
+Note also that an `__attribute__((visibility("hidden")))` annotation can have
 the same effect as hiding the symbol in a linker script. Such annotation will
-have to be removed to work in a containerized app.
+have to be removed to work in a compartmentalized app.


### PR DESCRIPTION
This (at least partially) addresses #414 and #415 by adding docs around those potential error cases. This covers the cases that I ran into working on zlib.