### PR TITLE
rewriter: switch from hardcoded `--enable-dav1d_get_picture-post-condition` to `IA2_{PRE,POST}_CONDITION()` attribute annotation macros

### DIFF
--- a/runtime/libia2/include/ia2.h
+++ b/runtime/libia2/include/ia2.h
@@ -36,6 +36,9 @@
 
 #define IA2_END_NO_WRAP _Pragma("clang attribute pop");
 
+#define IA2_PRE_CONDITION(target_func) __attribute__((annotate("pre_condition:" #target_func)))
+#define IA2_POST_CONDITION(target_func) __attribute__((annotate("post_condition:" #target_func)))
+
 #if !IA2_ENABLE
 #define IA2_DEFINE_WRAPPER(func)
 #define IA2_SIGHANDLER(func) func

--- a/runtime/libia2/include/ia2.h
+++ b/runtime/libia2/include/ia2.h
@@ -39,12 +39,12 @@
 /// Mark the annotated function as a pre-condition function for `target_func`.
 ///
 /// It will be called with the first 6 arguments of `target_func` before `target_func` is called.
-#define IA2_PRE_CONDITION(target_func) __attribute__((annotate("pre_condition:" #target_func)))
+#define IA2_PRE_CONDITION_FOR(target_func) __attribute__((annotate("pre_condition:" #target_func)))
 
 /// Mark the annotated function as a post-condition function for `target_func`.
 ///
 /// It will be called with the first 6 arguments of `target_func` after `target_func` is called.
-#define IA2_POST_CONDITION(target_func) __attribute__((annotate("post_condition:" #target_func)))
+#define IA2_POST_CONDITION_FOR(target_func) __attribute__((annotate("post_condition:" #target_func)))
 
 #if !IA2_ENABLE
 #define IA2_DEFINE_WRAPPER(func)

--- a/runtime/libia2/include/ia2.h
+++ b/runtime/libia2/include/ia2.h
@@ -36,7 +36,14 @@
 
 #define IA2_END_NO_WRAP _Pragma("clang attribute pop");
 
+/// Mark the annotated function as a pre-condition function for `target_func`.
+///
+/// It will be called with the first 6 arguments of `target_func` before `target_func` is called.
 #define IA2_PRE_CONDITION(target_func) __attribute__((annotate("pre_condition:" #target_func)))
+
+/// Mark the annotated function as a post-condition function for `target_func`.
+///
+/// It will be called with the first 6 arguments of `target_func` after `target_func` is called.
 #define IA2_POST_CONDITION(target_func) __attribute__((annotate("post_condition:" #target_func)))
 
 #if !IA2_ENABLE

--- a/tests/post_condition/dav1d.c
+++ b/tests/post_condition/dav1d.c
@@ -20,7 +20,7 @@ int dav1d_get_picture(Dav1dContext *const c, Dav1dPicture *const out) {
   return 0;
 }
 
