### PR TITLE
libia2 fixes for C++ compat

### DIFF
--- a/runtime/libia2/include/ia2_compartment_init.inc
+++ b/runtime/libia2/include/ia2_compartment_init.inc
@@ -44,7 +44,7 @@ extern int ia2_n_pkeys_to_alloc;
 extern char __start_ia2_shared_data __attribute__((visibility("hidden"))),
     __stop_ia2_shared_data __attribute__((visibility("hidden")));
 
-void ia2_set_up_tags(int *n_to_alloc);
+IA2_EXTERN_C void ia2_set_up_tags(int *n_to_alloc);
 __attribute__((constructor)) static void COMPARTMENT_IDENT(init_pkey)() {
   ia2_set_up_tags(&ia2_n_pkeys_to_alloc);
   struct IA2SharedSection shared_sections[2] = {{

--- a/runtime/libia2/include/ia2_compartment_init.inc
+++ b/runtime/libia2/include/ia2_compartment_init.inc
@@ -54,7 +54,7 @@ __attribute__((constructor)) static void COMPARTMENT_IDENT(init_pkey)() {
                                                 {NULL, NULL}};
   struct PhdrSearchArgs args = {
       .pkey = IA2_COMPARTMENT,
-      .address = &COMPARTMENT_IDENT(init_pkey),
+      .address = (const void *)&COMPARTMENT_IDENT(init_pkey),
       .extra_libraries = IA2_COMPARTMENT_LIBRARIES,
       .found_library_count = 0,
       .shared_sections = shared_sections,
@@ -110,7 +110,7 @@ __attribute__((constructor)) static void COMPARTMENT_IDENT(init_pkey)() {
 __attribute__((visibility("default"))) void COMPARTMENT_IDENT(init_tls)(void) {
   struct PhdrSearchArgs args = {
       .pkey = IA2_COMPARTMENT,
-      .address = &COMPARTMENT_IDENT(init_tls),
+      .address = (const void *)&COMPARTMENT_IDENT(init_tls),
   };
   dl_iterate_phdr(protect_tls_pages, &args);
 }

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -299,7 +299,7 @@ asm(".macro movz_shifted_tag_x18 tag\n"
 #if defined(__x86_64__)
 #define return_stackptr_if_compartment(compartment)                            \
   if (pkru == PKRU(compartment)) {                                             \
-    register void *out asm("rax");                                             \
+    register void **out asm("rax");                                             \
     __asm__ volatile(                                                          \
         "mov %%fs:(0), %%rax\n"                                                \
         "addq ia2_stackptr_" #compartment "@GOTTPOFF(%%rip), %%rax\n"          \

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -24,6 +24,12 @@ struct dl_phdr_info;
 #include <sys/mman.h>
 #include <unistd.h>
 
+#if __cplusplus
+#define IA2_EXTERN_C extern "C"
+#else
+#define IA2_EXTERN_C
+#endif
+
 #define IA2_CONCAT_(x, y) x##y
 #define IA2_CONCAT(x, y) IA2_CONCAT_(x, y)
 
@@ -136,8 +142,8 @@ struct dl_phdr_info;
 /// Iterates over shared objects until an object containing the address \p
 /// data->address is found. Protect the pages in that object according to the
 /// information in the search arguments.
-int protect_pages(struct dl_phdr_info *info, size_t size, void *data);
-int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data);
+IA2_EXTERN_C int protect_pages(struct dl_phdr_info *info, size_t size, void *data);
+IA2_EXTERN_C int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data);
 
 struct IA2SharedSection {
   const void *start;
@@ -332,10 +338,10 @@ static int ia2_mprotect_with_tag(void *addr, size_t len, int prot, int tag) {
 #define ia2_mprotect_with_tag pkey_mprotect
 #endif
 #endif
-char *allocate_stack(int i);
-void allocate_stack_0();
-void verify_tls_padding(void);
-void ia2_set_up_tags(int *n_to_alloc);
+IA2_EXTERN_C char *allocate_stack(int i);
+IA2_EXTERN_C void allocate_stack_0();
+IA2_EXTERN_C void verify_tls_padding(void);
+IA2_EXTERN_C void ia2_set_up_tags(int *n_to_alloc);
 __attribute__((__noreturn__)) void ia2_reinit_stack_err(int i);
 
 /* clang-format can't handle inline asm in macros */


### PR DESCRIPTION
Developed working on FF compartmentalization. We don't handle C++ constructs crossing the compartment boundary but might need to include our headers from C++ sources.