### PR TITLE
library-only mode (sans FF-specific work)

### DIFF
--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -1175,7 +1175,7 @@ auto ValidateDirectory = CLI::Validator(
     },
     "Directory", "path of a directory");
 
-const std::map<std::string, int> arch_map{{"x86", (int)Arch::X86}, {"aarch64", (int)Arch::Aarch64}};
+const std::map<std::string, Arch> arch_map{{"x86", Arch::X86}, {"aarch64", Arch::Aarch64}};
 
 std::string CompilationDbPath;
 std::string LibraryFilesFile;

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -1302,8 +1302,14 @@ int main(int argc, const char **argv) {
 
   // Collect mapping of filenames to pkeys and used pkeys
   std::set<Pkey> pkeys_used;
+  std::set<std::string> LibraryFilesSet(LibraryFiles.begin(), LibraryFiles.end());
   for (auto s : SourceFiles) {
-    auto pkey = pkey_from_commands(get_commands, s);
+    std::optional<Pkey> pkey;
+    if (LibraryOnlyMode) {
+      pkey = LibraryFilesSet.contains(s) ? 0 : 1;
+    } else {
+      pkey = pkey_from_commands(get_commands, s);
+    }
     if (!pkey) {
       return -1;
     }

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -1231,6 +1231,28 @@ int main(int argc, const char **argv) {
   }
   CompilationDatabase &comp_db = *MaybeCmds;
 
+  // Library-only mode file groups
+  llvm::SmallVector<llvm::StringRef> LibraryFiles;
+  llvm::SmallVector<llvm::StringRef> RewriteFiles;
+
+  // Read library and rewrite filenames from input files for library-only mode
+  if (LibraryOnlyMode) {
+    assert(SourceFiles.empty());
+
+    auto LibraryFilesStr = file_contents(LibraryFilesFile);
+    llvm::StringRef(LibraryFilesStr).split(LibraryFiles, '\n');
+
+    auto RewriteFilesStr = file_contents(RewriteFilesFile);
+    llvm::StringRef(RewriteFilesStr).split(RewriteFiles, '\n');
+
+    for (auto &i : LibraryFiles) {
+      SourceFiles.push_back(i.str());
+    }
+    for (auto &i : RewriteFiles) {
+      SourceFiles.push_back(i.str());
+    }
+  }
+
   // Ensure that all files to process are in the compilation db; if not, we don't know how to process them!
   auto all_files = comp_db.getAllFiles();
   auto all_files_set = std::set(all_files.begin(), all_files.end());

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -1174,11 +1174,29 @@ auto ValidateDirectory = CLI::Validator(
 const std::map<std::string, int> arch_map{{"x86", (int)Arch::X86}, {"aarch64", (int)Arch::Aarch64}};
 
 std::string CompilationDbPath;
+std::string LibraryFilesFile;
+std::string RewriteFilesFile;
 std::vector<std::string> SourceFiles;
 std::vector<std::string> ExtraArgs;
+bool LibraryOnlyMode = false;
+
+auto LibOnlyGroup = "Library-only mode";
 
 int main(int argc, const char **argv) {
   CLI::App app{"IA2 Source Rewriter"};
+  auto LibFilesOpt =
+      app.add_option("--library-files", LibraryFilesFile, "Path to file listing untrusted library sources")
+          ->group(LibOnlyGroup)
+          ->option_text("FILE")
+          ->check(CLI::ExistingFile);
+  auto RwFilesOpt =
+      app.add_option("--rewrite-files", RewriteFilesFile, "Path to file listing application sources to rewrite")
+          ->group(LibOnlyGroup)
+          ->option_text("FILE")
+          ->check(CLI::ExistingFile);
+  app.add_flag("--library-only-mode", LibraryOnlyMode, "Compartmentalize one untrusted library inside a trusted application")
+      ->needs(LibFilesOpt)
+      ->needs(RwFilesOpt);
   app.add_option("--arch", Target, "Target architecture (x86 or aarch64), x86 by default")
       ->option_text("x86|aarch64")
       ->transform(CLI::Transformer(arch_map));

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -470,11 +470,15 @@ public:
     // This matches expressions that reference declared functions and we use
     // this to filter out direct calls in the following matcher
     auto declared_function = declRefExpr(hasDeclaration(functionDecl()));
+    // Also match declared C++ methods
+    auto declared_method = declRefExpr(hasDeclaration(cxxMethodDecl()));
+
+    auto declared = anyOf(ignoringImplicit(declared_function), ignoringImplicit(declared_method));
 
     // Matches function calls excluding direct calls. Only the callee nodes are
     // bound to "fnPtrCall"
     StatementMatcher fn_ptr_call = callExpr(callee(
-                                                expr(unless(ignoringImplicit(declared_function))).bind("fnPtrExpr")))
+                                                expr(unless(declared)).bind("fnPtrExpr")))
                                        .bind("fnPtrCall");
 
     refactorer.addMatcher(fn_ptr_call, this);

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -58,6 +58,9 @@ static std::string OutputPrefix;
 std::unordered_multimap<Function, Function> pre_condition_funcs;
 std::unordered_multimap<Function, Function> post_condition_funcs;
 
+bool use_default_pkey = false;
+Pkey default_pkey = 1;
+
 // Map each translation unit's filename to its pkey.
 static std::map<Filename, Pkey> file_pkeys;
 
@@ -124,6 +127,9 @@ static Pkey get_file_pkey(const clang::SourceManager &sm) {
   try {
     return file_pkeys.at(filename);
   } catch (std::out_of_range const &exc) {
+    if (use_default_pkey) {
+      return default_pkey;
+    }
     llvm::errs() << "Source file " << filename.c_str()
                  << " has no entry with -DPKEY in compile_commands.json\n";
     abort();


### PR DESCRIPTION
We still need to merge the additional changes required for FF compartmentalization, but triage for those is ongoing. These changes shouldn't break anything upstream and are needed for library-only mode for any target application.