### PR TITLE
libia2: split `IA2_DEBUG_LOG` into `IA2_VERBOSE` and `IA2_DEBUG_MEMORY`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         linker: [lld, bfd]
         ia2-debug: [ON, OFF]
         ia2-tracer: [ON, OFF]
+        ia2-verbose: [ON]
+        ia2-debug-memory: [ON]
     steps:
       - name: Setup Rust
         # We don't use actions-rust-lang/setup-rust-toolchain because it's slower
@@ -44,8 +46,10 @@ jobs:
             -DClang_DIR=$Clang_DIR                                       \
             -DLLVM_DIR=$LLVM_DIR                                         \
             -DLLVM_EXTERNAL_LIT=$HOME/.local/bin/lit                     \
-            -DIA2_DEBUG=${{ matrix.ia2-debug }}                       \
+            -DIA2_DEBUG=${{ matrix.ia2-debug }}                          \
             -DIA2_TRACER=${{ matrix.ia2-tracer }}                        \
+            -DIA2_VERBOSE=${{ matrix.ia2-verbose }}                      \
+            -DIA2_DEBUG_MEMORY=${{ matrix.ia2-debug-memory }}        \
             -G Ninja
           ninja
           popd

--- a/docs/compartmentalizing_dav1d.md
+++ b/docs/compartmentalizing_dav1d.md
@@ -30,7 +30,7 @@ cmake .. \
     -DLLVM_EXTERNAL_LIT=$(which lit) \
     -G Ninja \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DIA2_DEBUG_LOG=True \
+    -DIA2_VERBOSE=True \
     -DIA2_DEBUG_MEMORY=True
 ```
 
@@ -38,7 +38,7 @@ We can build for another `-DCMAKE_BUILD_TYPE` as well,
 but a debug build like `Debug` or `RelWithDebInfo` is recommended
 in case tools crash and need to be debugged.
 
-`-DIA2_DEBUG_LOG=True` also helps with debugging the compartmentalized `dav1d`, too.
+`-DIA2_VERBOSE=True` also helps with debugging the compartmentalized `dav1d`, too.
 
 `-DIA2_DEBUG_MEMORY=True` helps with debugging memory maps.
 
@@ -147,7 +147,7 @@ First, there are required args:
 Then there are args for debugging:
 
 * `-DIA2_DEBUG=1` (for debug assertions)
-* `-DIA2_DEBUG_LOG=1` (for verbose logging)
+* `-DIA2_VERBOSE=1` (for verbose logging)
 * `-DIA2_DEBUG_MEMORY=1` (for tracking and debugging memory maps)
 
 Then there are overrides:

--- a/docs/compartmentalizing_dav1d.md
+++ b/docs/compartmentalizing_dav1d.md
@@ -30,7 +30,8 @@ cmake .. \
     -DLLVM_EXTERNAL_LIT=$(which lit) \
     -G Ninja \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DIA2_DEBUG_LOG=True
+    -DIA2_DEBUG_LOG=True \
+    -DIA2_DEBUG_MEMORY=True
 ```
 
 We can build for another `-DCMAKE_BUILD_TYPE` as well,
@@ -38,6 +39,8 @@ but a debug build like `Debug` or `RelWithDebInfo` is recommended
 in case tools crash and need to be debugged.
 
 `-DIA2_DEBUG_LOG=True` also helps with debugging the compartmentalized `dav1d`, too.
+
+`-DIA2_DEBUG_MEMORY=True` helps with debugging memory maps.
 
 ## Choosing Compartments
 
@@ -145,6 +148,7 @@ Then there are args for debugging:
 
 * `-DIA2_DEBUG=1` (for debug assertions)
 * `-DIA2_DEBUG_LOG=1` (for verbose logging)
+* `-DIA2_DEBUG_MEMORY=1` (for tracking and debugging memory maps)
 
 Then there are overrides:
 

