### PR TITLE
Fix translation of literal 0 in function pointer assignment/comparison

### DIFF
--- a/tests/rewrite_fn_ptr_eq/main.c
+++ b/tests/rewrite_fn_ptr_eq/main.c
@@ -84,6 +84,16 @@ Test(rewrite_fn_ptr_eq, main) {
     // REWRITER: fn = (typeof(fn)) { NULL };
     fn = NULL;
 
+    // Do we handle custom NULL defines?
+#define IA2NULL 0
+
+    // REWRITER: fn = (typeof(fn)) { 0 };
+    fn = IA2NULL;
+
+    // What about a cast combined with a null macro?
+    // REWRITER: fn = (typeof(fn)) { 0 };
+    fn = (typeof(fn)) IA2NULL;
+
     // the following tests don't use NULL so the rewriter output shouldn't rely on it either
 #undef NULL
     // REWRITER: bin_op fn3 = { 0 };

--- a/tests/rewrite_fn_ptr_eq/main.c
+++ b/tests/rewrite_fn_ptr_eq/main.c
@@ -27,8 +27,12 @@ Test(rewrite_fn_ptr_eq, main) {
     int res;
     int *y = &res;
     void *x = NULL;
+    // REWRITER: bin_op fn = IA2_FN(add);
     bin_op fn = add;
+    // REWRITER: bin_op fn2 = { NULL };
     bin_op fn2 = NULL;
+    // REWRITER: bin_op fn3 = { 0 };
+    bin_op fn3 = 0;
 
     // Check that pointers for types other than functions are not rewritten
     // REWRITER: if (y) { }
@@ -78,4 +82,28 @@ Test(rewrite_fn_ptr_eq, main) {
     if (y || !fn) { }
     // REWRITER: if (x && IA2_ADDR(fn) && y) { }
     if (x && fn && y) { }
+
+    // REWRITER: fn = (typeof(fn)) { NULL };
+    fn = NULL;
+
+    // the next test doesn't use NULL so the rewriter output shouldn't rely on it either
+//#undef NULL
+    // REWRITER: fn = (typeof(fn)) { 0 };
+    fn = 0;
+
+    // check that literal zeroes aren't rewritten if not cast to function pointers
+    // REWRITER: res = 0;
+    res = 0;
+
+    // REWRITER: if (IA2_ADDR(fn) == 0) { }
+    if (fn == 0) { }
+
+    // REWRITER: if (IA2_ADDR(mod.fn) == 0) { }
+    if (mod.fn == 0) { }
+
+    // REWRITER: if (IA2_ADDR(fn) == 0) { }
+    if (fn == (typeof(fn))0) { }
+
+    // REWRITER: if (IA2_ADDR(mod.fn) == 0) { }
+    if (mod.fn == (typeof(fn))0) { }
 }

--- a/tests/rewrite_fn_ptr_eq/main.c
+++ b/tests/rewrite_fn_ptr_eq/main.c
@@ -31,8 +31,6 @@ Test(rewrite_fn_ptr_eq, main) {
     bin_op fn = add;
     // REWRITER: bin_op fn2 = { NULL };
     bin_op fn2 = NULL;
-    // REWRITER: bin_op fn3 = { 0 };
-    bin_op fn3 = 0;
 
     // Check that pointers for types other than functions are not rewritten
     // REWRITER: if (y) { }
@@ -86,8 +84,11 @@ Test(rewrite_fn_ptr_eq, main) {
     // REWRITER: fn = (typeof(fn)) { NULL };
     fn = NULL;
 
-    // the next test doesn't use NULL so the rewriter output shouldn't rely on it either
-//#undef NULL
+    // the following tests don't use NULL so the rewriter output shouldn't rely on it either
+#undef NULL
+    // REWRITER: bin_op fn3 = { 0 };
+    bin_op fn3 = 0;
+
     // REWRITER: fn = (typeof(fn)) { 0 };
     fn = 0;
 

--- a/tests/rewrite_fn_ptr_eq/main.c
+++ b/tests/rewrite_fn_ptr_eq/main.c
@@ -89,8 +89,14 @@ Test(rewrite_fn_ptr_eq, main) {
     // REWRITER: bin_op fn3 = { 0 };
     bin_op fn3 = 0;
 
+    // REWRITER: bin_op fn4 = (typeof(fn)) { 0 };
+    bin_op fn4 = (typeof(fn)) 0;
+
     // REWRITER: fn = (typeof(fn)) { 0 };
     fn = 0;
+
+    // REWRITER: fn = (typeof(fn)) { 0 };
+    fn = (typeof(fn)) 0;
 
     // check that literal zeroes aren't rewritten if not cast to function pointers
     // REWRITER: res = 0;
@@ -103,8 +109,8 @@ Test(rewrite_fn_ptr_eq, main) {
     if (mod.fn == 0) { }
 
     // REWRITER: if (IA2_ADDR(fn) == 0) { }
-    if (fn == (typeof(fn))0) { }
+    //if (fn == (typeof(fn)) 0) { }
 
     // REWRITER: if (IA2_ADDR(mod.fn) == 0) { }
-    if (mod.fn == (typeof(fn))0) { }
+    //if (mod.fn == (typeof(fn)) 0) { }
 }

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -456,30 +456,31 @@ public:
       new_expr = "(typeof("s + lhs_binding.str() + ")) " + new_expr;
     }
 
-    clang::CharSourceRange expansion_range = sm.getExpansionRange(loc);
-
     auto &lang_opts = result.Context->getLangOpts();
     clang::SourceRange source_range = null_fn_ptr->getSourceRange();
     clang::CharSourceRange token_range = clang::CharSourceRange::getTokenRange(source_range);
     clang::CharSourceRange file_range = clang::Lexer::makeFileCharRange(token_range, sm, lang_opts);
 
-    // Decide whether to use the file range or the expansion range.
-    clang::CharSourceRange replacement_range;
-    // if (file_range.isValid()) {
-    //   replacement_range = file_range;
-    // } else {
-    //   llvm::errs() << "Falling back to expansion range" << "\n";
-    //   replacement_range = expansion_range;
-    // }
-    replacement_range = file_range;
-
-    // TODO: Remove debug logging.
     llvm::StringRef original_code = clang::Lexer::getSourceText(token_range, sm, lang_opts);
     unsigned line_number = sm.getExpansionLineNumber(loc);
+
+    // If the source range we're trying to replace isn't valid, it likely means
+    // that the expression is partially contained within a macro in such a way
+    // that we can't cleanly replace it.
+    if (!file_range.isValid()) {
+      llvm::errs()
+        << filename << ":" << line_number << ": "
+        << "Could not rewrite `" << original_code << "` to `"
+        << new_expr << "` (code may originate inside macros), this may need to be rewriten manually"
+        << "\n";
+      return;
+    }
+
+    // TODO: Remove debug logging.
     llvm::errs() << "Replacement in " << filename << ":" << line_number << ": "
                 << original_code << " replaced with " << new_expr << "\n";
 
-    Replacement old_r{sm, replacement_range, new_expr};
+    Replacement old_r{sm, file_range, new_expr};
     Replacement r = replace_new_file(filename, old_r);
     auto err = file_replacements[filename].add(r);
     if (err) {

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -461,23 +461,21 @@ public:
     clang::CharSourceRange token_range = clang::CharSourceRange::getTokenRange(source_range);
     clang::CharSourceRange file_range = clang::Lexer::makeFileCharRange(token_range, sm, lang_opts);
 
-    llvm::StringRef original_code = clang::Lexer::getSourceText(token_range, sm, lang_opts);
-    unsigned line_number = sm.getExpansionLineNumber(loc);
-
     // If the source range we're trying to replace isn't valid, it likely means
     // that the expression is partially contained within a macro in such a way
     // that we can't cleanly replace it.
     if (!file_range.isValid()) {
       llvm::errs()
-        << filename << ":" << line_number << ": "
-        << "Could not rewrite `" << original_code << "` to `"
-        << new_expr << "` (code may originate inside macros), this may need to be rewriten manually"
+        << filename << ":" << sm.getExpansionLineNumber(loc) << ": "
+        << "Could not rewrite assignment operation with `"
+        << new_expr << "` (code may originate inside macros), this needs to be rewriten manually"
         << "\n";
       return;
     }
 
     // TODO: Remove debug logging.
-    llvm::errs() << "Replacement in " << filename << ":" << line_number << ": "
+    llvm::StringRef original_code = clang::Lexer::getSourceText(token_range, sm, lang_opts);
+    llvm::errs() << "Replacement in " << filename << ":" << sm.getExpansionLineNumber(loc) << ": "
                 << original_code << " replaced with " << new_expr << "\n";
 
     Replacement old_r{sm, file_range, new_expr};

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -404,7 +404,9 @@ public:
 
     auto fn_ptr_typedef = hasType(typedefNameDecl(hasType(fn_ptr)));
 
-    auto null_expr = implicitCastExpr(ignoringParenCasts(nullPointerConstant()))
+    auto zero_literal = integerLiteral(equals(0));
+    auto null_macro = nullPointerConstant();
+    auto null_expr = implicitCastExpr(ignoringParenCasts(anyOf(null_macro, zero_literal)))
                          .bind("nullExpr");
 
     auto null_fn_ptr = varDecl(hasInitializer(null_expr),

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -412,21 +412,6 @@ public:
             implicitCastExpr(null_value),
             cStyleCastExpr(zero_literal)
         )).bind("nullExpr");
-    //auto literal_zero = implicitCastExpr(ignoringParenCasts(integerLiteral(equals(0))));
-    //auto cast_zero = cStyleCastExpr(ignoringParenCasts(integerLiteral(equals(0))));
-    //auto null_macro = implicitCastExpr(cStyleCastExpr(integerLiteral(equals(0))));
-    //auto null_expr = expr(anyOf(literal_zero, cast_zero, null_macro)).bind("nullExpr");
-    //auto literal_zero = integerLiteral(equals(0)).bind("literalZero");
-    //auto null_macro = nullPointerConstant();
-
-    //auto null_expr = expr(anyOf(
-    //    implicitCastExpr(ignoringParenCasts(null_macro)),
-    //    implicitCastExpr(zero_literal),
-        //implicitCastExpr(anyOf(zero_literal, null_macro)),
-        //cStyleCastExpr(ignoringParenCasts(anyOf(zero_literal, null_macro))))).bind("nullExpr");
-
-    //auto null_expr = implicitCastExpr(ignoringParenCasts(anyOf(null_macro, zero_literal)))
-    //                     .bind("nullExpr");
 
     auto null_fn_ptr = varDecl(hasInitializer(null_expr),
                                anyOf(fn_ptr_typedef, hasType(fn_ptr)));

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -404,7 +404,7 @@ public:
 
     auto fn_ptr_typedef = hasType(typedefNameDecl(hasType(fn_ptr)));
 
-    auto zero_literal = integerLiteral(equals(0));
+    auto zero_literal = integerLiteral(equals(0)).bind("literalZero");
     auto null_macro = nullPointerConstant();
     auto null_expr = implicitCastExpr(ignoringParenCasts(anyOf(null_macro, zero_literal)))
                          .bind("nullExpr");
@@ -420,6 +420,7 @@ public:
     refactorer.addMatcher(assign_null, this);
   }
   virtual void run(const MatchFinder::MatchResult &result) {
+    bool spelled_as_zero = result.Nodes.getNodeAs<clang::IntegerLiteral>("literalZero");
     // The two matchers both have a nullExpr node so this getNodeAs can't fail
     auto *null_fn_ptr = result.Nodes.getNodeAs<clang::Expr>("nullExpr");
     assert(null_fn_ptr != nullptr);
@@ -438,6 +439,9 @@ public:
     Filename filename = get_expansion_filename(loc, sm);
 
     std::string new_expr = "{ NULL }";
+    if (spelled_as_zero) {
+        new_expr = "{ 0 }";
+    }
     // If the matcher found an assignment add the type of the LHS variable to
     // new_expr
     if (auto *lhs_ptr = result.Nodes.getNodeAs<clang::Expr>("ptrLHS")) {
@@ -445,7 +449,7 @@ public:
           clang::CharSourceRange::getTokenRange(lhs_ptr->getSourceRange());
       auto lhs_binding =
           clang::Lexer::getSourceText(char_range, sm, ctxt.getLangOpts());
-      new_expr = "(typeof("s + lhs_binding.str() + ")) { NULL }";
+      new_expr = "(typeof("s + lhs_binding.str() + ")) " + new_expr;
     }
 
     clang::CharSourceRange expansion_range = sm.getExpansionRange(loc);

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -404,10 +404,29 @@ public:
 
     auto fn_ptr_typedef = hasType(typedefNameDecl(hasType(fn_ptr)));
 
-    auto zero_literal = integerLiteral(equals(0)).bind("literalZero");
-    auto null_macro = nullPointerConstant();
-    auto null_expr = implicitCastExpr(ignoringParenCasts(anyOf(null_macro, zero_literal)))
-                         .bind("nullExpr");
+    auto zero_literal = ignoringParenCasts(integerLiteral(equals(0)).bind("literalZero"));
+    auto null_macro = ignoringParenCasts(nullPointerConstant());
+    auto null_value = anyOf(zero_literal, null_macro);
+
+    auto null_expr = expr(anyOf(
+            implicitCastExpr(null_value),
+            cStyleCastExpr(zero_literal)
+        )).bind("nullExpr");
+    //auto literal_zero = implicitCastExpr(ignoringParenCasts(integerLiteral(equals(0))));
+    //auto cast_zero = cStyleCastExpr(ignoringParenCasts(integerLiteral(equals(0))));
+    //auto null_macro = implicitCastExpr(cStyleCastExpr(integerLiteral(equals(0))));
+    //auto null_expr = expr(anyOf(literal_zero, cast_zero, null_macro)).bind("nullExpr");
+    //auto literal_zero = integerLiteral(equals(0)).bind("literalZero");
+    //auto null_macro = nullPointerConstant();
+
+    //auto null_expr = expr(anyOf(
+    //    implicitCastExpr(ignoringParenCasts(null_macro)),
+    //    implicitCastExpr(zero_literal),
+        //implicitCastExpr(anyOf(zero_literal, null_macro)),
+        //cStyleCastExpr(ignoringParenCasts(anyOf(zero_literal, null_macro))))).bind("nullExpr");
+
+    //auto null_expr = implicitCastExpr(ignoringParenCasts(anyOf(null_macro, zero_literal)))
+    //                     .bind("nullExpr");
 
     auto null_fn_ptr = varDecl(hasInitializer(null_expr),
                                anyOf(fn_ptr_typedef, hasType(fn_ptr)));

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -456,7 +456,19 @@ public:
       new_expr = "(typeof("s + lhs_binding.str() + ")) " + new_expr;
     }
 
-    clang::CharSourceRange expansion_range = sm.getExpansionRange(loc);
+    // clang::CharSourceRange expansion_range = sm.getExpansionRange(loc);
+
+    clang::SourceRange expr_source_range = null_fn_ptr->getSourceRange();
+    clang::CharSourceRange expansion_range = clang::CharSourceRange::getTokenRange(expr_source_range);
+    llvm::StringRef original_code = clang::Lexer::getSourceText(expansion_range, sm, result.Context->getLangOpts());
+
+    // Get the line number from the SourceManager
+    unsigned line_number = sm.getExpansionLineNumber(loc);
+
+    // Print debug info with line number
+    llvm::errs() << "Replacement in " << filename << ":" << line_number << ": "
+                << original_code << " replaced with " << new_expr << "\n";
+
     Replacement old_r{sm, expansion_range, new_expr};
     Replacement r = replace_new_file(filename, old_r);
     auto err = file_replacements[filename].add(r);

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -473,11 +473,6 @@ public:
       return;
     }
 
-    // TODO: Remove debug logging.
-    llvm::StringRef original_code = clang::Lexer::getSourceText(token_range, sm, lang_opts);
-    llvm::errs() << "Replacement in " << filename << ":" << sm.getExpansionLineNumber(loc) << ": "
-                << original_code << " replaced with " << new_expr << "\n";
-
     Replacement old_r{sm, file_range, new_expr};
     Replacement r = replace_new_file(filename, old_r);
     auto err = file_replacements[filename].add(r);


### PR DESCRIPTION
This PR builds on https://github.com/immunant/IA2-Phase2/pull/438 to fix cases where the rewriter was generating invalid code when assigning 0 to a function pointer or when comparing a function pointer against 0. This fixes https://github.com/immunant/IA2-Phase2/issues/412.

@ayrtonm This doesn't fully address #411 (which you were trying to do in the original PR), but I'm having a harder time getting that working. Does it make sense to you to land this portion of the changes on its own?