### PR TITLE
Forward-port benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         run: rustup toolchain install stable-x86_64-unknown-linux-gnu
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Init b63 submodule # Can't use checkout@v4 because it unconditionally inits all
+        run: git submodule update --init external/b63
       - name: Build
         run: |
           LLVM_DIR=`llvm-config --cmakedir`
@@ -98,6 +100,8 @@ jobs:
           version: 1.0 # version of cache to load
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Init b63 submodule # Can't use checkout@v4 because it unconditionally inits all
+        run: git submodule update --init external/b63
       - name: Cache built QEMU
         id: cache-qemu
         uses: actions/cache@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/glibc"]
 	path = external/glibc
 	url = https://www.sourceware.org/git/glibc.git
+[submodule "external/b63"]
+	path = external/b63
+	url = https://github.com/okuvshynov/b63.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,10 @@ set(EXTERNAL_DIR ${PROJECT_SOURCE_DIR}/external)
 # runtime needs to be first so it defines libia2_BINARY_DIR
 add_subdirectory(runtime)
 
+add_subdirectory(benchmarks)
+
 if (NOT LIBIA2_AARCH64)
-    add_subdirectory(examples)
+  add_subdirectory(examples)
 endif()
 add_subdirectory(misc)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ add_subdirectory(runtime)
 add_subdirectory(benchmarks)
 
 if (NOT LIBIA2_AARCH64)
-  add_subdirectory(examples)
+    add_subdirectory(examples)
 endif()
 add_subdirectory(misc)
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,7 @@
+include("../cmake/define-ia2-wrapper.cmake")
+include("../cmake/define-test.cmake")
+
+add_library(b63 INTERFACE)
+target_include_directories(b63 INTERFACE ${PROJECT_SOURCE_DIR}/external/b63/include)
+
+add_subdirectory(microbench)

--- a/benchmarks/microbench/CMakeLists.txt
+++ b/benchmarks/microbench/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_ia2_compartment(microbench LIBRARY
+  SOURCES microbench_lib.c
+  PKEY 0
+)
+
+add_ia2_compartment(microbenchmark EXECUTABLE
+  SOURCES microbench_main.c
+  LIBRARIES b63 m microbench
+  PKEY 1
+)
+
+add_ia2_compartment(microbench_indirect LIBRARY
+  SOURCES microbench_lib_indirect.c
+  PKEY 0
+)
+
+add_ia2_compartment(microbench_indirect2 LIBRARY
+  SOURCES microbench_lib_indirect_compartment2.c
+  PKEY 2
+)
+
+add_ia2_compartment(microbenchmark_indirect EXECUTABLE
+  SOURCES microbench_indirect.c
+  LIBRARIES b63 m microbench_indirect microbench_indirect2
+  PKEY 1
+)

--- a/benchmarks/microbench/microbench_indirect.c
+++ b/benchmarks/microbench/microbench_indirect.c
@@ -1,0 +1,43 @@
+#include "b63/register.h"
+#include <b63/b63.h>
+#include <b63/counters/perf_events.h>
+#include <ia2.h>
+
+#include "microbench_lib.h"
+#include "microbench_lib2.h"
+
+INIT_RUNTIME(2);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
+
+void (*fn_ptr)(void);
+
+IA2_BEGIN_NO_WRAP
+void (*fn_ptr_unwrapped)(void);
+IA2_END_NO_WRAP
+
+B63_BASELINE(indirect, n) {
+  fn_ptr_unwrapped = no_op_unwrapped;
+  for (size_t i = 0; i < n; ++i) {
+    fn_ptr_unwrapped();
+  }
+}
+
+B63_BENCHMARK(indirect_wrapped, n) {
+  IA2_AS_PTR(fn_ptr) = (void *)no_op_unwrapped;
+  for (size_t i = 0; i < n; ++i) {
+    fn_ptr();
+  }
+}
+
+B63_BENCHMARK(indirect_compartment2, n) {
+  fn_ptr = no_op_compartment2;
+  for (size_t i = 0; i < n; ++i) {
+    IA2_CALL(fn_ptr, _ZTSPFvvE);
+  }
+}
+
+int main(int argc, char *argv[]) {
+  B63_RUN(argc, argv);
+  return 0;
+}

--- a/benchmarks/microbench/microbench_lib.c
+++ b/benchmarks/microbench/microbench_lib.c
@@ -1,0 +1,5 @@
+#include "microbench_lib.h"
+
+void no_op(void) {}
+
+void no_op_unwrapped(void) {}

