### PR TITLE
permissive_mode: label stacks and TLS regions in all threads

### DIFF
--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -262,7 +262,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
 
   const int pkey = search_args->pkey;
 
-  struct ia2_thread_data *const thread_data = ia2_thread_data_get_current_thread();
+  struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_current_thread();
 
   // Protect TLS segment.
   for (size_t i = 0; i < info->dlpi_phnum; i++) {
@@ -318,8 +318,8 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
           printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
           exit(-1);
         }
-        if (thread_data) {
-          thread_data->tls_addr_compartment1_first = (uintptr_t)start_round_down;
+        if (thread_metadata) {
+          thread_metadata->tls_addr_compartment1_first = (uintptr_t)start_round_down;
         }
       }
       uint64_t after_untrusted_region_start = untrusted_stackptr_addr + 0x1000;
@@ -332,8 +332,8 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
           printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
           exit(-1);
         }
-        if (thread_data) {
-          thread_data->tls_addr_compartment1_second = (uintptr_t)after_untrusted_region_start;
+        if (thread_metadata) {
+          thread_metadata->tls_addr_compartment1_second = (uintptr_t)after_untrusted_region_start;
         }
       }
     } else {
@@ -344,8 +344,8 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
         printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
         exit(-1);
       }
-      if (thread_data) {
-        thread_data->tls_addrs[pkey] = (uintptr_t)start_round_down;
+      if (thread_metadata) {
+        thread_metadata->tls_addrs[pkey] = (uintptr_t)start_round_down;
       }
     }
   }

--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -5,8 +5,9 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "ia2_internal.h"
 #include "ia2.h"
+#include "ia2_internal.h"
+#include "ia2_threads.h"
 
 #if defined(__x86_64__)
 
@@ -246,12 +247,6 @@ static int segment_flags_to_access_flags(Elf64_Word flags) {
       ((flags & PF_R) != 0 ? PROT_READ : 0);
 }
 
-/// The TLS region is split only for the first compartment,
-/// so we need two addresses for just that one.
-uintptr_t ia2_tls_addr_compartment1_first IA2_SHARED_DATA = 0;
-uintptr_t ia2_tls_addr_compartment1_second IA2_SHARED_DATA = 0;
-uintptr_t ia2_tls_addrs[IA2_MAX_COMPARTMENTS] IA2_SHARED_DATA = {0};
-
 int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
   if (!data || !info) {
     printf("Passed invalid args to dl_iterate_phdr callback\n");
@@ -266,6 +261,8 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
   }
 
   const int pkey = search_args->pkey;
+
+  struct ia2_thread_data *const thread_data = ia2_thread_data_get_current_thread();
 
   // Protect TLS segment.
   for (size_t i = 0; i < info->dlpi_phnum; i++) {
@@ -321,7 +318,9 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
           printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
           exit(-1);
         }
-        ia2_tls_addr_compartment1_first = (uintptr_t)start_round_down;
+        if (thread_data) {
+          thread_data->tls_addr_compartment1_first = (uintptr_t)start_round_down;
+        }
       }
       uint64_t after_untrusted_region_start = untrusted_stackptr_addr + 0x1000;
       uint64_t after_untrusted_region_len = end - after_untrusted_region_start;
@@ -333,7 +332,9 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
           printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
           exit(-1);
         }
-        ia2_tls_addr_compartment1_second = (uintptr_t)after_untrusted_region_start;
+        if (thread_data) {
+          thread_data->tls_addr_compartment1_second = (uintptr_t)after_untrusted_region_start;
+        }
       }
     } else {
       int mprotect_err =
@@ -343,7 +344,9 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
         printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
         exit(-1);
       }
-      ia2_tls_addrs[pkey] = (uintptr_t)start_round_down;
+      if (thread_data) {
+        thread_data->tls_addrs[pkey] = (uintptr_t)start_round_down;
+      }
     }
   }
 

