### PR TITLE
add `#pragma once` to headers w/ no include guards

### DIFF
--- a/runtime/libia2/include/permissive_mode.h
+++ b/runtime/libia2/include/permissive_mode.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #if IA2_ENABLE
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE // for SIG* macro

--- a/runtime/libia2/include/scrub_registers.h
+++ b/runtime/libia2/include/scrub_registers.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #if defined(__x86_64__)
 // This file defines the feature specific scrub routines.
 //

--- a/runtime/tracer/get_inferior_pkru.h
+++ b/runtime/tracer/get_inferior_pkru.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>

--- a/runtime/tracer/track_memory_map.h
+++ b/runtime/tracer/track_memory_map.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #define _GNU_SOURCE
 #include <stdbool.h>
 #include <sys/wait.h>

--- a/tests/macro_attr/include/functions.h
+++ b/tests/macro_attr/include/functions.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #define ATTR __attribute__((hot))
 #define UNUSED __attribute__((unused))
 #define EMPTY

--- a/tests/three_keys_minimal/include/lib.h
+++ b/tests/three_keys_minimal/include/lib.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #define DECLARE_LIB(lib_num, other_lib)                    \
     void lib_##lib_num##_noop(void);                       \
     void lib_##lib_num##_call_lib_##other_lib(void);       \

--- a/tools/rewriter/TypeOps.h
+++ b/tools/rewriter/TypeOps.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "clang/AST/AST.h"
 #include <string>
 


### PR DESCRIPTION
A bunch of headers are missing include guards (which are mostly `#pragma once`s), so this adds them.  I ran into this with `tools/rewriter/TypeOps.h` but there are more headers missing so this fixes them all.