### PR TITLE
runtime: fix zeroed PKRU in init_pkey

### DIFF
--- a/runtime/libia2/include/ia2_compartment_init.inc
+++ b/runtime/libia2/include/ia2_compartment_init.inc
@@ -81,7 +81,7 @@ __attribute__((constructor)) static void COMPARTMENT_IDENT(init_pkey)() {
       /* Set PKRU to fully untrusted (no access) */
       "xorl %%ecx, %%ecx\n"
       "xorl %%edx, %%edx\n"
-      "xorl %%eax, %%eax\n"
+      "mov_pkru_eax 0\n"
       "wrpkru\n"
       :
       :


### PR DESCRIPTION
we meant to zero the compartment; zeroing the PKRU gives access to *everything*