### PR TITLE
runtime/type-registry: add more descriptive panic messages

### DIFF
--- a/runtime/type-registry/src/lib.rs
+++ b/runtime/type-registry/src/lib.rs
@@ -15,7 +15,7 @@ pub struct PtrAddr(usize);
 
 impl Display for PtrAddr {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{:?}", ptr::without_provenance::<()>(self.0))
+        write!(f, "ptr {:?}", ptr::without_provenance::<()>(self.0))
     }
 }
 
@@ -34,7 +34,7 @@ pub struct TypeId(u32);
 
 impl Display for TypeId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "Type{}", self.0)
+        write!(f, "type {}", self.0)
     }
 }
 


### PR DESCRIPTION
Now it will panic like this:

```shell
❯ RUST_BACKTRACE=1 ./build/x86_64/tests/type_confusion/type_confusion
protecting library: libtype_confusion_lib.so
Shared range 0: 0x7e3b26e6a000-0x7e3b26e6a000
Segment 3: 0x7e3b26e68000-0x7e3b26e6b000
Shared range 0 overlaps end of segment 3, adjusting end to 0x7e3b26e6a000
Shared range 1 overlaps start of segment 3, adjusting start to 0x7e3b26e69000
ia2_mprotect_with_tag(addr=0x7e3b26e69000, len=4096, prot=3, tag=2)
ia2_mprotect_with_tag(addr=0x7e3b26e6a000, len=4096, prot=3, tag=2)
ia2_mprotect_with_tag(addr=0x7e3b25e00000, len=4194304, prot=3, tag=2)
ia2_mprotect_with_tag(addr=0x7e3b26cc2000, len=4096, prot=3, tag=2)
ia2_mprotect_with_tag(addr=0x7e3b25a00000, len=4194304, prot=3, tag=1)
ia2_mprotect_with_tag(addr=0x7e3b26cc5000, len=4096, prot=3, tag=1)
protecting library:
Shared range 0: 0x56dcc5a5b000-0x56dcc5a5d000
Segment 5: 0x56dcc5a56000-0x56dcc639f000
Shared range 0 overlaps end of segment 5, adjusting end to 0x56dcc5a5b000
Shared range 1 overlaps start of segment 5, adjusting start to 0x56dcc5a57000
ia2_mprotect_with_tag(addr=0x56dcc5a57000, len=16384, prot=3, tag=1)
Shared range 0 overlaps start of segment 5, adjusting start to 0x56dcc5a5d000
ia2_mprotect_with_tag(addr=0x56dcc5a5d000, len=9707520, prot=3, tag=1)
running suite 'type_confusion' test 'normal', expecting exit status 0 (EXIT_SUCCESS)...
construct(ptr 0x56dcc5a5b030, type 0): {}
check(ptr 0x56dcc5a5b030, type 0): {ptr 0x56dcc5a5b030: type 0}
destruct(ptr 0x56dcc5a5b030, type 0): {ptr 0x56dcc5a5b030: type 0}
exited with status 0, as expected
running suite 'type_confusion' test 'uninitialized', expecting signal 6 (SIGABRT)...
construct(ptr 0x56dcc5a5b030, type 0): {}
check(ptr 0x56dcc5a5b078, type 0): {ptr 0x56dcc5a5b030: type 0}

thread '<unnamed>' panicked at src/lib.rs:64:26:
ptr 0x56dcc5a5b078 should have type 0, but has no type currently
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panicking.rs:692:5
   1: core::panicking::panic_fmt
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/panicking.rs:75:14
   2: type_registry::TypeRegistry::check
             at ./runtime/type-registry/src/lib.rs:120:17
   3: ia2_type_registry_check
             at ./runtime/type-registry/src/lib.rs:64:5
   4: __wrap_dav1d_get_picture
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
killed by signal 6 (SIGABRT), as expected
running suite 'type_confusion' test 'wrong_type', expecting signal 6 (SIGABRT)...
construct(ptr 0x56dcc5a5b030, type 0): {}
check(ptr 0x56dcc5a5b038, type 0): {ptr 0x56dcc5a5b030: type 0}

thread '<unnamed>' panicked at src/lib.rs:64:26:
ptr 0x56dcc5a5b038 should have type 0, but has no type currently
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panicking.rs:692:5
   1: core::panicking::panic_fmt
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/panicking.rs:75:14
   2: type_registry::TypeRegistry::check
             at ./runtime/type-registry/src/lib.rs:120:17
   3: ia2_type_registry_check
             at ./runtime/type-registry/src/lib.rs:64:5
   4: __wrap_dav1d_get_picture
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
killed by signal 6 (SIGABRT), as expected
running suite 'type_confusion' test 'null', expecting signal 6 (SIGABRT)...
construct(ptr 0x56dcc5a5b030, type 0): {}
check(ptr 0x0, type 0): {ptr 0x56dcc5a5b030: type 0}

thread '<unnamed>' panicked at src/lib.rs:64:26:
ptr 0x0 should have type 0, but has no type currently
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panicking.rs:692:5
   1: core::panicking::panic_fmt
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/panicking.rs:75:14
   2: type_registry::TypeRegistry::check
             at ./runtime/type-registry/src/lib.rs:120:17
   3: ia2_type_registry_check
             at ./runtime/type-registry/src/lib.rs:64:5
   4: __wrap_dav1d_get_picture
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
killed by signal 6 (SIGABRT), as expected
running suite 'type_confusion' test 'use_after_free', expecting signal 6 (SIGABRT)...
construct(ptr 0x56dcc5a5b030, type 0): {}
destruct(ptr 0x56dcc5a5b030, type 0): {ptr 0x56dcc5a5b030: type 0}
check(ptr 0x56dcc5a5b030, type 0): {}

thread '<unnamed>' panicked at src/lib.rs:64:26:
ptr 0x56dcc5a5b030 should have type 0, but has no type currently
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panicking.rs:692:5
   1: core::panicking::panic_fmt
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/panicking.rs:75:14
   2: type_registry::TypeRegistry::check
             at ./runtime/type-registry/src/lib.rs:120:17
   3: ia2_type_registry_check
             at ./runtime/type-registry/src/lib.rs:64:5
   4: __wrap_dav1d_get_picture
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
killed by signal 6 (SIGABRT), as expected
```

