### PR TITLE
Fix structs test on ARM

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ add_subdirectory(rewrite_fn_ptr_eq)
 add_subdirectory(rewrite_macros)
 add_subdirectory(sighandler)
 add_subdirectory(static_addr_taken)
+add_subdirectory(structs)
 add_subdirectory(read_config)
 add_subdirectory(heap_two_keys)
 add_subdirectory(three_keys_minimal)
@@ -77,8 +78,6 @@ if (NOT LIBIA2_AARCH64)
     add_subdirectory(two_keys_minimal)
     add_subdirectory(two_shared_ranges)
     add_subdirectory(trusted_indirect)
-    # AArch64 call gates break this test sometimes
-    add_subdirectory(structs)
     # LLVM patch seems to break this test
     add_subdirectory(simple1)
 

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -973,6 +973,7 @@ std::string emit_asm_wrapper(AbiSignature sig,
   size_t indirect_arg_size = 0;
   for (auto &arg : args) {
     if (arg.is_indirect()) { // Only ever true on AArch64 for now.
+      assert(arch == Arch::Aarch64); // Let's find out if this ever gets encountered on x86_64.
       size_t align = std::max(arg.align(), (size_t)8);
       if (stack_arg_size % align != 0) {
         indirect_arg_size += align - (stack_arg_size % align);

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -525,8 +525,8 @@ static void x86_emit_intermediate_pkru(AsmWriter &aw, uint32_t caller_pkey, uint
 
 static void emit_copy_args(AsmWriter &aw, const std::vector<ArgLocation> &args,
                            const std::optional<std::vector<ArgLocation>> &wrapper_args,
-                           size_t stack_return_size, size_t stack_return_padding, int stack_alignment, 
-                           size_t stack_arg_size, size_t stack_arg_padding, size_t wrapper_stack_arg_size, 
+                           size_t stack_return_size, size_t stack_return_padding, int stack_alignment,
+                           size_t stack_arg_size, size_t stack_arg_padding, size_t wrapper_stack_arg_size,
                            uint32_t caller_pkey, Arch arch) {
   if (arch == Arch::X86) {
     // When returning via memory, the address of the return value is passed in
@@ -588,7 +588,7 @@ static void emit_copy_args(AsmWriter &aw, const std::vector<ArgLocation> &args,
         src_arg++;
         dest_arg++;
       }
-      
+
       add_asm_line(aw, "movq %"s + src_arg->as_str() + ", %r12");
       src_arg++;
       for (; dest_arg != args.end(); src_arg++, dest_arg++) {

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -645,6 +645,7 @@ static void emit_copy_args(AsmWriter &aw, const std::vector<ArgLocation> &args,
       emit_memcpy(aw, stack_arg_size, "sp", "x12", "x9", src_offset, arch);
     }
 
+    // Copy memory region for indirect arguments to target stack, updating indirect args themselves
     size_t indirect_arg_current_offset = indirect_args_start;
     for (auto &arg : args) {
       if (arg.is_indirect()) {
@@ -653,6 +654,9 @@ static void emit_copy_args(AsmWriter &aw, const std::vector<ArgLocation> &args,
         if (indirect_arg_current_offset % arg.align() != 0) {
           indirect_arg_current_offset += arg.align() - (indirect_arg_current_offset % arg.align());
         }
+        add_comment_line(
+            aw, llvm::formatv("Copy {} bytes for indirect argument in {} and update it by {}",
+                              arg.size(), arg.as_str(), indirect_arg_current_offset));
         if (arg.is_stack()) {
           add_asm_line(aw, "ldr x10, [sp, #" + std::to_string(arg.stack_offset()) + "]");
           add_asm_line(aw, "add x9, sp, #" + std::to_string(indirect_arg_current_offset));


### PR DESCRIPTION
It turns out we were not aligning our stacks properly in ARM call gates since 13c495ddec8658101c2453362e76eba50518e1c3.