### PR TITLE
rewriter: wrap `AbiSignature` in `FnSignature` that also stores API info (arg/return types)

### DIFF
--- a/tools/rewriter/CAbi.h
+++ b/tools/rewriter/CAbi.h
@@ -112,7 +112,20 @@ struct AbiSignature {
   std::vector<ArgLocation> ret;
 };
 
+struct Param {
+  std::string name;
+  std::string type_name;
+  std::string canonical_type_name;
+  uint32_t type_id;
+};
+
+struct ApiSignature {
+  std::vector<Param> args;
+  Param ret;
+};
+
 struct FnSignature {
   AbiSignature abi;
+  ApiSignature api;
   bool variadic;
 };

--- a/tools/rewriter/CAbi.h
+++ b/tools/rewriter/CAbi.h
@@ -110,5 +110,9 @@ public:
 struct AbiSignature {
   std::vector<ArgLocation> args;
   std::vector<ArgLocation> ret;
+};
+
+struct FnSignature {
+  AbiSignature abi;
   bool variadic;
 };

--- a/tools/rewriter/DetermineAbi.h
+++ b/tools/rewriter/DetermineAbi.h
@@ -7,8 +7,8 @@
 #include "clang/AST/AST.h"
 #pragma GCC diagnostic pop
 
-auto determineAbiForDecl(const clang::FunctionDecl &fnDecl, Arch arch) -> AbiSignature;
+FnSignature determineFnSignatureForDecl(const clang::FunctionDecl &fnDecl, Arch arch);
 
