### PR TITLE
Add test timeout to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test-on-pkru-enabled-host:
     runs-on: self-hosted
+    timeout-minutes: 5
     continue-on-error: ${{ matrix.ia2-tracer == 'ON' }}
     strategy:
       fail-fast: true

--- a/runtime/libia2/include/permissive_mode.h
+++ b/runtime/libia2/include/permissive_mode.h
@@ -384,7 +384,7 @@ void *log_mpk_violations(void *arg) {
   assert(log);
   while (1) {
     // We don't want this thread to just spin if nothing is happening
-    sleep(1);
+    usleep(10000);
 
     flush_queue(log);
 


### PR DESCRIPTION
We've been seeing some CI jobs take hours when they should take less than a minute. This should at least let these time out and not hose the whole infrastructure.