### PR TITLE
ci: use more specific `rustup toolchain install` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
         ia2-tracer: [ON, OFF]
     steps:
       - name: Setup Rust
-        run: rustup toolchain install stable-x86_64-unknown-linux-gnu
+        # We don't use actions-rust-lang/setup-rust-toolchain because it's slower
+        # (~17 s vs. ~70 s) and we need to sequentially run this 32 times.
+        run: rustup toolchain install stable --target x86_64-unknown-linux-gnu --profile minimal --no-self-update --allow-downgrade
       - name: Check out code
         uses: actions/checkout@v4
       - name: Init b63 submodule # Can't use checkout@v4 because it unconditionally inits all


### PR DESCRIPTION
* Fixes #565.

This is the same ultimate `rustup toolchain install` command that `actions-rust-lang/setup-rust-toolchain@v1` uses, but that action is much slower (~70 s vs. ~17 s previously for the whole workflow), so we just run the main `rustup toolchain install` command directly.

I fixed #565 (likely) by `rm -rf ~/.rustup` in a temporary CI step, but this also adds `--profile minimal --no-self-update --allow-downgrade`, which should hopefully help with not running into situations like #565 again.