--- a/runtime/libia2/CMakeLists.txt
+++ b/runtime/libia2/CMakeLists.txt
@@ -17,6 +17,10 @@ if(IA2_DEBUG_LOG)
     target_compile_definitions(libia2 PRIVATE IA2_DEBUG_LOG=1)
 endif()
 
+if(IA2_DEBUG_MEMORY)
+    target_compile_definitions(libia2 PRIVATE IA2_DEBUG_MEMORY=1)
+endif()
+
 target_link_options(libia2
     INTERFACE
         "-pthread"

--- a/runtime/libia2/CMakeLists.txt
+++ b/runtime/libia2/CMakeLists.txt
@@ -13,8 +13,8 @@ if(IA2_DEBUG)
     target_compile_definitions(libia2 PUBLIC IA2_DEBUG=1)
 endif()
 
-if(IA2_DEBUG_LOG)
-    target_compile_definitions(libia2 PRIVATE IA2_DEBUG_LOG=1)
+if(IA2_VERBOSE)
+    target_compile_definitions(libia2 PRIVATE IA2_VERBOSE=1)
 endif()
 
 if(IA2_DEBUG_MEMORY)

--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -262,7 +262,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
 
   const int pkey = search_args->pkey;
 
-#if IA2_DEBUG_LOG
+#if IA2_DEBUG_MEMORY
   struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_current_thread();
 #endif
 
@@ -320,7 +320,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
           printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
           exit(-1);
         }
-#if IA2_DEBUG_LOG
+#if IA2_DEBUG_MEMORY
         if (thread_metadata) {
           thread_metadata->tls_addr_compartment1_first = (uintptr_t)start_round_down;
         }
@@ -336,7 +336,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
           printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
           exit(-1);
         }
-#if IA2_DEBUG_LOG
+#if IA2_DEBUG_MEMORY
         if (thread_metadata) {
           thread_metadata->tls_addr_compartment1_second = (uintptr_t)after_untrusted_region_start;
         }
@@ -350,7 +350,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
         printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
         exit(-1);
       }
-#if IA2_DEBUG_LOG
+#if IA2_DEBUG_MEMORY
       if (thread_metadata) {
         thread_metadata->tls_addrs[pkey] = (uintptr_t)start_round_down;
       }

--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -386,7 +386,7 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
     search_args->found_library_count++;
   }
 
-#if IA2_DEBUG_LOG
+#if IA2_VERBOSE
   printf("protecting library: %s\n", basename(info->dlpi_name));
 #endif
 
@@ -416,7 +416,7 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
              search_args->shared_sections[i].end);
       exit(-1);
     }
-#if IA2_DEBUG_LOG
+#if IA2_VERBOSE
     printf("Shared range %zu: 0x%" PRIx64 "-0x%" PRIx64 "\n", shared_range_count, cur_range->start, cur_range->end);
 #endif
 
@@ -470,7 +470,7 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
 
     Elf64_Addr start = (info->dlpi_addr + phdr.p_vaddr) & ~0xFFFUL;
     Elf64_Addr seg_end = (info->dlpi_addr + phdr.p_vaddr + phdr.p_memsz + 0xFFFUL) & ~0xFFFUL;
