### PR TITLE
Minor rewriter fixes and cleanups

### DIFF
--- a/tools/rewriter/DetermineAbi.h
+++ b/tools/rewriter/DetermineAbi.h
@@ -1,7 +1,11 @@
 #pragma once
 #include "CAbi.h"
 #include "GenCallAsm.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion"
+#pragma GCC diagnostic ignored "-Wnonnull"
 #include "clang/AST/AST.h"
+#pragma GCC diagnostic pop
 
 auto determineAbiForDecl(const clang::FunctionDecl &fnDecl, Arch arch) -> AbiSignature;
 

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -513,16 +513,14 @@ public:
 
     std::string new_expr =
         "IA2_CALL("s + old_callee.str() + ", " + mangled_ty;
-    
+
     for (auto const &arg : fn_ptr_call->arguments()) {
-      new_expr += ", " + clang::Lexer::getSourceText(
-          clang::CharSourceRange::getTokenRange(arg->getSourceRange()), sm,
-          ctxt.getLangOpts())
-                     .str();
+      auto char_range = clang::CharSourceRange::getTokenRange(arg->getSourceRange());
+      new_expr += ", " + clang::Lexer::getSourceText(char_range, sm, ctxt.getLangOpts()).str();
     }
     new_expr += ")";
 
-    auto char_range = 
+    auto char_range =
         clang::CharSourceRange::getTokenRange(fn_ptr_call->getSourceRange());
 
     if (in_macro_expansion(char_range.getBegin(), sm)) {

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -232,7 +232,7 @@ public:
                    result.Nodes.getNodeAs<clang::TypeAliasDecl>(
                        "fnPtrTypedef")) {
       old_decl = llvm::cast<clang::Decl>(type_alias_decl);
-      old_type = typedef_decl->getUnderlyingType();
+      old_type = type_alias_decl->getUnderlyingType();
       generate_decl = [](const auto &new_type, const auto &name) {
         return "using "s + name + " = " + new_type;
       };

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -597,7 +597,6 @@ public:
     auto *fn_ptr_expr = result.Nodes.getNodeAs<clang::DeclRefExpr>("fnPtrExpr");
     assert(fn_ptr_expr != nullptr);
 
-    auto annotation = fn_ptr_expr->getDecl()->getAttr<clang::AnnotateAttr>();
     assert(result.SourceManager != nullptr);
     auto &sm = *result.SourceManager;
 


### PR DESCRIPTION
Split off of library-only mode, sending PR to keep that branch closer to `main`. The only real semantic change here is a fix for a bug in type alias handling.