-IA2_POST_CONDITION(dav1d_get_picture)
+IA2_POST_CONDITION_FOR(dav1d_get_picture)
 void dav1d_get_picture_post_condition(Dav1dContext *const c, Dav1dPicture *const out) {
   cr_log_info("dav1d_get_picture post condition ran");
   if (out->stride[0] < 0) {

--- a/tests/post_condition/dav1d.c
+++ b/tests/post_condition/dav1d.c
@@ -20,6 +20,7 @@ int dav1d_get_picture(Dav1dContext *const c, Dav1dPicture *const out) {
   return 0;
 }
 
+IA2_POST_CONDITION(dav1d_get_picture)
 void dav1d_get_picture_post_condition(Dav1dContext *const c, Dav1dPicture *const out) {
   cr_log_info("dav1d_get_picture post condition ran");
   if (out->stride[0] < 0) {

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -972,7 +972,7 @@ std::string emit_asm_wrapper(AbiSignature sig,
 
   size_t indirect_arg_size = 0;
   for (auto &arg : args) {
-    if (arg.is_indirect()) { // Only ever true on AArch64 for now.
+    if (arg.is_indirect()) {         // Only ever true on AArch64 for now.
       assert(arch == Arch::Aarch64); // Let's find out if this ever gets encountered on x86_64.
       size_t align = std::max(arg.align(), (size_t)8);
       if (stack_arg_size % align != 0) {

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -501,7 +501,7 @@ static void emit_prologue(AsmWriter &aw, uint32_t caller_pkey, uint32_t target_p
     }
 
     if (save_param_regs) {
-      llvm::report_fatal_error("--enable-dav1d_get_picture-post-condition is not yet supported on aarch64");
+      llvm::report_fatal_error("post conditions are not yet supported on aarch64");
     }
   }
 }
@@ -1102,12 +1102,15 @@ std::string emit_asm_wrapper(AbiSignature sig,
     stack_alignment = (compartment_stack_space + 8) % 16;
   }
 
-  // For now, we hardcode the existence and name of the post-condition function.
-  // The name is `${target_name}_post_condition`,
-  // and we only do this for `dav1d_get_picture`.
   std::optional<std::string> target_post_condition_name = std::nullopt;
-  if (enable_dav1d_get_picture_post_condition && target_name && *target_name == "dav1d_get_picture") {
-    target_post_condition_name = *target_name + "_post_condition";
+  if (target_name && arch == Arch::X86) {
+    // TODO implement on aarch64
+    assert(pre_condition_funcs.count(*target_name) == 0);  // Pre conditions not yet supported
+    assert(post_condition_funcs.count(*target_name) <= 1); // Only one post condition currently supported.
+    auto post_condition = post_condition_funcs.find(*target_name);
+    if (post_condition != post_condition_funcs.end()) {
+      target_post_condition_name = post_condition->second;
+    }
   }
 
   add_comment_line(aw, "Wrapper for "s + sig_string(sig, target_name) + ":");

--- a/tools/rewriter/GenCallAsm.h
+++ b/tools/rewriter/GenCallAsm.h
@@ -17,7 +17,8 @@ enum class WrapperKind {
 };
 
 enum class Arch {
-    Aarch64, X86
+  Aarch64,
+  X86
 };
 
 extern bool enable_dav1d_get_picture_post_condition;

--- a/tools/rewriter/GenCallAsm.h
+++ b/tools/rewriter/GenCallAsm.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <optional>
 #include <string>
+#include <unordered_map>
 
 #include "CAbi.h"
 
@@ -21,7 +22,10 @@ enum class Arch {
   X86
 };
 
-extern bool enable_dav1d_get_picture_post_condition;
+// Key is target function.
+// Value is pre/post condition function name.
+extern std::unordered_multimap<std::string, std::string> pre_condition_funcs;
+extern std::unordered_multimap<std::string, std::string> post_condition_funcs;
 
 // Generates a wrapper for a function named \p name with the signature \p sig.
 // The WrapperKind parameter \p kind determines the type of call which may

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -179,6 +179,9 @@ static std::string append_name_if_nonempty(const std::string &new_type,
 /// with an annotation starting with `prefix`.
 /// The annotation minus the prefix is the key,
 /// and the function name is the value.
+///
+/// This is, for example, used for
+/// pre- and post-condition function annotations.
 class AnnotationPrefixFunctions : public MatchFinder::MatchCallback {
 
 public:

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -53,8 +53,8 @@ static std::string OutputPrefix;
 
 // Key is target function.
 // Value is pre/post condition function name.
-std::unordered_multimap<std::string, std::string> pre_condition_funcs;
-std::unordered_multimap<std::string, std::string> post_condition_funcs;
+std::unordered_multimap<Function, Function> pre_condition_funcs;
+std::unordered_multimap<Function, Function> post_condition_funcs;
 
 // Map each translation unit's filename to its pkey.
 static std::map<Filename, Pkey> file_pkeys;
@@ -184,7 +184,7 @@ class AnnotationPrefixFunctions : public MatchFinder::MatchCallback {
 public:
   const std::string prefix;
   /// Key is suffix, value is function name.
-  std::unordered_multimap<std::string, std::string> funcs;
+  std::unordered_multimap<std::string, Function> funcs;
 
   AnnotationPrefixFunctions(std::string prefix) : prefix(prefix) {}
 

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -50,7 +50,11 @@ static Arch Target = Arch::X86;
 static std::string RootDirectory;
 static std::string OutputDirectory;
 static std::string OutputPrefix;
-bool enable_dav1d_get_picture_post_condition = true;
+
+// Key is target function.
+// Value is pre/post condition function name.
+std::unordered_multimap<std::string, std::string> pre_condition_funcs;
+std::unordered_multimap<std::string, std::string> post_condition_funcs;
 
 // Map each translation unit's filename to its pkey.
 static std::map<Filename, Pkey> file_pkeys;
@@ -169,6 +173,35 @@ static bool ignore_function(const clang::Decl &decl,
 static std::string append_name_if_nonempty(const std::string &new_type,
                                            const std::string &name) {
   return new_type + (name.empty() ? "" : " ") + name;
+};
+
+/// Collects in a multimap (`funcs`) all of the function names
+/// with an annotation starting with `prefix`.
+/// The annotation minus the prefix is the key,
+/// and the function name is the value.
+class AnnotationPrefixFunctions : public MatchFinder::MatchCallback {
+
+public:
+  const std::string prefix;
+  /// Key is suffix, value is function name.
+  std::unordered_multimap<std::string, std::string> funcs;
+
+  AnnotationPrefixFunctions(std::string prefix) : prefix(prefix) {}
+
+  void run(const MatchFinder::MatchResult &result) override {
+    if (const auto *func = result.Nodes.getNodeAs<clang::FunctionDecl>("annotatedFunc")) {
+      for (const auto *attr : func->attrs()) {
+        if (const auto *annotate_attr = llvm::dyn_cast<clang::AnnotateAttr>(attr)) {
+          llvm::StringRef annotation = annotate_attr->getAnnotation();
+          if (!annotation.consume_front(prefix)) {
+            continue;
+          }
+          const auto func_name = func->getNameInfo().getName().getAsString();
+          funcs.emplace(annotation, func_name);
+        }
+      }
+    }
+  }
 };
 
 /*
@@ -1138,9 +1171,6 @@ int main(int argc, const char **argv) {
   app.add_option("--arch", Target, "Target architecture (x86 or aarch64), x86 by default")
       ->option_text("x86|aarch64")
       ->transform(CLI::Transformer(arch_map));
-  app.add_option("--enable-dav1d_get_picture-post-condition", enable_dav1d_get_picture_post_condition,
-                 "enable calling the post condition function hardcoded for dav1d_get_picture")
-      ->group("Dav1d-specific");
   app.add_option("--output-directory", OutputDirectory, "Root directory for output files")
       ->option_text("<DIR> (REQUIRED)")
       ->transform(ValidateDirectory)
@@ -1274,6 +1304,22 @@ int main(int argc, const char **argv) {
     llvm::errs() << "Error opening output header file: " << EC.message()
                  << "\n";
     return EC.value();
+  }
+
+  {
+    auto annotation_matcher = functionDecl(hasAttr(clang::attr::Annotate)).bind("annotatedFunc");
+    AnnotationPrefixFunctions pre_condition("pre_condition:");
+    AnnotationPrefixFunctions post_condition("post_condition:");
+    MatchFinder annotation_finder;
+    annotation_finder.addMatcher(annotation_matcher, &pre_condition);
+    annotation_finder.addMatcher(annotation_matcher, &post_condition);
+    const auto rc = tool.run(newFrontendActionFactory(&annotation_finder).get());
+    if (rc != 0) {
+      return rc;
+    }
+
+    pre_condition_funcs = std::move(pre_condition.funcs);
+    post_condition_funcs = std::move(post_condition.funcs);
   }
 
   ASTMatchRefactorer refactorer(tool.getReplacements());


### PR DESCRIPTION
This is much more robust and flexible and is much closer to the end state for how this API will look.  It also makes the tests much simpler by encoding the options in the source code to be detected, rather than needing to specify them in the CLI or hardcoded like before.

Will the full gamut of the attribute API is implemented here, we still only support a single post-condition function, and no pre-condition functions yet.  Those will come next.

I also tested this more thoroughly in another branch with mostly complete multiple pre- and post-condition functions, but that implementation is more complex, so I wanted to put this in a separate PR.