### PR TITLE
permissive_mode: only store shared addrs in `IA2_DEBUG_LOG` mode and warn about using them as ptrs

### DIFF
--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -262,7 +262,9 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
 
   const int pkey = search_args->pkey;
 
+#if IA2_DEBUG_LOG
   struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_current_thread();
+#endif
 
   // Protect TLS segment.
   for (size_t i = 0; i < info->dlpi_phnum; i++) {
@@ -318,9 +320,11 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
           printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
           exit(-1);
         }
+#if IA2_DEBUG_LOG
         if (thread_metadata) {
           thread_metadata->tls_addr_compartment1_first = (uintptr_t)start_round_down;
         }
+#endif
       }
       uint64_t after_untrusted_region_start = untrusted_stackptr_addr + 0x1000;
       uint64_t after_untrusted_region_len = end - after_untrusted_region_start;
@@ -332,9 +336,11 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
           printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
           exit(-1);
         }
+#if IA2_DEBUG_LOG
         if (thread_metadata) {
           thread_metadata->tls_addr_compartment1_second = (uintptr_t)after_untrusted_region_start;
         }
+#endif
       }
     } else {
       int mprotect_err =
@@ -344,9 +350,11 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
         printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
         exit(-1);
       }
+#if IA2_DEBUG_LOG
       if (thread_metadata) {
         thread_metadata->tls_addrs[pkey] = (uintptr_t)start_round_down;
       }
+#endif
     }
   }
 

--- a/runtime/libia2/include/ia2_threads.h
+++ b/runtime/libia2/include/ia2_threads.h
@@ -2,6 +2,8 @@
 
 #include "ia2.h"
 
+#if IA2_DEBUG_LOG
+
 /// The data here is shared, so it should not be trusted for use as a pointer,
 /// but it can be used best effort for non-trusted purposes.
 struct ia2_thread_metadata {
@@ -27,6 +29,17 @@ struct ia2_thread_metadata {
   uintptr_t tls_addr_compartment1_second;
 };
 
+/// Find the `struct ia2_thread_metadata*` for the current thread,
+/// adding (but not allocating) one if there isn't one yet.
+/// If there is no memory for more or an error, `NULL` is returned.
+/// This is a purely lookup and/or additive operation,
+/// so the lifetime of the returned `struct ia2_thread_metadata*` is infinite,
+/// and since it's thread-specific,
+/// it is thread-safe to read and write.
+struct ia2_thread_metadata *ia2_thread_metadata_get_current_thread(void);
+
+#endif
+
 struct ia2_addr_location {
   /// A descriptive name of what this address points to.
   /// For example, "stack".
@@ -49,15 +62,6 @@ struct ia2_addr_location {
   /// `-1` if unknown.
   int compartment;
 };
-
-/// Find the `struct ia2_thread_metadata*` for the current thread,
-/// adding (but not allocating) one if there isn't one yet.
-/// If there is no memory for more or an error, `NULL` is returned.
-/// This is a purely lookup and/or additive operation,
-/// so the lifetime of the returned `struct ia2_thread_metadata*` is infinite,
-/// and since it's thread-specific,
-/// it is thread-safe to read and write.
-struct ia2_thread_metadata *ia2_thread_metadata_get_current_thread(void);
 
 /// Find the `ia2_addr_location` of `addr`.
 /// If it is not found or there is an error,

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -36,10 +36,12 @@ char *allocate_stack(int i) {
   stack = (char *)((uint64_t)stack | (uint64_t)i << 56);
 #endif
 
+#if IA2_DEBUG_LOG
   struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_current_thread();
   if (thread_metadata) {
     thread_metadata->stack_addrs[i] = (uintptr_t)stack;
   }
+#endif
 
 #ifdef __aarch64__
   return stack + STACK_SIZE - 16;

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -105,6 +105,11 @@ struct ia2_all_threads_metadata {
 #define array_len(a) (sizeof(a) / sizeof(*(a)))
 
 struct ia2_thread_metadata *ia2_all_threads_metadata_lookup(struct ia2_all_threads_metadata *const this) {
+#if !IA2_DEBUG_LOG
+  // Only store these addresses and have this overhead when debug logging is on.
+  return NULL;
+#endif
+
   const pid_t tid = gettid();
 
   struct ia2_thread_metadata *metadata = NULL;

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -199,15 +199,12 @@ static struct ia2_all_threads_metadata IA2_SHARED_DATA threads = {
     .thread_metadata = {0},
 };
 
-#endif // IA2_DEBUG_LOG
 
 struct ia2_thread_metadata *ia2_thread_metadata_get_current_thread(void) {
-#if IA2_DEBUG_LOG
   return ia2_all_threads_metadata_lookup(&threads);
-#else
-  return NULL;
-#endif
 }
+
+#endif // IA2_DEBUG_LOG
 
 struct ia2_addr_location ia2_addr_location_find(const uintptr_t addr) {
 #if IA2_DEBUG_LOG


### PR DESCRIPTION
* Fixes #554.