### PR TITLE
test_runner: ensure no signal with an expected signal is an error

### DIFF
--- a/misc/test_runner/include/ia2_test_runner.h
+++ b/misc/test_runner/include/ia2_test_runner.h
@@ -23,6 +23,7 @@ struct fake_criterion_test {
   ia2_test_fn test;
   ia2_test_fn init;
   int exit_code;
+  int signal;
 };
 
 extern struct fake_criterion_test *fake_criterion_tests;

--- a/misc/test_runner/include/ia2_test_runner.h
+++ b/misc/test_runner/include/ia2_test_runner.h
@@ -28,8 +28,8 @@ struct fake_criterion_test {
 
 extern struct fake_criterion_test *fake_criterion_tests;
 
-#define _STRINGIFY(a) #a
-#define STRINGIFY(a) _STRINGIFY(a)
+#define STRINGIFY(a) #a
+#define EXPAND_AND_STRINGIFY(a) STRINGIFY(a)
 
 /*
  * Placing IA2_{BEGIN,END}_NO_WRAP between the function declaration stops the rewriter from creating a
@@ -43,8 +43,8 @@ extern struct fake_criterion_test *fake_criterion_tests;
   IA2_END_NO_WRAP                                                                           \
   struct fake_criterion_test fake_criterion_##suite_##_##name_##_##test IA2_SHARED_DATA = { \
       .next = NULL,                                                                         \
-      .suite = STRINGIFY(suite_),                                                           \
-      .name = STRINGIFY(name_),                                                             \
+      .suite = EXPAND_AND_STRINGIFY(suite_),                                                           \
+      .name = EXPAND_AND_STRINGIFY(name_),                                                             \
       .test = fake_criterion_##suite_##_##name_,                                            \
       ##__VA_ARGS__};                                                                       \
   __attribute__((constructor)) void fake_criterion_add_##suite_##_##name_##_##test(void) {  \

--- a/misc/test_runner/test_runner.c
+++ b/misc/test_runner/test_runner.c
@@ -123,6 +123,13 @@ int main() {
   for (i = 0; i < num_tests; i++) {
     const struct fake_criterion_test *test = &tests[i];
 
+    if (single_test_name) {
+      if (strcmp(test->name, single_test_name) != 0) {
+        continue;
+      }
+      fprintf(stderr, "running single test alone (exit status will not be checked):\n");
+    }
+
     fprintf(stderr, "running suite '%s' test '%s', expecting ", test->suite, test->name);
     if (test->signal != 0) {
       fprintf(stderr, "signal %d (SIG%s)", test->signal, sigabbrev_np(test->signal));
@@ -135,13 +142,6 @@ int main() {
       }
     }
     fprintf(stderr, "...\n");
-
-    if (single_test_name) {
-      if (strcmp(test->name, single_test_name) != 0) {
-        continue;
-      }
-      fprintf(stderr, "running single test alone (exit status will not be checked):\n");
-    }
 
     /* Do not fork or check exit status if only running one test. */
     pid_t pid = 0;

--- a/misc/test_runner/test_runner.c
+++ b/misc/test_runner/test_runner.c
@@ -106,8 +106,8 @@ int main() {
       if (test->exit_code != 0) {
         fprintf(stderr, "can't expect both signal %d (SIG%s) and exit status %d\n",
                 test->signal, sigabbrev_np(test->signal), test->exit_code);
+        return EXIT_FAILURE;
       }
-      assert(test->exit_code == 0);
       // Sometimes the signal doesn't show up with `WIFSIGNALED`,
       // so we check the exit status as well.
       test->exit_code = 128 + test->signal;

--- a/tests/post_condition/main.c
+++ b/tests/post_condition/main.c
@@ -21,7 +21,7 @@ Test(post_condition, normal) {
   dav1d_get_picture(&c, &pic);
 }
 
-Test(post_condition, corrupt_bounds, .exit_code = 128 + SIGABRT) {
+Test(post_condition, corrupt_bounds, .signal = SIGABRT) {
   corrupt_stride = true;
   dav1d_get_picture(&c, &pic);
 }


### PR DESCRIPTION
This reworks the test runner to be more rigourous in checking signals and exit codes.

For one, either `.signal` xor `.exit_code` should be set to non-zero, and setting both is now an error.

The error messages are clearer and more consistent now, too, as is the logic.