### PR TITLE
permissive_mode: print thread name if there is one (in addition to tid)

### DIFF
--- a/runtime/libia2/include/ia2_threads.h
+++ b/runtime/libia2/include/ia2_threads.h
@@ -6,6 +6,7 @@
 /// but it can be used best effort for non-trusted purposes.
 struct ia2_thread_metadata {
   pid_t tid;
+  pthread_t thread;
 
   /// The addresses of each compartment's stack for this thread.
   uintptr_t stack_addrs[IA2_MAX_COMPARTMENTS];

--- a/runtime/libia2/include/ia2_threads.h
+++ b/runtime/libia2/include/ia2_threads.h
@@ -5,6 +5,8 @@
 /// The data here is shared, so it should not be trusted for use as a pointer,
 /// but it can be used best effort for non-trusted purposes.
 struct ia2_thread_metadata {
+  pid_t tid;
+
   /// The addresses of each compartment's stack for this thread.
   uintptr_t stack_addrs[IA2_MAX_COMPARTMENTS];
 

--- a/runtime/libia2/include/ia2_threads.h
+++ b/runtime/libia2/include/ia2_threads.h
@@ -39,6 +39,11 @@ struct ia2_addr_location {
   /// `-1` if unknown.
   pid_t tid;
 
+  /// The `pthread_t` of the thread this address belongs to.
+  ///
+  /// If `tid` is `-1`, this is not initialized.
+  pthread_t thread;
+
   /// The compartment this address is in.
   ///
   /// `-1` if unknown.

--- a/runtime/libia2/include/permissive_mode.h
+++ b/runtime/libia2/include/permissive_mode.h
@@ -517,7 +517,13 @@ void log_memory_map(void) {
       // No path, try to identify it.
       const struct ia2_addr_location location = ia2_addr_location_find(start_addr);
       if (location.name) {
-        fprintf(log, "[%s:tid %ld:compartment %d]", location.name, (long)location.tid, location.compartment);
+        char thread_name[16] = {0};
+        const bool has_thread_name = pthread_getname_np(location.thread, thread_name, sizeof(thread_name)) == 0;
+        fprintf(log, "[%s:tid %ld", location.name, (long)location.tid);
+        if (has_thread_name) {
+          fprintf(log, " (thread %s)", thread_name);
+        }
+        fprintf(log, ":compartment %d]", location.compartment);
       }
       if (partition_alloc_thread_isolated_pool_base_address) {
         for (size_t pkey = 0; pkey < IA2_MAX_COMPARTMENTS; pkey++) {

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -123,6 +123,7 @@ struct ia2_thread_metadata *ia2_all_threads_metadata_lookup(struct ia2_all_threa
   metadata = &this->thread_metadata[this->num_threads];
   this->tids[this->num_threads] = tid;
   this->num_threads++;
+  metadata->tid = tid;
   goto unlock;
 
 unlock:

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -157,18 +157,21 @@ struct ia2_addr_location ia2_all_threads_metadata_find_addr(struct ia2_all_threa
       if (addr == thread_metadata->stack_addrs[compartment]) {
         location.name = "stack";
         location.tid = tid;
+        location.thread = thread_metadata->thread;
         location.compartment = compartment;
         goto unlock;
       }
       if (addr == thread_metadata->tls_addrs[compartment]) {
         location.name = "tls";
         location.tid = tid;
+        location.thread = thread_metadata->thread;
         location.compartment = compartment;
         goto unlock;
       }
       if (addr == thread_metadata->tls_addr_compartment1_first || addr == thread_metadata->tls_addr_compartment1_second) {
         location.name = "tls";
         location.tid = tid;
+        location.thread = thread_metadata->thread;
         location.compartment = 1;
         goto unlock;
       }

--- a/tests/permissive_mode/permissive_mode.c
+++ b/tests/permissive_mode/permissive_mode.c
@@ -55,6 +55,13 @@ Test(permissive_mode, multithreaded) {
     pthread_create(&threads[i], NULL, start_thread, NULL);
 #endif
   }
+
+  // Name some (but not all) of them to see how we print them.
+  pthread_setname_np(threads[2], "two");
+  pthread_setname_np(threads[3], "three");
+  pthread_setname_np(threads[5], "five");
+  pthread_setname_np(threads[7], "seven");
+
   // Exit before joining threads.
   // We want to inspect the labeled memory map with all of the threads,
   // so if we joined them first then we wouldn't be able to see them.

--- a/tests/permissive_mode/permissive_mode.c
+++ b/tests/permissive_mode/permissive_mode.c
@@ -41,6 +41,10 @@ void *start_thread(void *const arg) {
   // Just want to use stack, heap, and TLS.
   int a[4096] = {0};
   malloc(10);
+
+  // We want to inspect the labeled memory map with all of the threads,
+  // so if we joined them first then we wouldn't be able to see them.
+  pause();
   return (void *)((void *)a - (void *)&tls);
 }
 


### PR DESCRIPTION
* Part of #567.

<details>
  <summary>An example <code>mpk_log_*</code>:</summary>

```
  start addr-end addr     perms offset  path
17bfffff000-18000000000 ---p 00000000
2b23c0000000-2b23c0001000 ---p 00000000 [heap:compartment 1]
2b23c0001000-2b23c0002000 rw-p 00000000
2b23c0002000-2b23c0004000 ---p 00000000
2b23c0004000-2b23c0008000 rw-p 00000000
2b23c0008000-2b23d0000000 ---p 00000000
35f000000000-35f400000000 ---p 00000000
61b8588ee000-61b8588f8000 r--p 00000000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
61b8588f8000-61b85892d000 r-xp 0000a000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
61b85892d000-61b858942000 r--p 0003f000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
61b858943000-61b858944000 r--p 00054000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
61b858944000-61b85894a000 rw-p 00055000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
61b85894a000-61b8589e0000 rw-p 0005b000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
61b8589e0000-61b859322000 rw-p 00000000
61b87a377000-61b87a398000 rw-p 00000000 [heap]
7a2518c00000-7a2519400000 rw-p 00000000 [stack:tid 892024 (thread permissive_mode):compartment 0]
7a2519400000-7a2519800000 rw-p 00000000 [stack:tid 892024 (thread permissive_mode):compartment 1]
7a2519800000-7a2519c00000 rw-p 00000000 [stack:tid 892022 (thread seven):compartment 0]
7a2519c00000-7a251a000000 rw-p 00000000 [stack:tid 892023 (thread permissive_mode):compartment 1]
7a251a000000-7a251a001000 ---p 00000000
7a251a001000-7a251a7fc000 rw-p 00000000
7a251a7fc000-7a251a7fe000 rw-p 00000000 [tls:tid 892024 (thread permissive_mode):compartment 1]
7a251a7fe000-7a251a801000 rw-p 00000000
7a251aa00000-7a251ae00000 rw-p 00000000 [stack:tid 892022 (thread seven):compartment 1]
7a251ae00000-7a251ae01000 ---p 00000000
7a251ae01000-7a251b5fc000 rw-p 00000000
7a251b5fc000-7a251b5fe000 rw-p 00000000 [tls:tid 892023 (thread permissive_mode):compartment 1]
7a251b5fe000-7a251b601000 rw-p 00000000
7a251b800000-7a251bc00000 rw-p 00000000 [stack:tid 892021 (thread permissive_mode):compartment 0]
7a251bc00000-7a251bc01000 ---p 00000000
7a251bc01000-7a251c3fc000 rw-p 00000000
7a251c3fc000-7a251c3fe000 rw-p 00000000 [tls:tid 892022 (thread seven):compartment 1]
7a251c3fe000-7a251c401000 rw-p 00000000
7a251c600000-7a251ca00000 rw-p 00000000 [stack:tid 892021 (thread permissive_mode):compartment 1]
7a251ca00000-7a251ce00000 rw-p 00000000 [stack:tid 892020 (thread five):compartment 0]
7a251ce00000-7a251d200000 rw-p 00000000 [stack:tid 892020 (thread five):compartment 1]
7a251d200000-7a251d600000 rw-p 00000000 [stack:tid 892019 (thread permissive_mode):compartment 0]
7a251d600000-7a251d601000 ---p 00000000
7a251d601000-7a251ddfc000 rw-p 00000000
7a251ddfc000-7a251ddfe000 rw-p 00000000 [tls:tid 892021 (thread permissive_mode):compartment 1]
7a251ddfe000-7a251de01000 rw-p 00000000
7a251e000000-7a251e400000 rw-p 00000000 [stack:tid 892018 (thread three):compartment 0]
7a251e400000-7a251e800000 rw-p 00000000 [stack:tid 892019 (thread permissive_mode):compartment 1]
7a251e800000-7a251e801000 ---p 00000000
7a251e801000-7a251effc000 rw-p 00000000
7a251effc000-7a251effe000 rw-p 00000000 [tls:tid 892020 (thread five):compartment 1]
7a251effe000-7a251f001000 rw-p 00000000
7a251f200000-7a251f600000 rw-p 00000000 [stack:tid 892017 (thread two):compartment 0]
7a251f600000-7a251fa00000 rw-p 00000000 [stack:tid 892018 (thread three):compartment 1]
7a251fa00000-7a251fe00000 rw-p 00000000 [stack:tid 892015 (thread permissive_mode):compartment 0]
7a251fe00000-7a251fe01000 ---p 00000000
7a251fe01000-7a25205fc000 rw-p 00000000
7a25205fc000-7a25205fe000 rw-p 00000000 [tls:tid 892019 (thread permissive_mode):compartment 1]
7a25205fe000-7a2520601000 rw-p 00000000
7a2520800000-7a2520c00000 rw-p 00000000 [stack:tid 892016 (thread permissive_mode):compartment 0]
7a2520c00000-7a2521000000 rw-p 00000000 [stack:tid 892017 (thread two):compartment 1]
7a2521000000-7a2521001000 ---p 00000000
7a2521001000-7a25217fc000 rw-p 00000000
7a25217fc000-7a25217fe000 rw-p 00000000 [tls:tid 892018 (thread three):compartment 1]
7a25217fe000-7a2521801000 rw-p 00000000
7a2521a00000-7a2521a01000 ---p 00000000
7a2521a01000-7a25221fc000 rw-p 00000000
7a25221fc000-7a25221fe000 rw-p 00000000 [tls:tid 892017 (thread two):compartment 1]
7a25221fe000-7a2522201000 rw-p 00000000
7a2522400000-7a2522c00000 rw-p 00000000 [stack:tid 892016 (thread permissive_mode):compartment 1]
7a2522c00000-7a2522c01000 ---p 00000000
7a2522c01000-7a25233fc000 rw-p 00000000
7a25233fc000-7a25233fe000 rw-p 00000000 [tls:tid 892016 (thread permissive_mode):compartment 1]
7a25233fe000-7a2523401000 rw-p 00000000
7a2523600000-7a2523601000 ---p 00000000
7a2523601000-7a2523dfc000 rw-p 00000000
7a2523dfc000-7a2523dfe000 rw-p 00000000 [tls:tid 892015 (thread permissive_mode):compartment 1]
7a2523dfe000-7a2523e01000 rw-p 00000000
7a2524000000-7a2524021000 rw-p 00000000
7a2524021000-7a2528000000 ---p 00000000
7a2528200000-7a2528600000 rw-p 00000000 [stack:tid 892007 (thread permissive_mode):compartment 0]
7a2528600000-7a2528a00000 rw-p 00000000 [stack:tid 892007 (thread permissive_mode):compartment 1]
7a2528a00000-7a2528a01000 ---p 00000000
7a2528a01000-7a2529201000 rw-p 00000000
7a2529400000-7a2529500000 rw-p 00000000
7a2529600000-7a2529700000 rw-p 00000000
7a2529800000-7a252989a000 r--p 00000000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
7a252989a000-7a25299ab000 r-xp 0009a000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
7a25299ab000-7a2529a1a000 r--p 001ab000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
7a2529a1a000-7a2529a1b000 ---p 0021a000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
7a2529a1b000-7a2529a26000 r--p 0021a000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
7a2529a26000-7a2529a29000 rw-p 00225000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
7a2529a29000-7a2529a2c000 rw-p 00000000
7a2529c00000-7a2529c28000 r--p 00000000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
7a2529c28000-7a2529dbd000 r-xp 00028000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
7a2529dbd000-7a2529e15000 r--p 001bd000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
7a2529e15000-7a2529e16000 ---p 00215000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
7a2529e16000-7a2529e1a000 r--p 00215000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
7a2529e1a000-7a2529e1c000 rw-p 00219000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
7a2529e1c000-7a2529e29000 rw-p 00000000
7a2529e54000-7a2529e77000 rw-p 00000000
7a2529e77000-7a2529e79000 rw-p 00000000 [tls:tid 892007 (thread permissive_mode):compartment 1]
7a2529e79000-7a2529e80000 rw-p 00000000
7a2529e80000-7a2529e83000 r--p 00000000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7a2529e83000-7a2529e9a000 r-xp 00003000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7a2529e9a000-7a2529e9e000 r--p 0001a000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7a2529e9e000-7a2529e9f000 r--p 0001d000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7a2529e9f000-7a2529ea0000 rw-p 0001e000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7a2529ea0000-7a2529ea2000 rw-p 00000000
7a2529ea2000-7a2529ea5000 r--p 00000000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
7a2529ea5000-7a2529eaf000 r-xp 00003000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
7a2529eaf000-7a2529eb2000 r--p 0000d000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
7a2529eb2000-7a2529eb3000 r--p 0000f000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
7a2529eb3000-7a2529eb4000 rw-p 00010000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
7a2529eb4000-7a2529eb6000 rw-p 00000000
7a2529eb6000-7a2529ec4000 r--p 00000000 /usr/lib/x86_64-linux-gnu/libm.so.6
7a2529ec4000-7a2529f40000 r-xp 0000e000 /usr/lib/x86_64-linux-gnu/libm.so.6
7a2529f40000-7a2529f9b000 r--p 0008a000 /usr/lib/x86_64-linux-gnu/libm.so.6
7a2529f9b000-7a2529f9c000 r--p 000e4000 /usr/lib/x86_64-linux-gnu/libm.so.6
7a2529f9c000-7a2529f9d000 rw-p 000e5000 /usr/lib/x86_64-linux-gnu/libm.so.6
7a2529fa6000-7a2529fbb000 rw-p 00000000
7a2529fbb000-7a2529fbc000 r--p 00000000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
7a2529fbc000-7a2529fbd000 r-xp 00001000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
7a2529fbd000-7a2529fbe000 r--p 00002000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
7a2529fbe000-7a2529fbf000 r--p 00002000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
7a2529fbf000-7a2529fc0000 rw-p 00003000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
7a2529fc0000-7a2529fc1000 rw-p 00000000
7a2529fc1000-7a252a028000 r--p 00000000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
7a252a028000-7a252a088000 r-xp 00067000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
7a252a088000-7a252a0b0000 r--p 000c7000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
7a252a0b0000-7a252a0b6000 r--p 000ee000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
7a252a0b6000-7a252a0bd000 rw-p 000f4000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
7a252a0bd000-7a252a0bf000 rw-p 000fb000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
7a252a0bf000-7a252a106000 rw-p 000fd000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
7a252a106000-7a252a122000 rw-p 00000000
7a252a122000-7a252a123000 rw-p 00000000
7a252a123000-7a252a138000 rw-p 00000000
7a252a138000-7a252a13a000 r--p 00000000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7a252a13a000-7a252a164000 r-xp 00002000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7a252a164000-7a252a16f000 r--p 0002c000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7a252a170000-7a252a172000 r--p 00037000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7a252a172000-7a252a174000 rw-p 00039000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7ffc3d3ef000-7ffc3d411000 rw-p 00000000 [stack]
7ffc3d574000-7ffc3d578000 r--p 00000000 [vvar]
7ffc3d578000-7ffc3d57a000 r-xp 00000000 [vdso]
ffffffffff600000-ffffffffff601000 --xp 00000000 [vsyscall]
```

</details>