--- a/benchmarks/microbench/microbench_lib.h
+++ b/benchmarks/microbench/microbench_lib.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <ia2.h>
+
+void no_op(void);
+
+IA2_BEGIN_NO_WRAP
+void no_op_unwrapped(void);
+IA2_END_NO_WRAP

--- a/benchmarks/microbench/microbench_lib2.h
+++ b/benchmarks/microbench/microbench_lib2.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void no_op_compartment2(void);

--- a/benchmarks/microbench/microbench_lib_indirect.c
+++ b/benchmarks/microbench/microbench_lib_indirect.c
@@ -1,0 +1,5 @@
+#include "microbench_lib.h"
+
+void no_op(void) {}
+
+void no_op_unwrapped(void) {}

--- a/benchmarks/microbench/microbench_lib_indirect_compartment2.c
+++ b/benchmarks/microbench/microbench_lib_indirect_compartment2.c
@@ -1,0 +1,8 @@
+#include "microbench_lib2.h"
+
+#include <ia2.h>
+
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>
+
+void no_op_compartment2(void) {}

--- a/benchmarks/microbench/microbench_main.c
+++ b/benchmarks/microbench/microbench_main.c
@@ -1,0 +1,27 @@
+#include "b63/register.h"
+#include <b63/b63.h>
+#include <b63/counters/perf_events.h>
+#include <ia2.h>
+
+#include "microbench_lib.h"
+
+INIT_RUNTIME(1);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
+
+B63_BASELINE(no_op, n) {
+  for (size_t i = 0; i < n; ++i) {
+    no_op_unwrapped();
+  }
+}
+
+B63_BENCHMARK(no_op_wrapped, n) {
+  for (size_t i = 0; i < n; ++i) {
+    no_op();
+  }
+}
+
+int main(int argc, char *argv[]) {
+  B63_RUN(argc, argv);
+  return 0;
+}

--- a/examples/video_player/CMakeLists.txt
+++ b/examples/video_player/CMakeLists.txt
@@ -18,3 +18,4 @@ add_ia2_compartment(video_player EXECUTABLE
   INCLUDE_DIRECTORIES include ${SDL2_INCLUDE_DIRS}
 )
 
+add_subdirectory(benchmark)

--- a/examples/video_player/benchmark/CMakeLists.txt
+++ b/examples/video_player/benchmark/CMakeLists.txt
@@ -1,0 +1,29 @@
+pkg_check_modules(FFMPEG REQUIRED libavcodec libavformat libavutil libswscale)
+pkg_check_modules(SDL2 REQUIRED sdl2)
+
+# Build video decoder library. We have to build a second copy of this because we
+# can't shared shared libraries across multiple compartmentalized executables
+# yet.
+add_ia2_compartment(video_decoder_benchmark_lib LIBRARY
+  SOURCES video_decoder.c
+  PKEY 2
+  INCLUDE_DIRECTORIES include
+  LIBRARIES ${FFMPEG_LIBRARIES}
+)
+
+add_ia2_compartment(video_decoder_benchmark EXECUTABLE
+  SOURCES benchmark.c
+  LIBRARIES video_decoder_benchmark_lib ${SDL2_LIBRARIES} ${FFMPEG_LIBRARIES}
+  PKEY 1
+  INCLUDE_DIRECTORIES include ${SDL2_INCLUDE_DIRS}
+)
+
+
+# Non-compartmentalized baseline
+add_library(libvideo_decoder_benchmark_baseline SHARED video_decoder.c)
+target_include_directories(libvideo_decoder_benchmark_baseline PUBLIC include $<TARGET_PROPERTY:libia2,INCLUDE_DIRECTORIES>)
+target_link_libraries(libvideo_decoder_benchmark_baseline ${FFMPEG_LIBRARIES})
+
+add_executable(video_decoder_benchmark_baseline benchmark.c)
+target_link_libraries(video_decoder_benchmark_baseline ${SDL2_LIBRARIES} ${FFMPEG_LIBRARIES})
+target_link_libraries(video_decoder_benchmark_baseline libvideo_decoder_benchmark_baseline)