or this:

```shell
❯ (cd runtime/type-registry && cargo test -- --show-output)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/type_registry-37a3f3db1903020f)

running 5 tests
test tests::check_non_existent_ptr - should panic ... ok
test tests::check_freed_ptr - should panic ... ok
test tests::construct_existing_ptr - should panic ... ok
test tests::destruct_non_existent_ptr - should panic ... ok
test tests::normal ... ok

successes:

---- tests::check_non_existent_ptr stdout ----
check(ptr 0xa, type 1): {}

thread 'tests::check_non_existent_ptr' panicked at src/lib.rs:177:18:
ptr 0xa should have type 1, but has no type currently
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tests::check_freed_ptr stdout ----
construct(ptr 0xa, type 1): {}
check(ptr 0xa, type 1): {ptr 0xa: type 1}
destruct(ptr 0xa, type 1): {ptr 0xa: type 1}
check(ptr 0xa, type 1): {}

thread 'tests::check_freed_ptr' panicked at src/lib.rs:187:18:
ptr 0xa should have type 1, but has no type currently

---- tests::construct_existing_ptr stdout ----
construct(ptr 0xa, type 1): {}
check(ptr 0xa, type 1): {ptr 0xa: type 1}
construct(ptr 0xa, type 1): {ptr 0xa: type 1}

thread 'tests::construct_existing_ptr' panicked at src/lib.rs:196:18:
trying to construct type 1 at ptr 0xa, but ptr 0xa is already type 1
poison: poisoned lock: another task failed inside

---- tests::destruct_non_existent_ptr stdout ----
destruct(ptr 0xa, type 1): {}

thread 'tests::destruct_non_existent_ptr' panicked at src/lib.rs:170:18:
trying to destruct type 1 at ptr 0xa, but ptr 0xa has no type currently
poison: poisoned lock: another task failed inside

---- tests::normal stdout ----
construct(ptr 0xa, type 1): {}
check(ptr 0xa, type 1): {ptr 0xa: type 1}
construct(ptr 0xb, type 2): {ptr 0xa: type 1}
check(ptr 0xa, type 1): {ptr 0xb: type 2, ptr 0xa: type 1}
check(ptr 0xb, type 2): {ptr 0xb: type 2, ptr 0xa: type 1}
destruct(ptr 0xa, type 1): {ptr 0xb: type 2, ptr 0xa: type 1}
check(ptr 0xb, type 2): {ptr 0xb: type 2}
destruct(ptr 0xb, type 2): {ptr 0xb: type 2}


successes:
    tests::check_freed_ptr
    tests::check_non_existent_ptr
    tests::construct_existing_ptr
    tests::destruct_non_existent_ptr
    tests::normal

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```