### PR TITLE
ci: use tweaked x18 tagging logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           path: |
             llvm-project/build/bin
             llvm-project/build/lib/clang
-          key: ${{ runner.os }}-clang-2
+          key: ${{ runner.os }}-clang-fw/tweak-tagging
       - name: Cache built runtime libraries
         id: cache-rtlibs
         uses: actions/cache@v4
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: immunant/llvm-project
-          ref: fw/instrument-llvm-ir
+          ref: fw/tweak-tagging
           path: ${{ github.workspace }}/llvm-project
       - name: Build Clang
         if: steps.cache-clang.outputs.cache-hit != 'true'


### PR DESCRIPTION
Seeing if this is relevant for the `simple1` test that's failing intermittently in CI.

EDIT: No, this fixes `three_keys_minimal`.