### PR TITLE
tests: add a `type_confusion` test w/ type confusion detection stubbed out

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,4 +96,5 @@ if (NOT LIBIA2_AARCH64)
     add_subdirectory(permissive_mode)
 
     add_subdirectory(post_condition)
+    add_subdirectory(type_confusion)
 endif()

--- a/tests/type_confusion/CMakeLists.txt
+++ b/tests/type_confusion/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Build the wrapped lib
+define_shared_lib(
+    SRCS dav1d.c
+    PKEY 2
+)
+
+# Build the test
+define_test(
+    SRCS main.c
+    PKEY 1
+    NEEDS_LD_WRAP
+    CRITERION_TEST
+)
+
+# Build the wrapper lib
+define_ia2_wrapper()

--- a/tests/type_confusion/dav1d.c
+++ b/tests/type_confusion/dav1d.c
@@ -1,0 +1,28 @@
+/*
+RUN: cat dav1d_call_gates_1.ld | FileCheck --check-prefix=LINKARGS %s
+*/
+
+#include "dav1d.h"
+#include <ia2_test_runner.h>
+
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>
+
+// LINKARGS: --wrap=dav1d_open
+int dav1d_open(Dav1dContext **const c_out, const Dav1dSettings *const s) {
+  return 0;
+}
+
+// LINKARGS: --wrap=dav1d_close
+void dav1d_close(Dav1dContext **const c_out) {
+  return;
+}
+
+// LINKARGS: --wrap=dav1d_get_picture
+int dav1d_get_picture(Dav1dContext *const c, Dav1dPicture *const out) {
+  return 0;
+}
+
+void dav1d_get_picture_post_condition(Dav1dContext *const c, Dav1dPicture *const out) {
+  return;
+}

--- a/tests/type_confusion/include/dav1d.h
+++ b/tests/type_confusion/include/dav1d.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stddef.h>
+
+typedef struct {
+  int field;
+} Dav1dContext;
+
+typedef struct Dav1dSettings {
+  int field;
+} Dav1dSettings;
+
+typedef struct {
+  ptrdiff_t stride[2];
+} Dav1dPicture;
+
+int dav1d_open(Dav1dContext **const c_out, const Dav1dSettings *const s);
+
+void dav1d_close(Dav1dContext **const c_out);
+
+int dav1d_get_picture(Dav1dContext *c, Dav1dPicture *out);

--- a/tests/type_confusion/main.c
+++ b/tests/type_confusion/main.c
@@ -1,0 +1,35 @@
+/*
+RUN: sh -c 'if [ ! -s "dav1d_call_gates_0.ld" ]; then echo "No link args as expected"; exit 0; fi; echo "Unexpected link args"; exit 1;'
+*/
+
+// Check that readelf shows exactly one executable segment
+
+#include "dav1d.h"
+#include <ia2.h>
+#include <ia2_test_runner.h>
+
+#include <signal.h>
+
+INIT_RUNTIME(2);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
+
+Dav1dContext *c IA2_SHARED_DATA;
+Dav1dSettings settings IA2_SHARED_DATA;
+Dav1dPicture pic IA2_SHARED_DATA;
+Dav1dContext c2 IA2_SHARED_DATA;
+
+Test(type_confusion, normal) {
+  dav1d_open(&c, &settings);
+  dav1d_get_picture(c, &pic);
+  dav1d_close(&c);
+}
+
+Test(type_confusion, type_confusion,
+     //  .signal = SIGABRT, // TODO turn on once type confusion checking is working
+) {
+  dav1d_open(&c, &settings);
+  // Try to use another `Dav1dContext` that hasn't been constructed/opened yet.
+  dav1d_get_picture(&c2, &pic);
+  dav1d_close(&c);
+}


### PR DESCRIPTION
This is for the type confusion detection API we'll be adding as a potential pre/post-condition check.  This is the basic test for it before implementing the detection.