### PR TITLE
runtime/type-registry: some small fixes/updates

### DIFF
--- a/runtime/type-registry/Cargo.toml
+++ b/runtime/type-registry/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "type-registry"
 version = "0.1.0"
-edition = "2021"
-rust-version = "1.84"
+edition = "2024"
+rust-version = "1.85"
 
 [lib]
 crate-type = ["staticlib"]

--- a/runtime/type-registry/src/lib.rs
+++ b/runtime/type-registry/src/lib.rs
@@ -30,7 +30,7 @@ impl Debug for PtrAddr {
 /// This can be anything, as long as it's unique for a type in a program.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
-pub struct TypeId(usize);
+pub struct TypeId(u32);
 
 impl Display for TypeId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {

--- a/runtime/type-registry/src/lib.rs
+++ b/runtime/type-registry/src/lib.rs
@@ -47,19 +47,19 @@ impl Debug for TypeId {
 static GLOBAL_TYPE_REGISTRY: LazyLock<TypeRegistry> = LazyLock::new(TypeRegistry::default);
 
 /// See [`TypeRegistry::construct`].
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C-unwind" fn ia2_type_registry_construct(ptr: Ptr, type_id: TypeId) {
     GLOBAL_TYPE_REGISTRY.construct(ptr, type_id);
 }
 
 /// See [`TypeRegistry::destruct`].
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C-unwind" fn ia2_type_registry_destruct(ptr: Ptr, expected_type_id: TypeId) {
     GLOBAL_TYPE_REGISTRY.destruct(ptr, expected_type_id);
 }
 
 /// See [`TypeRegistry::check`].
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C-unwind" fn ia2_type_registry_check(ptr: Ptr, expected_type_id: TypeId) {
     GLOBAL_TYPE_REGISTRY.check(ptr, expected_type_id);
 }

--- a/runtime/type-registry/src/lib.rs
+++ b/runtime/type-registry/src/lib.rs
@@ -76,8 +76,11 @@ impl TypeRegistry {
     #[track_caller]
     pub fn construct(&self, ptr: Ptr, type_id: TypeId) {
         let ptr = PtrAddr(ptr.addr());
-        let guard = &mut *self.map.write().unwrap();
-        let prev_type_id = guard.insert(ptr, type_id);
+        let map = &mut *self.map.write().unwrap();
+        if cfg!(debug_assertions) {
+            eprintln!("construct({ptr}, {type_id}): {map:?}");
+        }
+        let prev_type_id = map.insert(ptr, type_id);
         assert_eq!(prev_type_id, None);
     }
 
@@ -87,8 +90,11 @@ impl TypeRegistry {
     #[track_caller]
     pub fn destruct(&self, ptr: Ptr, expected_type_id: TypeId) {
         let ptr = PtrAddr(ptr.addr());
-        let guard = &mut *self.map.write().unwrap();
-        let type_id = guard.remove(&ptr);
+        let map = &mut *self.map.write().unwrap();
+        if cfg!(debug_assertions) {
+            eprintln!("destruct({ptr}, {expected_type_id}): {map:?}");
+        }
+        let type_id = map.remove(&ptr);
         assert_eq!(type_id, Some(expected_type_id));
     }
 
@@ -98,8 +104,11 @@ impl TypeRegistry {
     #[track_caller]
     pub fn check(&self, ptr: Ptr, expected_type_id: TypeId) {
         let ptr = PtrAddr(ptr.addr());
-        let guard = &*self.map.read().unwrap();
-        let type_id = guard.get(&ptr).copied();
+        let map = &*self.map.read().unwrap();
+        if cfg!(debug_assertions) {
+            eprintln!("check({ptr}, {expected_type_id}): {map:?}");
+        }
+        let type_id = map.get(&ptr).copied();
         assert_eq!(type_id, Some(expected_type_id));
     }
 }


### PR DESCRIPTION
This switches the type registry to use the same type (`u32`) for `TypeId`s as the rewriter, and also adds some debug logs.  Also, updates to edition 2024.