### PR TITLE
ci: add `ligglib2.0-dev` to `aarch64-wip-test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
             libclang-15-dev
             zlib1g-dev
             libcapstone-dev
+            libglib2.0-dev
           version: 1.0 # version of cache to load
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
There are errors about not finding `glib-2.0`; hopefully this fixes it.