### PR TITLE
ARM: Align stack pointer to support SCTLR_EL1.SA0

### DIFF
--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -271,12 +271,12 @@ asm(".macro movz_shifted_tag_x18 tag\n"
         "mov x9, sp\n"                                                         \
         /* switch to newly allocated stack */                                  \
         "mov sp, %0\n"                                                         \
-        /* push old stack pointer to new stack */                              \
-        "str x9, [sp], #-8\n"                                                  \
+        /* push sp in x9 and a dummy reg to keep new stack 16-byte aligned */  \
+        "stp x9, x10, [sp, #-16]!\n"                                           \
         /* initialize TLS */                                                   \
         "bl init_tls_" #i "\n"                                                 \
         /* pop old stack pointer from new stack */                             \
-        "ldr x9, [sp, #8]!\n"                                                  \
+        "ldp x9, x10, [sp], #16\n"                                             \
         /* save pointer to new stack */                                        \
         "mov x10, sp\n"                                                        \
         /* switch to old stack */                                              \


### PR DESCRIPTION
It seems that the pixel's kernel sets `SCTLR_EL1.SA0` (unconditionally?) so stack accesses at EL0 must be aligned to 16 bytes. This fixes a few accesses in our handwritten asm to enable running the minimal test on MTE-enabled hardware. There are likely some stack accesses in the callgates that also need to be fixed and I'd like to fix the TODO in `allocate_stack` before merging this (@fw-immunant any ideas there?). I checked that when the minimal test binary is run from a tmpfs MTE protection for its writeable file-backed mappings are enforced (see #469).