--- a/examples/video_player/benchmark/benchmark.c
+++ b/examples/video_player/benchmark/benchmark.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Immunant, Inc.
+ */
+
+#include <err.h>
+#include <fcntl.h>
+#include <ia2.h>
+#include <libswscale/swscale.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <video_decoder.h>
+
+INIT_RUNTIME(2);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
+
+static char *video_data;
+static size_t video_size;
+static int video_width IA2_SHARED_DATA;
+static int video_height IA2_SHARED_DATA;
+static enum AVPixelFormat video_pix_fmt IA2_SHARED_DATA;
+static struct SwsContext *sws_ctx;
+static uint8_t *y_plane, *u_plane, *v_plane;
+
+static void process_frame(AVFrame *frame, void *ctx) {}
+
+void decode() {
+  struct video_decoder *decoder;
+
+  decoder = video_decoder_init(video_data, video_size);
+  if (!decoder) {
+    errx(1, "Failed to initialize decoder");
+  }
+  video_decoder_get_info(decoder, &video_width, &video_height, &video_pix_fmt);
+  printf("Video dimensions: %dx%d\n", video_width, video_height);
+
+  if (!video_decoder_decode(decoder, NULL, process_frame)) {
+    errx(1, "Failed to decode frame");
+  }
+}
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    errx(1, "Usage: video_decoder <file>");
+  }
+
+  int fd = open(argv[1], O_RDONLY);
+  if (fd == -1) {
+    err(1, "Failed to open file: %s", argv[1]);
+  }
+
+  struct stat buf;
+  if (fstat(fd, &buf) == -1) {
+    err(1, "stat() failed on file: %s", argv[1]);
+  }
+
+  video_size = buf.st_size;
+  printf("Playing video: %zu bytes\n", video_size);
+
+  video_data = mmap(NULL, video_size, PROT_READ, MAP_PRIVATE, fd, 0);
+  if (video_data == MAP_FAILED) {
+    err(1, "Failed to mmap file: %s", argv[1]);
+  }
+
+  decode();
+
+  munmap(video_data, video_size);
+  close(fd);
+  return 0;
+}

--- a/examples/video_player/benchmark/include/video_decoder.h
+++ b/examples/video_player/benchmark/include/video_decoder.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 Immunant, Inc.
+ */
+#pragma once
+
+#include <libavcodec/avcodec.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+struct video_decoder;
+
+typedef void (*video_decoder_frame_callback_t)(AVFrame*, void*);
+
+struct video_decoder *video_decoder_init(const char *file_data,
+                                         size_t file_size);
+
+void video_decoder_get_info(struct video_decoder *, int *width, int *height,
+                            enum AVPixelFormat *pix_fmt);
+
+bool video_decoder_decode(struct video_decoder *, void *,
+                          video_decoder_frame_callback_t);

