### PR TITLE
rewriter: wrap callgate header in `#ifndef __ASSEMBLER__` so it doesn't get interpreted as asm

### DIFF
--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -1214,9 +1214,11 @@ int main(int argc, const char **argv) {
     return rc;
   }
 
+  header_out << "#ifndef __ASSEMBLER__\n";
+  header_out << '\n';
+
   header_out << "#include <ia2.h>\n";
   header_out << "#include <scrub_registers.h>\n";
-
   header_out << '\n';
 
   wrapper_out << "#include <ia2.h>\n";
@@ -1531,6 +1533,9 @@ int main(int argc, const char **argv) {
   header_out << "asm(\"__libia2_abort:\\n\"\n"
              << "    \"" << undef_insn << "\");\n";
   header_out << macros_defining_wrappers.c_str();
+
+  header_out << '\n';
+  header_out << "#endif\n";
 
   for (int i = 0; i < num_pkeys; i++) {
     if (ld_args_out[i] != nullptr) {


### PR DESCRIPTION
In `meson`, `*.S` asm files are pre-processed with the C preprocessor, and thus C flags are used to compile `*.S` asm files (unlike `*.s` asm files). To fix this on the `meson` side, we'd have to manually add args to each target instead of using `add_project_arguments(args, language: 'c')`, so this way is simpler.