--- a/runtime/libia2/include/ia2_threads.h
+++ b/runtime/libia2/include/ia2_threads.h
@@ -15,8 +15,8 @@ struct ia2_thread_metadata {
   /// The TLS region is split only for the first compartment,
   /// so we need two addresses for just that one.
   ///
-  /// Compartment 1's TLS region is split because there is
-  /// a page of unprotected data for `ia2_stackptr_0` plus padding,
+  /// Compartment 1's TLS region is split because there is a page of
+  /// unprotected data for `ia2_stackptr_0` (in compartment 0), plus padding,
   /// as we don't have a general implementation of shared TLS yet,
   /// but `ia2_stackptr_0` is special-cased for now
   /// as it must be stored in TLS and unprotected.

--- a/runtime/libia2/include/ia2_threads.h
+++ b/runtime/libia2/include/ia2_threads.h
@@ -2,7 +2,7 @@
 
 #include "ia2.h"
 
-struct ia2_thread_data {
+struct ia2_thread_metadata {
   /// The addresses of each compartment's stack for this thread.
   ///
   /// This data is shared, so it should not be trusted for use as a pointer,
@@ -37,14 +37,14 @@ struct ia2_addr_location {
   int compartment;
 };
 
-/// Find the `struct ia2_thread_data*` for the current thread,
+/// Find the `struct ia2_thread_metadata*` for the current thread,
 /// adding (but not allocating) one if there isn't one yet.
 /// If there is no memory for more or an error, `NULL` is returned.
 /// This is a purely lookup and/or additive operation,
-/// so the lifetime of the returned `struct ia2_thread_data*` is infinite,
+/// so the lifetime of the returned `struct ia2_thread_metadata*` is infinite,
 /// and since it's thread-specific,
 /// it is thread-safe to read and write.
-struct ia2_thread_data *ia2_thread_data_get_current_thread(void);
+struct ia2_thread_metadata *ia2_thread_metadata_get_current_thread(void);
 
 /// Find the `ia2_addr_location` of `addr`.
 /// If it is not found or there is an error,

--- a/runtime/libia2/include/ia2_threads.h
+++ b/runtime/libia2/include/ia2_threads.h
@@ -26,7 +26,7 @@ struct ia2_addr_location {
   /// `NULL` if unknown.
   const char *name;
 
-  /// The thread ID of the thread this address is on.
+  /// The thread ID of the thread this address belongs to.
   ///
   /// `-1` if unknown.
   pid_t tid;

--- a/runtime/libia2/include/ia2_threads.h
+++ b/runtime/libia2/include/ia2_threads.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "ia2.h"
+
+struct ia2_thread_data {
+  /// The addresses of each compartment's stack for this thread.
+  ///
+  /// This data is shared, so it should not be trusted for use as a pointer,
+  /// but it can be used best effort as a provenance-less address.
+  uintptr_t stack_addrs[IA2_MAX_COMPARTMENTS];
+};
+
+struct ia2_addr_location {
+  /// A descriptive name of what this address points to.
+  /// For example, "stack".
+  ///
+  /// `NULL` if unknown.
+  const char *name;
+
+  /// The thread ID of the thread this address is on.
+  ///
+  /// `-1` if unknown.
+  pid_t tid;
+
+  /// The compartment this address is in.
+  ///
+  /// `-1` if unknown.
+  int compartment;
+};
+
+/// Find the `struct ia2_thread_data*` for the current thread,
+/// adding (but not allocating) one if there isn't one yet.
+/// If there is no memory for more or an error, `NULL` is returned.
+/// This is a purely lookup and/or additive operation,
+/// so the lifetime of the returned `struct ia2_thread_data*` is infinite,
+/// and since it's thread-specific,
+/// it is thread-safe to read and write.
+struct ia2_thread_data *ia2_thread_data_get_current_thread(void);
+
+/// Find the `ia2_addr_location` of `addr`.
+/// If it is not found or there is an error,
+/// the fields are set to `NULL` or `-1` depending on the type.
+struct ia2_addr_location ia2_addr_location_find(uintptr_t addr);

--- a/runtime/libia2/include/ia2_threads.h
+++ b/runtime/libia2/include/ia2_threads.h
@@ -2,11 +2,10 @@
 
 #include "ia2.h"
 
+/// The data here is shared, so it should not be trusted for use as a pointer,
+/// but it can be used best effort for non-trusted purposes.
 struct ia2_thread_metadata {
   /// The addresses of each compartment's stack for this thread.
-  ///
-  /// This data is shared, so it should not be trusted for use as a pointer,
-  /// but it can be used best effort for non-trusted purposes.
   uintptr_t stack_addrs[IA2_MAX_COMPARTMENTS];
 
   /// The addresses of each compartment's TLS region for this thread,

--- a/runtime/libia2/include/ia2_threads.h
+++ b/runtime/libia2/include/ia2_threads.h
@@ -14,6 +14,12 @@ struct ia2_thread_metadata {
 
   /// The TLS region is split only for the first compartment,
   /// so we need two addresses for just that one.
+  ///
+  /// Compartment 1's TLS region is split because there is
+  /// a page of unprotected data for `ia2_stackptr_0` plus padding,
+  /// as we don't have a general implementation of shared TLS yet,
+  /// but `ia2_stackptr_0` is special-cased for now
+  /// as it must be stored in TLS and unprotected.
   uintptr_t tls_addr_compartment1_first;
   uintptr_t tls_addr_compartment1_second;
 };

--- a/runtime/libia2/include/ia2_threads.h
+++ b/runtime/libia2/include/ia2_threads.h
@@ -6,7 +6,7 @@ struct ia2_thread_metadata {
   /// The addresses of each compartment's stack for this thread.
   ///
   /// This data is shared, so it should not be trusted for use as a pointer,
-  /// but it can be used best effort as a provenance-less address.
+  /// but it can be used best effort for non-trusted purposes.
   uintptr_t stack_addrs[IA2_MAX_COMPARTMENTS];
 
   /// The addresses of each compartment's TLS region for this thread,

--- a/runtime/libia2/include/ia2_threads.h
+++ b/runtime/libia2/include/ia2_threads.h
@@ -8,6 +8,15 @@ struct ia2_thread_data {
   /// This data is shared, so it should not be trusted for use as a pointer,
   /// but it can be used best effort as a provenance-less address.
   uintptr_t stack_addrs[IA2_MAX_COMPARTMENTS];
+
+  /// The addresses of each compartment's TLS region for this thread,
+  /// except for compartment 1, which has split TLS regions (see below).
+  uintptr_t tls_addrs[IA2_MAX_COMPARTMENTS];
+
+  /// The TLS region is split only for the first compartment,
+  /// so we need two addresses for just that one.
+  uintptr_t tls_addr_compartment1_first;
+  uintptr_t tls_addr_compartment1_second;
 };
 
 struct ia2_addr_location {

--- a/runtime/libia2/include/permissive_mode.h
+++ b/runtime/libia2/include/permissive_mode.h
@@ -468,7 +468,7 @@ __attribute__((constructor)) void permissive_mode_init(void) {
 // `getline` calls `malloc` inside of `libc`,
 // but we wrap `malloc` with `__wrap_malloc`,
 // so we need to free what `getline` allocated with `__real_free`.
-void __real_free(void *ptr);
+typeof(IA2_IGNORE(free)) __real_free;
 
 extern uintptr_t ia2_stack_addrs[IA2_MAX_COMPARTMENTS];
 

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -36,9 +36,9 @@ char *allocate_stack(int i) {
   stack = (char *)((uint64_t)stack | (uint64_t)i << 56);
 #endif
 
-  struct ia2_thread_data *const thread_data = ia2_thread_data_get_current_thread();
-  if (thread_data) {
-    thread_data->stack_addrs[i] = (uintptr_t)stack;
+  struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_current_thread();
+  if (thread_metadata) {
+    thread_metadata->stack_addrs[i] = (uintptr_t)stack;
   }
 
 #ifdef __aarch64__

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -154,8 +154,21 @@ struct ia2_addr_location ia2_all_threads_data_find_addr(struct ia2_all_threads_d
         location.compartment = compartment;
         goto unlock;
       }
+      if (addr == thread_data->tls_addrs[compartment]) {
+        location.name = "tls";
+        location.tid = tid;
+        location.compartment = compartment;
+        goto unlock;
+      }
+      if (addr == thread_data->tls_addr_compartment1_first || addr == thread_data->tls_addr_compartment1_second) {
+        location.name = "tls";
+        location.tid = tid;
+        location.compartment = 1;
+        goto unlock;
+      }
     }
   }
+
   goto unlock;
 
 unlock:

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -75,9 +75,7 @@ void *ia2_thread_begin(void *arg) {
 #endif
 }
 
-int __real_pthread_create(pthread_t *restrict thread,
-                          const pthread_attr_t *restrict attr, void *(*fn)(void *),
-                          void *data);
+typeof(pthread_create) __real_pthread_create;
 
 int __wrap_pthread_create(pthread_t *restrict thread,
                           const pthread_attr_t *restrict attr, void *(*fn)(void *),

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -111,7 +111,7 @@ struct ia2_all_threads_data {
 
 struct ia2_thread_data *ia2_all_threads_data_lookup(struct ia2_all_threads_data *const this, const pid_t tid) {
   struct ia2_thread_data *data = NULL;
-  if (pthread_mutex_lock(&this->lock) == -1) {
+  if (pthread_mutex_lock(&this->lock) != 0) {
     goto ret;
   }
   for (size_t i = 0; i < this->num_threads; i++) {
@@ -141,7 +141,7 @@ struct ia2_addr_location ia2_all_threads_data_find_addr(struct ia2_all_threads_d
       .tid = -1,
       .compartment = -1,
   };
-  if (pthread_mutex_lock(&this->lock) == -1) {
+  if (pthread_mutex_lock(&this->lock) != 0) {
     goto ret;
   }
   for (size_t thread = 0; thread < this->num_threads; thread++) {

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -99,7 +99,7 @@ struct ia2_all_threads_data {
   pthread_mutex_t lock;
   size_t num_threads;
   pid_t tids[IA2_MAX_THREADS];
-  struct ia2_thread_data ia2_thread_data[IA2_MAX_THREADS];
+  struct ia2_thread_data thread_data[IA2_MAX_THREADS];
 };
 
 #define array_len(a) (sizeof(a) / sizeof(*(a)))
@@ -111,15 +111,15 @@ struct ia2_thread_data *ia2_all_threads_data_lookup(struct ia2_all_threads_data 
   }
   for (size_t i = 0; i < this->num_threads; i++) {
     if (this->tids[i] == tid) {
-      data = &this->ia2_thread_data[i];
+      data = &this->thread_data[i];
       goto unlock;
     }
   }
-  if (this->num_threads >= array_len(this->ia2_thread_data)) {
+  if (this->num_threads >= array_len(this->thread_data)) {
     fprintf(stderr, "created %zu threads, but can't store them all (max is IA2_MAX_THREADS)\n", this->num_threads);
     goto unlock;
   }
-  data = &this->ia2_thread_data[this->num_threads];
+  data = &this->thread_data[this->num_threads];
   this->tids[this->num_threads] = tid;
   this->num_threads++;
   goto unlock;
@@ -142,7 +142,7 @@ struct ia2_addr_location ia2_all_threads_data_find_addr(struct ia2_all_threads_d
   for (size_t thread = 0; thread < this->num_threads; thread++) {
     const pid_t tid = this->tids[thread];
     for (int compartment = 0; compartment < IA2_MAX_COMPARTMENTS; compartment++) {
-      const struct ia2_thread_data *const thread_data = &this->ia2_thread_data[thread];
+      const struct ia2_thread_data *const thread_data = &this->thread_data[thread];
       if (addr == thread_data->stack_addrs[compartment]) {
         location.name = "stack";
         location.tid = tid;
@@ -176,7 +176,7 @@ ret:
 static struct ia2_all_threads_data IA2_SHARED_DATA threads = {
     .lock = PTHREAD_MUTEX_INITIALIZER,
     .num_threads = 0,
-    .ia2_thread_data = {0},
+    .thread_data = {0},
 };
 
 struct ia2_thread_data *ia2_thread_data_get_current_thread(void) {

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -95,16 +95,11 @@ int __wrap_pthread_create(pthread_t *restrict thread,
   return __real_pthread_create(thread, attr, ia2_thread_begin, thread_thunk);
 }
 
-// It's much simpler to only support a static number of created threads,
-// especially because we want to have very few dependencies.
-// If a program needs more threads, you can just increase this number.
-#define MAX_THREADS_SUPPORTED 4096
-
 struct ia2_all_threads_data {
   pthread_mutex_t lock;
   size_t num_threads;
-  pid_t tids[MAX_THREADS_SUPPORTED];
-  struct ia2_thread_data ia2_thread_data[MAX_THREADS_SUPPORTED];
+  pid_t tids[IA2_MAX_THREADS];
+  struct ia2_thread_data ia2_thread_data[IA2_MAX_THREADS];
 };
 
 #define array_len(a) (sizeof(a) / sizeof(*(a)))
@@ -121,7 +116,7 @@ struct ia2_thread_data *ia2_all_threads_data_lookup(struct ia2_all_threads_data 
     }
   }
   if (this->num_threads >= array_len(this->ia2_thread_data)) {
-    fprintf(stderr, "created %zu threads, but can't store them all, but you can increase MAX_THREADS_SUPPORTED\n", this->num_threads);
+    fprintf(stderr, "created %zu threads, but can't store them all (max is IA2_MAX_THREADS)\n", this->num_threads);
     goto unlock;
   }
   data = &this->ia2_thread_data[this->num_threads];

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -107,6 +107,7 @@ struct ia2_all_threads_metadata {
 struct ia2_thread_metadata *ia2_all_threads_metadata_lookup(struct ia2_all_threads_metadata *const this, const pid_t tid) {
   struct ia2_thread_metadata *metadata = NULL;
   if (pthread_mutex_lock(&this->lock) != 0) {
+    perror("pthread_mutex_lock in ia2_all_threads_data_lookup failed");
     goto ret;
   }
   for (size_t i = 0; i < this->num_threads; i++) {
@@ -125,7 +126,9 @@ struct ia2_thread_metadata *ia2_all_threads_metadata_lookup(struct ia2_all_threa
   goto unlock;
 
 unlock:
-  pthread_mutex_unlock(&this->lock);
+  if (pthread_mutex_unlock(&this->lock) != 0) {
+    perror("pthread_mutex_unlock in ia2_all_threads_data_lookup failed");
+  }
 ret:
   return metadata;
 }
@@ -137,6 +140,7 @@ struct ia2_addr_location ia2_all_threads_metadata_find_addr(struct ia2_all_threa
       .compartment = -1,
   };
   if (pthread_mutex_lock(&this->lock) != 0) {
+    perror("pthread_mutex_lock in ia2_all_threads_data_find_addr failed");
     goto ret;
   }
   for (size_t thread = 0; thread < this->num_threads; thread++) {
@@ -167,7 +171,9 @@ struct ia2_addr_location ia2_all_threads_metadata_find_addr(struct ia2_all_threa
   goto unlock;
 
 unlock:
-  pthread_mutex_unlock(&this->lock);
+  if (pthread_mutex_unlock(&this->lock) != 0) {
+    perror("pthread_mutex_unlock in ia2_all_threads_data_find_addr failed");
+  }
 ret:
   return location;
 }

--- a/tests/permissive_mode/permissive_mode.c
+++ b/tests/permissive_mode/permissive_mode.c
@@ -52,5 +52,7 @@ Test(permissive_mode, multithreaded) {
 #endif
   }
   // Exit before joining threads.
+  // We want to inspect the labeled memory map with all of the threads,
+  // so if we joined them first then we wouldn't be able to see them.
   exit(0);
 }


### PR DESCRIPTION
* Fixes #405.

<details>
  <summary>An example <code>mpk_log_*</code>:</summary>

```
  start addr-end addr     perms offset  path
1987fffff000-198c00000000 ---p 00000000
3a0c00000000-3a1000000000 ---p 00000000
3efe50000000-3efe50001000 ---p 00000000
3efe50001000-3efe50002000 rw-p 00000000
3efe50002000-3efe50004000 ---p 00000000
3efe50004000-3efe50008000 rw-p 00000000
3efe50008000-3efe60000000 ---p 00000000
5ea323a3f000-5ea323a49000 r--p 00000000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
5ea323a49000-5ea323a7e000 r-xp 0000a000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
5ea323a7e000-5ea323a93000 r--p 0003f000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
5ea323a94000-5ea323a95000 r--p 00054000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
5ea323a95000-5ea323a9a000 rw-p 00055000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
5ea323a9a000-5ea323c20000 rw-p 0005a000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
5ea323c20000-5ea324562000 rw-p 00000000
5ea330893000-5ea3308b4000 rw-p 00000000 [heap]
70ea42000000-70ea42400000 rw-p 00000000 [stack:tid 2761199:compartment 0]
70ea42400000-70ea42800000 rw-p 00000000 [stack:tid 2761199:compartment 1]
70ea42800000-70ea42c00000 rw-p 00000000 [stack:tid 2761198:compartment 0]
70ea42c00000-70ea43000000 rw-p 00000000 [stack:tid 2761198:compartment 1]
70ea43000000-70ea43001000 ---p 00000000
70ea43001000-70ea437fc000 rw-p 00000000
70ea437fc000-70ea437fe000 rw-p 00000000 [tls:tid 2761199:compartment 1]
70ea437fe000-70ea43801000 rw-p 00000000
70ea43a00000-70ea43e00000 rw-p 00000000 [stack:tid 2761197:compartment 0]
70ea43e00000-70ea43e01000 ---p 00000000
70ea43e01000-70ea445fc000 rw-p 00000000
70ea445fc000-70ea445fe000 rw-p 00000000 [tls:tid 2761198:compartment 1]
70ea445fe000-70ea44601000 rw-p 00000000
70ea44800000-70ea44c00000 rw-p 00000000 [stack:tid 2761197:compartment 1]
70ea44c00000-70ea45000000 rw-p 00000000 [stack:tid 2761196:compartment 0]
70ea45000000-70ea45400000 rw-p 00000000 [stack:tid 2761196:compartment 1]
70ea45400000-70ea45401000 ---p 00000000
70ea45401000-70ea45bfc000 rw-p 00000000
70ea45bfc000-70ea45bfe000 rw-p 00000000 [tls:tid 2761197:compartment 1]
70ea45bfe000-70ea45c01000 rw-p 00000000
70ea45e00000-70ea46200000 rw-p 00000000 [stack:tid 2761195:compartment 0]
70ea46200000-70ea46600000 rw-p 00000000 [stack:tid 2761195:compartment 1]
70ea46600000-70ea46601000 ---p 00000000
70ea46601000-70ea46dfc000 rw-p 00000000
70ea46dfc000-70ea46dfe000 rw-p 00000000 [tls:tid 2761196:compartment 1]
70ea46dfe000-70ea46e01000 rw-p 00000000
70ea47000000-70ea47400000 rw-p 00000000 [stack:tid 2761194:compartment 0]
70ea47400000-70ea47800000 rw-p 00000000 [stack:tid 2761194:compartment 1]
70ea47800000-70ea47801000 ---p 00000000
70ea47801000-70ea47ffc000 rw-p 00000000
70ea47ffc000-70ea47ffe000 rw-p 00000000 [tls:tid 2761195:compartment 1]
70ea47ffe000-70ea48001000 rw-p 00000000
70ea48200000-70ea48600000 rw-p 00000000 [stack:tid 2761193:compartment 0]
70ea48600000-70ea48a00000 rw-p 00000000 [stack:tid 2761193:compartment 1]
70ea48a00000-70ea48a01000 ---p 00000000
70ea48a01000-70ea491fc000 rw-p 00000000
70ea491fc000-70ea491fe000 rw-p 00000000 [tls:tid 2761194:compartment 1]
70ea491fe000-70ea49201000 rw-p 00000000
70ea49400000-70ea49c00000 rw-p 00000000 [stack:tid 2761192:compartment 0]
70ea49c00000-70ea4a000000 rw-p 00000000 [stack:tid 2761192:compartment 1]
70ea4a000000-70ea4a400000 rw-p 00000000 [stack:tid 2761190:compartment 0]
70ea4a400000-70ea4a401000 ---p 00000000
70ea4a401000-70ea4abfc000 rw-p 00000000
70ea4abfc000-70ea4abfe000 rw-p 00000000 [tls:tid 2761193:compartment 1]
70ea4abfe000-70ea4ac01000 rw-p 00000000
70ea4ae00000-70ea4b200000 rw-p 00000000 [stack:tid 2761191:compartment 1]
70ea4b200000-70ea4b201000 ---p 00000000
70ea4b201000-70ea4b9fc000 rw-p 00000000
70ea4b9fc000-70ea4b9fe000 rw-p 00000000 [tls:tid 2761192:compartment 1]
70ea4b9fe000-70ea4ba01000 rw-p 00000000
70ea4bc00000-70ea4c000000 rw-p 00000000 [stack:tid 2761190:compartment 1]
70ea4c000000-70ea4c021000 rw-p 00000000
70ea4c021000-70ea50000000 ---p 00000000
70ea50400000-70ea50401000 ---p 00000000
70ea50401000-70ea50bfc000 rw-p 00000000
70ea50bfc000-70ea50bfe000 rw-p 00000000 [tls:tid 2761191:compartment 1]
70ea50bfe000-70ea50c01000 rw-p 00000000
70ea50e00000-70ea50e01000 ---p 00000000
70ea50e01000-70ea515fc000 rw-p 00000000
70ea515fc000-70ea515fe000 rw-p 00000000 [tls:tid 2761190:compartment 1]
70ea515fe000-70ea51601000 rw-p 00000000
70ea51800000-70ea51c00000 rw-p 00000000 [stack:tid 2761184:compartment 0]
70ea51c00000-70ea52000000 rw-p 00000000 [stack:tid 2761184:compartment 1]
70ea52000000-70ea52001000 ---p 00000000
70ea52001000-70ea52801000 rw-p 00000000
70ea52a00000-70ea52b00000 rw-p 00000000
70ea52c00000-70ea52d00000 rw-p 00000000
70ea52e00000-70ea52e9a000 r--p 00000000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
70ea52e9a000-70ea52fab000 r-xp 0009a000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
70ea52fab000-70ea5301a000 r--p 001ab000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
70ea5301a000-70ea5301b000 ---p 0021a000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
70ea5301b000-70ea53026000 r--p 0021a000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
70ea53026000-70ea53029000 rw-p 00225000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
70ea53029000-70ea5302c000 rw-p 00000000
70ea53200000-70ea53228000 r--p 00000000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
70ea53228000-70ea533bd000 r-xp 00028000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
70ea533bd000-70ea53415000 r--p 001bd000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
70ea53415000-70ea53416000 ---p 00215000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
70ea53416000-70ea5341a000 r--p 00215000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
70ea5341a000-70ea5341c000 rw-p 00219000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
70ea5341c000-70ea53429000 rw-p 00000000
70ea53441000-70ea53464000 rw-p 00000000
70ea53464000-70ea53466000 rw-p 00000000 [tls:tid 2761184:compartment 1]
70ea53466000-70ea5346d000 rw-p 00000000
70ea5346d000-70ea53470000 r--p 00000000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
70ea53470000-70ea53487000 r-xp 00003000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
70ea53487000-70ea5348b000 r--p 0001a000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
70ea5348b000-70ea5348c000 r--p 0001d000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
70ea5348c000-70ea5348d000 rw-p 0001e000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
70ea5348d000-70ea5348f000 rw-p 00000000
70ea5348f000-70ea53492000 r--p 00000000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
70ea53492000-70ea5349c000 r-xp 00003000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
70ea5349c000-70ea5349f000 r--p 0000d000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
70ea5349f000-70ea534a0000 r--p 0000f000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
70ea534a0000-70ea534a1000 rw-p 00010000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
70ea534a1000-70ea534a3000 rw-p 00000000
70ea534a3000-70ea534b1000 r--p 00000000 /usr/lib/x86_64-linux-gnu/libm.so.6
70ea534b1000-70ea5352d000 r-xp 0000e000 /usr/lib/x86_64-linux-gnu/libm.so.6
70ea5352d000-70ea53588000 r--p 0008a000 /usr/lib/x86_64-linux-gnu/libm.so.6
70ea53588000-70ea53589000 r--p 000e4000 /usr/lib/x86_64-linux-gnu/libm.so.6
70ea53589000-70ea5358a000 rw-p 000e5000 /usr/lib/x86_64-linux-gnu/libm.so.6
70ea53593000-70ea535a8000 rw-p 00000000
70ea535a8000-70ea535a9000 r--p 00000000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
70ea535a9000-70ea535aa000 r-xp 00001000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
70ea535aa000-70ea535ab000 r--p 00002000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
70ea535ab000-70ea535ac000 r--p 00002000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
70ea535ac000-70ea535ad000 rw-p 00003000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
70ea535ad000-70ea535ae000 rw-p 00000000
70ea535ae000-70ea53615000 r--p 00000000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
70ea53615000-70ea53675000 r-xp 00067000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
70ea53675000-70ea5369d000 r--p 000c7000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
70ea5369d000-70ea536a3000 r--p 000ee000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
70ea536a3000-70ea536aa000 rw-p 000f4000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
70ea536aa000-70ea536ac000 rw-p 000fb000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
70ea536ac000-70ea536f3000 rw-p 000fd000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
70ea536f3000-70ea5370f000 rw-p 00000000
70ea5370f000-70ea53710000 rw-p 00000000
70ea53710000-70ea53725000 rw-p 00000000
70ea53725000-70ea53727000 r--p 00000000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
70ea53727000-70ea53751000 r-xp 00002000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
70ea53751000-70ea5375c000 r--p 0002c000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
70ea5375d000-70ea5375f000 r--p 00037000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
70ea5375f000-70ea53761000 rw-p 00039000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7ffc6514a000-7ffc6516c000 rw-p 00000000 [stack]
7ffc65184000-7ffc65188000 r--p 00000000 [vvar]
7ffc65188000-7ffc6518a000 r-xp 00000000 [vdso]
ffffffffff600000-ffffffffff601000 --xp 00000000 [vsyscall]
```

</details>