### PR TITLE
tests/type_confusion: add `dav1d_{alloc,free}` instead of `IA2_SHARED_DATA` and make `Dav1dContext` opaque

### DIFF
--- a/tests/type_confusion/dav1d.c
+++ b/tests/type_confusion/dav1d.c
@@ -8,6 +8,15 @@ RUN: cat dav1d_call_gates_1.ld | FileCheck --check-prefix=LINKARGS %s
 #define IA2_COMPARTMENT 2
 #include <ia2_compartment_init.inc>
 
+/// Allocate memory in dav1d's compartment 2.
+void* dav1d_alloc(const size_t size) {
+  return malloc(size);
+}
+
+void dav1d_free(void* const memory) {
+  free(memory);
+}
+
 IA2_CONSTRUCTOR // Registers that ptr `this` has type `Dav1dContext` now.
 int dav1d_open(Dav1dContext *const this, const Dav1dSettings *const s) {
   // Initialize `this`; implementation omitted.

--- a/tests/type_confusion/dav1d.c
+++ b/tests/type_confusion/dav1d.c
@@ -8,6 +8,12 @@ RUN: cat dav1d_call_gates_1.ld | FileCheck --check-prefix=LINKARGS %s
 #define IA2_COMPARTMENT 2
 #include <ia2_compartment_init.inc>
 
+struct Dav1dContext {
+  int field;
+};
+
+const size_t DAV1D_CONTEXT_SIZE = sizeof(Dav1dContext);
+
 /// Allocate memory in dav1d's compartment 2.
 void* dav1d_alloc(const size_t size) {
   return malloc(size);

--- a/tests/type_confusion/include/dav1d.h
+++ b/tests/type_confusion/include/dav1d.h
@@ -2,9 +2,9 @@
 
 #include <stddef.h>
 
-typedef struct {
-  int field;
-} Dav1dContext;
+typedef struct Dav1dContext Dav1dContext;
+
+extern const size_t DAV1D_CONTEXT_SIZE;
 
 typedef struct Dav1dSettings {
   int field;

--- a/tests/type_confusion/include/dav1d.h
+++ b/tests/type_confusion/include/dav1d.h
@@ -14,6 +14,10 @@ typedef struct {
   ptrdiff_t stride[2];
 } Dav1dPicture;
 
+void* dav1d_alloc(size_t size);
+
+void dav1d_free(void* memory);
+
 int dav1d_open(Dav1dContext *this, const Dav1dSettings *s);
 
 void dav1d_close(Dav1dContext *this);

--- a/tests/type_confusion/main.c
+++ b/tests/type_confusion/main.c
@@ -15,7 +15,8 @@ INIT_RUNTIME(2);
 #include <ia2_compartment_init.inc>
 
 Test(type_confusion, normal) {
-  Dav1dContext *c = dav1d_alloc(sizeof(Dav1dContext));
+  // `Dav1dContext` is opaque.
+  Dav1dContext *c = dav1d_alloc(DAV1D_CONTEXT_SIZE);
   Dav1dSettings *settings = dav1d_alloc(sizeof(Dav1dSettings));
   Dav1dPicture *pic = dav1d_alloc(sizeof(Dav1dPicture));
 
@@ -29,8 +30,8 @@ Test(type_confusion, normal) {
 }
 
 Test(type_confusion, uninitialized, .signal = SIGABRT) {
-  Dav1dContext *c = dav1d_alloc(sizeof(Dav1dContext));
-  Dav1dContext *c2 = dav1d_alloc(sizeof(Dav1dContext));
+  Dav1dContext *c = dav1d_alloc(DAV1D_CONTEXT_SIZE);
+  Dav1dContext *c2 = dav1d_alloc(DAV1D_CONTEXT_SIZE);
   Dav1dSettings *settings = dav1d_alloc(sizeof(Dav1dSettings));
   Dav1dPicture *pic = dav1d_alloc(sizeof(Dav1dPicture));
 
@@ -46,7 +47,7 @@ Test(type_confusion, uninitialized, .signal = SIGABRT) {
 }
 
 Test(type_confusion, wrong_type, .signal = SIGABRT) {
-  Dav1dContext *c = dav1d_alloc(sizeof(Dav1dContext));
+  Dav1dContext *c = dav1d_alloc(DAV1D_CONTEXT_SIZE);
   Dav1dSettings *settings = dav1d_alloc(sizeof(Dav1dSettings));
   Dav1dPicture *pic = dav1d_alloc(sizeof(Dav1dPicture));
 
@@ -61,7 +62,7 @@ Test(type_confusion, wrong_type, .signal = SIGABRT) {
 }
 
 Test(type_confusion, null, .signal = SIGABRT) {
-  Dav1dContext *c = dav1d_alloc(sizeof(Dav1dContext));
+  Dav1dContext *c = dav1d_alloc(DAV1D_CONTEXT_SIZE);
   Dav1dSettings *settings = dav1d_alloc(sizeof(Dav1dSettings));
   Dav1dPicture *pic = dav1d_alloc(sizeof(Dav1dPicture));
 
@@ -76,7 +77,7 @@ Test(type_confusion, null, .signal = SIGABRT) {
 }
 
 Test(type_confusion, use_after_free, .signal = SIGABRT) {
-  Dav1dContext *c = dav1d_alloc(sizeof(Dav1dContext));
+  Dav1dContext *c = dav1d_alloc(DAV1D_CONTEXT_SIZE);
   Dav1dSettings *settings = dav1d_alloc(sizeof(Dav1dSettings));
   Dav1dPicture *pic = dav1d_alloc(sizeof(Dav1dPicture));
 

--- a/tests/type_confusion/main.c
+++ b/tests/type_confusion/main.c
@@ -14,41 +14,78 @@ INIT_RUNTIME(2);
 #define IA2_COMPARTMENT 1
 #include <ia2_compartment_init.inc>
 
-Dav1dContext c IA2_SHARED_DATA;
-Dav1dSettings settings IA2_SHARED_DATA;
-Dav1dPicture pic IA2_SHARED_DATA;
-Dav1dContext c2 IA2_SHARED_DATA;
-
 Test(type_confusion, normal) {
-  dav1d_open(&c, &settings);
-  dav1d_get_picture(&c, &pic);
-  dav1d_close(&c);
+  Dav1dContext *c = dav1d_alloc(sizeof(Dav1dContext));
+  Dav1dSettings *settings = dav1d_alloc(sizeof(Dav1dSettings));
+  Dav1dPicture *pic = dav1d_alloc(sizeof(Dav1dPicture));
+
+  dav1d_open(c, settings);
+  dav1d_get_picture(c, pic);
+  dav1d_close(c);
+
+  dav1d_free(pic);
+  dav1d_free(settings);
+  dav1d_free(c);
 }
 
 Test(type_confusion, uninitialized, .signal = SIGABRT) {
-  dav1d_open(&c, &settings);
+  Dav1dContext *c = dav1d_alloc(sizeof(Dav1dContext));
+  Dav1dContext *c2 = dav1d_alloc(sizeof(Dav1dContext));
+  Dav1dSettings *settings = dav1d_alloc(sizeof(Dav1dSettings));
+  Dav1dPicture *pic = dav1d_alloc(sizeof(Dav1dPicture));
+
+  dav1d_open(c, settings);
   // Try to use another `Dav1dContext` that hasn't been constructed/opened yet.
-  dav1d_get_picture(&c2, &pic);
-  dav1d_close(&c);
+  dav1d_get_picture(c2, pic); // Will `SIGABRT`.
+  dav1d_close(c);
+
+  dav1d_free(pic);
+  dav1d_free(settings);
+  dav1d_free(c2);
+  dav1d_free(c);
 }
 
 Test(type_confusion, wrong_type, .signal = SIGABRT) {
-  dav1d_open(&c, &settings);
+  Dav1dContext *c = dav1d_alloc(sizeof(Dav1dContext));
+  Dav1dSettings *settings = dav1d_alloc(sizeof(Dav1dSettings));
+  Dav1dPicture *pic = dav1d_alloc(sizeof(Dav1dPicture));
+
+  dav1d_open(c, settings);
   // Try to use another type (`Dav1dPicture`) instead.
-  dav1d_get_picture((Dav1dContext *)&pic, &pic);
-  dav1d_close(&c);
+  dav1d_get_picture((Dav1dContext *)pic, pic); // Will `SIGABRT`.
+  dav1d_close(c);
+
+  dav1d_free(pic);
+  dav1d_free(settings);
+  dav1d_free(c);
 }
 
 Test(type_confusion, null, .signal = SIGABRT) {
-  dav1d_open(&c, &settings);
+  Dav1dContext *c = dav1d_alloc(sizeof(Dav1dContext));
+  Dav1dSettings *settings = dav1d_alloc(sizeof(Dav1dSettings));
+  Dav1dPicture *pic = dav1d_alloc(sizeof(Dav1dPicture));
+
+  dav1d_open(c, settings);
   // Try to `NULL`.
-  dav1d_get_picture(NULL, &pic);
-  dav1d_close(&c);
+  dav1d_get_picture(NULL, pic); // Will `SIGABRT`.
+  dav1d_close(c);
+
+  dav1d_free(pic);
+  dav1d_free(settings);
+  dav1d_free(c);
 }
 
 Test(type_confusion, use_after_free, .signal = SIGABRT) {
-  dav1d_open(&c, &settings);
-  dav1d_close(&c);
+  Dav1dContext *c = dav1d_alloc(sizeof(Dav1dContext));
+  Dav1dSettings *settings = dav1d_alloc(sizeof(Dav1dSettings));
+  Dav1dPicture *pic = dav1d_alloc(sizeof(Dav1dPicture));
+
+  dav1d_open(c, settings);
+  dav1d_close(c);
   // Try to use an already destructed `Dav1dContext`.
-  dav1d_get_picture(&c, &pic);
+  dav1d_get_picture(c, pic); // Will `SIGABRT`.
+
+  dav1d_free(pic);
+  dav1d_free(settings);
+  dav1d_free(c);
 }


### PR DESCRIPTION
`donna` is down, so I'm testing this in CI.

@fw-immunant, is this what you meant?