--- a/examples/video_player/benchmark/video_decoder.c
+++ b/examples/video_player/benchmark/video_decoder.c
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2023 Immunant, Inc.
+ */
+
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/avutil.h>
+#include <sys/param.h>
+#include <video_decoder.h>
+
+#include <ia2.h>
+#define IA2_COMPARTMENT 2
+#define IA2_COMPARTMENT_LIBRARIES "libavcodec.so;libavformat.so"
+#include <ia2_compartment_init.inc>
+
+#define AVIO_BUF_SIZE 65536
+
+struct video_decoder {
+  const char *file_data;
+  size_t file_size;
+  AVFormatContext *fmt_ctx;
+  AVIOContext *avio_ctx;
+  AVCodecContext *codec_ctx;
+  int video_stream_idx;
+  bool fmt_ctx_opened;
+};
+
+static int read_input_buffer(void *opaque, uint8_t *buf, int buf_size) {
+  struct video_decoder *d = opaque;
+  size_t count = MIN(d->file_size, buf_size);
+  if (!count) {
+    return AVERROR_EOF;
+  }
+
+  memcpy(buf, d->file_data, count);
+  d->file_data += count;
+  d->file_size -= count;
+  return count;
+}
+
+struct video_decoder *video_decoder_init(const char *file_data,
+                                         size_t file_size) {
+  struct video_decoder *d = NULL;
+  int ret;
+
+  d = calloc(1, sizeof(struct video_decoder));
+  if (!d) {
+    goto err_alloc_decoder;
+  }
+
+  d->file_data = file_data;
+  d->file_size = file_size;
+
+  d->fmt_ctx = avformat_alloc_context();
+  if (!d->fmt_ctx) {
+    goto err_alloc_fmt_context;
+  }
+
+  void *avio_ctx_buffer = av_malloc(AVIO_BUF_SIZE);
+  if (!avio_ctx_buffer) {
+    goto err_alloc_buffer;
+  }
+
+  d->avio_ctx = avio_alloc_context(avio_ctx_buffer, AVIO_BUF_SIZE, 0, d,
+                                   IA2_IGNORE(read_input_buffer), NULL, NULL);
+  if (!d->avio_ctx) {
+    goto err_alloc_avio_context;
+  }
+  d->fmt_ctx->pb = d->avio_ctx;
+
+  /* d->avio_ctx takes ownership of the buffer */
+  avio_ctx_buffer = NULL;
+
+  ret = avformat_open_input(&d->fmt_ctx, NULL, NULL, NULL);
+  if (ret) {
+    goto err_open_input;
+  }
+  d->fmt_ctx_opened = true;
+
+  ret = avformat_find_stream_info(d->fmt_ctx, NULL);
+  if (ret < 0) {
+    goto err_find_stream_info;
+  }
+
+  d->video_stream_idx =
+      av_find_best_stream(d->fmt_ctx, AVMEDIA_TYPE_VIDEO, -1, -1, NULL, 0);
+  if (d->video_stream_idx < 0) {
+    goto err_find_stream;
+  }
+
+  AVStream *video_stream = d->fmt_ctx->streams[d->video_stream_idx];
+  const AVCodec *codec = avcodec_find_decoder(video_stream->codecpar->codec_id);
+  if (!codec) {
+    goto err_find_codec;
+  }
+
+  d->codec_ctx = avcodec_alloc_context3(codec);
+  if (!d->codec_ctx) {
+    goto err_alloc_codec_context;
+  }
+  d->codec_ctx->pix_fmt = AV_PIX_FMT_YUV420P;
+
+  ret = avcodec_parameters_to_context(d->codec_ctx, video_stream->codecpar);
+  if (ret) {
+    goto err_params_to_context;
+  }
+
+  ret = avcodec_open2(d->codec_ctx, codec, NULL);
+  if (ret < 0) {
+    goto err_open_codec;
+  }
+
+  /* Success */
+  return d;
+
+err_open_codec:
+err_params_to_context:
+  avcodec_free_context(&d->codec_ctx);
+err_alloc_codec_context:
+err_find_codec:
+err_find_stream:
+err_find_stream_info:
+  avformat_close_input(&d->fmt_ctx);
+err_open_input:
+  av_free(d->avio_ctx->buffer);
+  av_free(d->avio_ctx);
+err_alloc_avio_context:
+  av_free(avio_ctx_buffer);
+err_alloc_buffer:
+  avformat_free_context(d->fmt_ctx);
+err_alloc_fmt_context:
+  free(d);
+err_alloc_decoder:
+  return NULL;
+}
+
+void video_decoder_get_info(struct video_decoder *d, int *width, int *height,
+                            enum AVPixelFormat *pix_fmt) {
+  if (width) {
+    *width = d->codec_ctx->width;
+  }
+  if (height) {
+    *height = d->codec_ctx->height;
+  }
+  if (pix_fmt) {
+    *pix_fmt = d->codec_ctx->pix_fmt;
+  }
+}
+
+bool video_decoder_decode(struct video_decoder *d, void *ctx,
+                          video_decoder_frame_callback_t f) {
+  int ret;
+
+  AVFrame *frame = av_frame_alloc();
+  if (!frame) {
+    goto err_alloc_frame;
+  }
+
+  AVPacket *pkt = av_packet_alloc();
+  if (!pkt) {
+    goto err_alloc_packet;
+  }
+
+  for (;;) {
+    ret = av_read_frame(d->fmt_ctx, pkt);
+    if (ret < 0) {
+      break;
+    }
+
+    if (pkt->stream_index != d->video_stream_idx) {
+      av_packet_unref(pkt);
+      continue;
+    }
+
+    ret = avcodec_send_packet(d->codec_ctx, pkt);
+    av_packet_unref(pkt);
+    if (ret < 0) {
+      goto err_send_packet;
+    }
+
+    while (ret >= 0) {
+      ret = avcodec_receive_frame(d->codec_ctx, frame);
+      if (ret == AVERROR_EOF || ret == AVERROR(EAGAIN)) {
+        break;
+      } else if (ret < 0) {
+        goto err_receive_frame;
+      }
+
+      f(frame, ctx);
+      av_frame_unref(frame);
+    }
+
+    if (ret == AVERROR_EOF) {
+      break;
+    }
+  }
+
+  av_packet_free(&pkt);
+  av_frame_free(&frame);
+  return true;
+
+err_receive_frame:
+err_send_packet:
+  av_packet_free(&pkt);
+err_alloc_packet:
+  av_frame_free(&frame);
+err_alloc_frame:
+  return false;
+}

--- a/runtime/libia2/include/ia2.h
+++ b/runtime/libia2/include/ia2.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef IA2_ENABLE
+#define IA2_ENABLE 0
+#endif
+
 // This include must come first so we define _GNU_SOURCE before including
 // standard headers. ia2_internal.h requires GNU-specific headers.
 #if IA2_ENABLE


### PR DESCRIPTION
@rinon wrote some nice microbenchmarks and a larger video-decoding macrobenchmark. There's no reason not to merge these to keep them from bitrotting. This PR brings them into the build but doesn't run benchmarks as part of CI; we can decide if we want to do that later.