-AbiSignature determineAbiForProtoType(const clang::FunctionProtoType &fpt,
+FnSignature determineFnSignatureForProtoType(const clang::FunctionProtoType &fpt,
                                       clang::ASTContext &astContext,
                                       Arch arch);

--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -945,8 +945,8 @@ static void emit_return(AsmWriter &aw) {
   add_asm_line(aw, "ret");
 }
 
-std::string emit_asm_wrapper(AbiSignature sig,
-                             std::optional<AbiSignature> wrapper_sig,
+std::string emit_asm_wrapper(FnSignature sig,
+                             std::optional<FnSignature> wrapper_sig,
                              const std::string &wrapper_name,
                              const std::optional<std::string> target_name,
                              WrapperKind kind, int caller_pkey, int target_pkey,
@@ -958,17 +958,17 @@ std::string emit_asm_wrapper(AbiSignature sig,
   AsmWriter aw = get_asmwriter(as_macro);
 
   size_t stack_arg_size = 0;
-  auto args = allocate_param_locations(sig, arch, &stack_arg_size);
+  auto args = allocate_param_locations(sig.abi, arch, &stack_arg_size);
   std::optional<std::vector<ArgLocation>> wrapper_args;
   size_t wrapper_stack_arg_size = stack_arg_size;
   if (wrapper_sig) {
-    wrapper_args = {allocate_param_locations(*wrapper_sig, arch, &wrapper_stack_arg_size)};
+    wrapper_args = {allocate_param_locations(wrapper_sig->abi, arch, &wrapper_stack_arg_size)};
   }
   size_t unaligned = stack_arg_size % 8;
   size_t stack_arg_padding = unaligned != 0 ? 8 - unaligned : 0;
 
-  llvm::errs() << "Generating wrapper for " << sig_string(sig, target_name) << "\n";
-  auto rets = allocate_return_locations(sig, arch);
+  llvm::errs() << "Generating wrapper for " << sig_string(sig.abi, target_name) << "\n";
+  auto rets = allocate_return_locations(sig.abi, arch);
 
   size_t indirect_arg_size = 0;
   for (auto &arg : args) {
@@ -1113,7 +1113,7 @@ std::string emit_asm_wrapper(AbiSignature sig,
     }
   }
 
-  add_comment_line(aw, "Wrapper for "s + sig_string(sig, target_name) + ":");
+  add_comment_line(aw, "Wrapper for "s + sig_string(sig.abi, target_name) + ":");
   add_asm_line(aw, ".text");
   if (kind != WrapperKind::PointerToStatic) {
     add_asm_line(aw, ".global "s + wrapper_name);

--- a/tools/rewriter/GenCallAsm.h
+++ b/tools/rewriter/GenCallAsm.h
@@ -38,8 +38,8 @@ extern std::unordered_multimap<std::string, std::string> post_condition_funcs;
 // which must be valid to pass to the `PKRU` macro in ia2.h.
 // \p as_macro determines if the wrappers for direct calls is emitted as a
 // macro. Indirect calls are unconditionally emitted as macros.
-std::string emit_asm_wrapper(AbiSignature sig,
-                             std::optional<AbiSignature> wrapper_sig,
+std::string emit_asm_wrapper(FnSignature sig,
+                             std::optional<FnSignature> wrapper_sig,
                              const std::string &wrapper_name,
                              const std::optional<std::string> target_name,
                              WrapperKind kind, int caller_pkey, int target_pkey,

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -518,8 +518,8 @@ public:
 
       auto expr_ty_str = wrap_fn_ptr_ty.getAsString();
 
-      auto sig = determineAbiForProtoType(*dest_fn_ty, ctxt, Target);
-      auto wrapper_sig = determineAbiForProtoType(*wrap_fn_prototype, ctxt, Target);
+      auto sig = determineFnSignatureForProtoType(*dest_fn_ty, ctxt, Target);
+      auto wrapper_sig = determineFnSignatureForProtoType(*wrap_fn_prototype, ctxt, Target);
 
       auto res = fn_ptr_info.emplace(mangled_ty, FnPtrInfo({expr_ty_str, sig, wrapper_sig}));
       info = res.first;
@@ -576,8 +576,8 @@ public:
 
   struct FnPtrInfo {
     std::string type_str;
-    AbiSignature sig;
-    AbiSignature wrapper_sig;
+    FnSignature sig;
+    FnSignature wrapper_sig;
   };
 
   // Mapping from mangled type name to function pointer info
@@ -917,8 +917,8 @@ public:
       return;
     }
 
-    AbiSignature fn_sig = determineAbiForDecl(*fn_node, Target);
-    abi_signatures[fn_name] = fn_sig;
+    FnSignature fn_sig = determineFnSignatureForDecl(*fn_node, Target);
+    fn_signatures[fn_name] = fn_sig;
 
     // Get the translation unit's filename to figure out the pkey
     Pkey pkey = get_file_pkey(sm);
@@ -936,7 +936,7 @@ public:
 
   std::set<Function> defined_fns[MAX_PKEYS];
   std::set<Function> declared_fns[MAX_PKEYS];
-  std::map<Function, AbiSignature> abi_signatures;
+  std::map<Function, FnSignature> fn_signatures;
   std::map<Function, Pkey> fn_pkeys;
   std::map<Function, Filename> fn_definitions;
 };
@@ -1454,14 +1454,14 @@ int main(int argc, const char **argv) {
       // original entries in these maps for the renamed symbols. While we could
       // avoid this duplication if necessary, this simplifies the call gate
       // generation.
-      AbiSignature c_abi;
+      FnSignature fn_sig;
       try {
-        c_abi = fn_decl_pass.abi_signatures.at(fn_name);
+        fn_sig = fn_decl_pass.fn_signatures.at(fn_name);
       } catch (std::out_of_range const &exc) {
         llvm::errs() << "ABI signature not known for function " << fn_name << "\n";
         abort();
       }
-      fn_decl_pass.abi_signatures.insert({new_fn_name, c_abi});
+      fn_decl_pass.fn_signatures.insert({new_fn_name, fn_sig});
 
       Pkey pkey;
       try {
@@ -1482,9 +1482,9 @@ int main(int argc, const char **argv) {
   // At this point direct_call_wrappers has both single-caller and multicaller
   // functions so we just need to generate the callgates
   for (const auto &[fn_name, caller_pkey] : direct_call_wrappers) {
-    AbiSignature c_abi_sig;
+    FnSignature fn_sig;
     try {
-      c_abi_sig = fn_decl_pass.abi_signatures.at(fn_name);
+      fn_sig = fn_decl_pass.fn_signatures.at(fn_name);
     } catch (std::out_of_range const &exc) {
       llvm::errs() << "C ABI signature for function " << fn_name.c_str()
                    << " not found by FnDecl pass\n";
@@ -1508,7 +1508,7 @@ int main(int argc, const char **argv) {
       continue;
     }
     std::string asm_wrapper =
-        emit_asm_wrapper(c_abi_sig, std::nullopt, wrapper_name, target_fn,
+        emit_asm_wrapper(fn_sig, std::nullopt, wrapper_name, target_fn,
                          WrapperKind::Direct, caller_pkey, target_pkey, Target);
     wrapper_out << asm_wrapper;
 
@@ -1518,9 +1518,9 @@ int main(int argc, const char **argv) {
   // Create wrapper for compartment destructor
   for (int compartment_pkey = 1; compartment_pkey < num_pkeys; compartment_pkey++) {
     std::string fn_name = "ia2_compartment_destructor_" + std::to_string(compartment_pkey);
-    AbiSignature c_abi_sig;
+    FnSignature fn_sig;
     try {
-      c_abi_sig = fn_decl_pass.abi_signatures.at(fn_name);
+      fn_sig = fn_decl_pass.fn_signatures.at(fn_name);
     } catch (std::out_of_range const &exc) {
       llvm::errs() << "Could not find ia2_compartment_destructor_" << compartment_pkey << '\n'
                    << "Make sure to #include ia2_compartment_init.inc for this compartment\n";
@@ -1528,7 +1528,7 @@ int main(int argc, const char **argv) {
     }
     std::string wrapper_name = "__wrap_"s + fn_name;
     std::string asm_wrapper =
-        emit_asm_wrapper(c_abi_sig, std::nullopt, wrapper_name, fn_name, WrapperKind::Direct,
+        emit_asm_wrapper(fn_sig, std::nullopt, wrapper_name, fn_name, WrapperKind::Direct,
                          0, compartment_pkey, Target);
     wrapper_out << asm_wrapper;
 
@@ -1563,9 +1563,9 @@ int main(int argc, const char **argv) {
 
     Pkey target_pkey = fn_decl_pass.fn_pkeys[fn_name];
     if (target_pkey != 0) {
-      AbiSignature c_abi_sig = fn_decl_pass.abi_signatures[fn_name];
+      FnSignature fn_sig = fn_decl_pass.fn_signatures[fn_name];
       std::string asm_wrapper =
-          emit_asm_wrapper(c_abi_sig, std::nullopt, wrapper_name, fn_name,
+          emit_asm_wrapper(fn_sig, std::nullopt, wrapper_name, fn_name,
                            WrapperKind::Pointer, 0, target_pkey, Target,
                            true /* as_macro */);
       macros_defining_wrappers += "#define IA2_DEFINE_WRAPPER_"s + fn_name + " \\\n";
@@ -1604,10 +1604,10 @@ int main(int argc, const char **argv) {
       // also has pkey 0 then it just needs call the original function
       Pkey target_pkey = fn_decl_pass.fn_pkeys[fn_name];
       if (target_pkey != 0) {
-        AbiSignature c_abi_sig = fn_decl_pass.abi_signatures[fn_name];
+        FnSignature fn_sig = fn_decl_pass.fn_signatures[fn_name];
 
         std::string asm_wrapper = emit_asm_wrapper(
-            c_abi_sig, std::nullopt, wrapper_name, fn_name, WrapperKind::PointerToStatic, 0,
+            fn_sig, std::nullopt, wrapper_name, fn_name, WrapperKind::PointerToStatic, 0,
             target_pkey, Target, true /* as_macro */);
         macros_defining_wrappers += "#define IA2_DEFINE_WRAPPER_"s + fn_name + " \\\n";
         macros_defining_wrappers += asm_wrapper;


### PR DESCRIPTION
This wraps `AbiSignature` in a more generic `FnSignature` that also contains API info as well as the existing ABI info.  The API info is stored in `ApiSignature`, which contains `Param`s for the args and return.  Each `Param` contains the parameter name (if a parameter), the type name, the canonical type name, and a type ID based on the canonical name.  For now, the type ID is counted by interning the canonical types, so it's unique within a single `ia2-rewriter` invocation.

Next, we can use this API info to both define C functions (if we want to) and call into the `type-registry` library (#493) with type IDs for the arguments and return type.