### PR TITLE
Always test optimized builds on AArch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
           popd
   aarch64-wip-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build-type: [RelWithDebInfo, Debug]
     steps:
       - name: Install dep packages
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -168,7 +171,7 @@ jobs:
         working-directory: ${{ github.workspace }}/llvm-project
         run: |
           ln -s ../build-rtlibs ./
-      - name: Test ARM build
+      - name: Test ARM build (${{ matrix.build-type }})
         run: |
           LLVM_DIR=`llvm-config-15 --cmakedir`
           Clang_DIR=`realpath $LLVM_DIR/../clang`
@@ -182,6 +185,7 @@ jobs:
           -I${rtlibs_dir}/include/c++/v1"
           export LDFLAGS="-L/usr/aarch64-linux-gnu/lib"
           cmake .. \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
             -DCMAKE_CROSSCOMPILING_EMULATOR=${{ github.workspace }}/qemu/build/qemu-aarch64 \
             -DCMAKE_TOOLCHAIN_FILE=../cmake/aarch64-toolchain.cmake \
             -DCMAKE_C_COMPILER=`pwd`/../llvm-project/build/bin/clang-19 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build-type: [RelWithDebInfo, Debug]
+        build-type: [RelWithDebInfo]
     steps:
       - name: Install dep packages
         uses: awalsh128/cache-apt-pkgs-action@latest


### PR DESCRIPTION
The persistent weird failures we're seeing in CI couldn't reproduce locally because I was doing an optimized build locally. We should test both configurations in CI, but for now let's get CI green by always testing optimized builds.