### PR TITLE
libia2/memory_maps: make `IA2_MAX_THREADS` private and move it to `memory_maps.c` behind `IA2_DEBUG_MEMORY`

### DIFF
--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -202,7 +202,6 @@ asm(".macro movz_shifted_tag_x18 tag\n"
 #define errno_s (strerror_l(errno, uselocale((locale_t)0)))
 
 #define PTRS_PER_PAGE (PAGE_SIZE / sizeof(void *))
-#define IA2_MAX_THREADS (PTRS_PER_PAGE)
 
 #define IA2_ROUND_DOWN(x, y) ((x) & ~((y)-1))
 

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -5,6 +5,8 @@
 // This reduces the trusted codebase and avoids runtime overhead.
 #if IA2_DEBUG_MEMORY
 
+#define IA2_MAX_THREADS (PTRS_PER_PAGE)
+
 struct ia2_all_threads_metadata {
   pthread_mutex_t lock;
   size_t num_threads;

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -5,6 +5,9 @@
 // This reduces the trusted codebase and avoids runtime overhead.
 #if IA2_DEBUG_MEMORY
 
+// It's much simpler to only support a static number of created threads,
+// especially because we want to have very few dependencies.
+// If a program needs more threads, you can just increase this number.
 #define IA2_MAX_THREADS 512
 
 struct ia2_all_threads_metadata {

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -8,13 +8,13 @@
 // It's much simpler to only support a static number of created threads,
 // especially because we want to have very few dependencies.
 // If a program needs more threads, you can just increase this number.
-#define IA2_MAX_THREADS 512
+#define MAX_THREADS 512
 
 struct ia2_all_threads_metadata {
   pthread_mutex_t lock;
   size_t num_threads;
-  pid_t tids[IA2_MAX_THREADS];
-  struct ia2_thread_metadata thread_metadata[IA2_MAX_THREADS];
+  pid_t tids[MAX_THREADS];
+  struct ia2_thread_metadata thread_metadata[MAX_THREADS];
 };
 
 #define array_len(a) (sizeof(a) / sizeof(*(a)))
@@ -34,7 +34,7 @@ struct ia2_thread_metadata *ia2_all_threads_metadata_lookup(struct ia2_all_threa
     }
   }
   if (this->num_threads >= array_len(this->thread_metadata)) {
-    fprintf(stderr, "created %zu threads, but can't store them all (max is IA2_MAX_THREADS)\n", this->num_threads);
+    fprintf(stderr, "created %zu threads, but can't store them all (max is MAX_THREADS)\n", this->num_threads);
     goto unlock;
   }
 

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -5,7 +5,7 @@
 // This reduces the trusted codebase and avoids runtime overhead.
 #if IA2_DEBUG_MEMORY
 
-#define IA2_MAX_THREADS (PTRS_PER_PAGE)
+#define IA2_MAX_THREADS 512
 
 struct ia2_all_threads_metadata {
   pthread_mutex_t lock;


### PR DESCRIPTION
* Fixes #571.

`IA2_MAX_THREADS` was once used as part of a different design of per-compartment stacks, but we never actually used that non-TLS design, so there is no limit to the number of threads.  However, the memory maps code uses it now, so this just moves it there.  Thus, it's no longer public in `ia2_internal.h` and behind `IA2_DEBUG_MEMORY` in a `*.c` file.

~~Unlike what #571 and https://github.com/immunant/IA2-Phase2/pull/557#discussion_r2095889891 say, this doesn't actually rename it.  I didn't really see a reason to do so now that it's clearly behind `IA2_DEBUG_MEMORY` and in `memory_maps.c`, so it's not visible outside that file.~~

It's renamed to just `MAX_THREADS` now.  It's not a public export anymore so it doesn't need the `IA2_*` prefix anymore.