-#if IA2_DEBUG_LOG
+#if IA2_VERBOSE
     printf("Segment %zu: 0x%" PRIx64 "-0x%" PRIx64 "\n", i, start, seg_end);
 #endif
     while (start < seg_end) {
@@ -483,7 +483,7 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
         // and remove the overlapping portion.
         if (shared_ranges[j].start <= start && shared_ranges[j].end > start) {
           start = shared_ranges[j].end;
-#if IA2_DEBUG_LOG
+#if IA2_VERBOSE
           printf("Shared range %zu overlaps start of segment %zu, adjusting start to 0x%" PRIx64 "\n", j, i, start);
 #endif
         }
@@ -494,7 +494,7 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
         if (shared_ranges[j].start > start &&
             shared_ranges[j].start < cur_end) {
           cur_end = shared_ranges[j].start;
-#if IA2_DEBUG_LOG
+#if IA2_VERBOSE
           printf("Shared range %zu overlaps end of segment %zu, adjusting end to 0x%" PRIx64 "\n", j, i, cur_end);
 #endif
         }

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -328,7 +328,7 @@ works as a reasonable signpost no-op. */
 #if defined(__aarch64__)
 int ia2_mprotect_with_tag(void *addr, size_t len, int prot, int tag);
 #elif defined(__x86_64__)
-#if IA2_DEBUG_LOG
+#if IA2_VERBOSE
 static int ia2_mprotect_with_tag(void *addr, size_t len, int prot, int tag) {
   printf("ia2_mprotect_with_tag(addr=%p, len=%zu, prot=%d, tag=%d)\n", addr, len, prot, tag);
   return pkey_mprotect(addr, len, prot, tag);

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -36,7 +36,7 @@ char *allocate_stack(int i) {
   stack = (char *)((uint64_t)stack | (uint64_t)i << 56);
 #endif
 
-#if IA2_DEBUG_LOG
+#if IA2_DEBUG_MEMORY
   struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_current_thread();
   if (thread_metadata) {
     thread_metadata->stack_addrs[i] = (uintptr_t)stack;

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -3,7 +3,7 @@
 
 // Only enable this code that stores these addresses when debug logging is enabled.
 // This reduces the trusted codebase and avoids runtime overhead.
-#if IA2_DEBUG_LOG
+#if IA2_DEBUG_MEMORY
 
 struct ia2_all_threads_metadata {
   pthread_mutex_t lock;
@@ -136,11 +136,11 @@ static void label_memory_map(FILE *log, uintptr_t start_addr) {
   }
 }
 
-#else // IA2_DEBUG_LOG
+#else // IA2_DEBUG_MEMORY
 
 static void label_memory_map(FILE *log, uintptr_t start_addr) {}
 
-#endif // IA2_DEBUG_LOG
+#endif // IA2_DEBUG_MEMORY
 
 // `getline` calls `malloc` inside of `libc`,
 // but we wrap `malloc` with `__wrap_malloc`,

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -138,7 +138,7 @@ static void label_memory_map(FILE *log, uintptr_t start_addr) {
 
 #else // IA2_DEBUG_LOG
 
-void label_memory_map(FILE *log, uintptr_t start_addr) {}
+static void label_memory_map(FILE *log, uintptr_t start_addr) {}
 
 #endif // IA2_DEBUG_LOG
 

--- a/runtime/libia2/memory_maps.h
+++ b/runtime/libia2/memory_maps.h
@@ -7,7 +7,7 @@
 
 // Only enable this code that stores these addresses when debug logging is enabled.
 // This reduces the trusted codebase and avoids runtime overhead.
-#if IA2_DEBUG_LOG
+#if IA2_DEBUG_MEMORY
 
 /// The data here is shared, so it should not be trusted for use as a pointer,
 /// but it can be used best effort for non-trusted purposes.
@@ -71,4 +71,4 @@ struct ia2_addr_location {
 /// the fields are set to `NULL` or `-1` depending on the type.
 struct ia2_addr_location ia2_addr_location_find(uintptr_t addr);
 
-#endif // IA2_DEBUG_LOG
+#endif // IA2_DEBUG_MEMORY

--- a/tests/pre_post_condition/src.c
+++ b/tests/pre_post_condition/src.c
@@ -1,5 +1,4 @@
 #include "src.h"
-#include <ia2_test_runner.h>
 #include <signal.h>
 #include <stdio.h>
 


### PR DESCRIPTION
* Fixes #572.

`IA2_VERBOSE` and `IA2_DEBUG_MEMORY` and more precise and descriptive names, and it can be useful to enable one but not the other.

We also don't test with either of them on (previously `IA2_DEBUG_LOG`) in CI, so this enables that.  To avoid exponentially increasing CI times (because the self-hosted runner runs jobs sequentially), this only tests with them on rather than off, too.