### PR TITLE
libia2/memory_maps: label start fn

### DIFF
--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -124,9 +124,18 @@ static void label_memory_map(FILE *log, uintptr_t start_addr) {
   if (location.name) {
     char thread_name[16] = {0};
     const bool has_thread_name = pthread_getname_np(metadata->thread, thread_name, sizeof(thread_name)) == 0;
+
+    Dl_info dl_info = {0};
+    const bool has_dl_info = dladdr((void *)metadata->start_fn, &dl_info);
+
     fprintf(log, "[%s:tid %ld", location.name, (long)metadata->tid);
     if (has_thread_name) {
       fprintf(log, " (thread %s)", thread_name);
+    }
+    if (has_dl_info && dl_info.dli_sname) {
+      fprintf(log, " (start fn %s)", dl_info.dli_sname);
+    } else {
+      fprintf(log, " (start fn %p)", metadata->start_fn);
     }
     fprintf(log, ":compartment %d]", location.compartment);
   }

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -128,7 +128,7 @@ static void label_memory_map(FILE *log, uintptr_t start_addr) {
     Dl_info dl_info = {0};
     const bool has_dl_info = dladdr((void *)metadata->start_fn, &dl_info);
 
-    fprintf(log, "[%s:tid %ld", location.name, (long)metadata->tid);
+    fprintf(log, "[%s:compartment %d:tid %ld", location.name, location.compartment, (long)metadata->tid);
     if (has_thread_name) {
       fprintf(log, " (thread %s)", thread_name);
     }
@@ -142,7 +142,7 @@ static void label_memory_map(FILE *log, uintptr_t start_addr) {
     } else {
       fprintf(log, "%p", metadata->start_fn);
     }
-    fprintf(log, "):compartment %d]", location.compartment);
+    fprintf(log, ")]");
   }
 
   if (partition_alloc_thread_isolated_pool_base_address) {

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -132,7 +132,11 @@ static void label_memory_map(FILE *log, uintptr_t start_addr) {
     if (has_thread_name) {
       fprintf(log, " (thread %s)", thread_name);
     }
-    if (has_dl_info && dl_info.dli_sname) {
+    if (!metadata->start_fn) {
+      // `metadata->start_fn` is always set during `__wrap_pthread_create`/`ia2_thread_begin`,
+      // so if it wasn't set, then it must be the main thread, started in `main`.
+      fprintf(log, " (start fn main)");
+    } else if (has_dl_info && dl_info.dli_sname) {
       fprintf(log, " (start fn %s)", dl_info.dli_sname);
     } else {
       fprintf(log, " (start fn %p)", metadata->start_fn);

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -132,16 +132,17 @@ static void label_memory_map(FILE *log, uintptr_t start_addr) {
     if (has_thread_name) {
       fprintf(log, " (thread %s)", thread_name);
     }
+    fprintf(log, " (start fn ");
     if (!metadata->start_fn) {
       // `metadata->start_fn` is always set during `__wrap_pthread_create`/`ia2_thread_begin`,
       // so if it wasn't set, then it must be the main thread, started in `main`.
-      fprintf(log, " (start fn main)");
+      fprintf(log, "main");
     } else if (has_dl_info && dl_info.dli_sname) {
-      fprintf(log, " (start fn %s)", dl_info.dli_sname);
+      fprintf(log, "%s", dl_info.dli_sname);
     } else {
-      fprintf(log, " (start fn %p)", metadata->start_fn);
+      fprintf(log, "%p", metadata->start_fn);
     }
-    fprintf(log, ":compartment %d]", location.compartment);
+    fprintf(log, "):compartment %d]", location.compartment);
   }
 
   if (partition_alloc_thread_isolated_pool_base_address) {

--- a/runtime/libia2/memory_maps.h
+++ b/runtime/libia2/memory_maps.h
@@ -15,6 +15,9 @@ struct ia2_thread_metadata {
   pid_t tid;
   pthread_t thread;
 
+  /// The start function passed to `pthread_create`.
+  void *(*start_fn)(void *arg);
+
   /// The addresses of each compartment's stack for this thread.
   uintptr_t stack_addrs[IA2_MAX_COMPARTMENTS];
 

--- a/runtime/libia2/memory_maps.h
+++ b/runtime/libia2/memory_maps.h
@@ -50,15 +50,8 @@ struct ia2_addr_location {
   /// `NULL` if unknown.
   const char *name;
 
-  /// The thread ID of the thread this address belongs to.
-  ///
-  /// `-1` if unknown.
-  pid_t tid;
-
-  /// The `pthread_t` of the thread this address belongs to.
-  ///
-  /// If `tid` is `-1`, this is not initialized.
-  pthread_t thread;
+  /// The metadata of the thread this address belongs to.
+  const struct ia2_thread_metadata *thread_metadata;
 
   /// The compartment this address is in.
   ///

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include <sys/mman.h>
 
+#include "memory_maps.h"
+
 __attribute__((visibility("default"))) void init_stacks_and_setup_tls(void);
 __attribute__((visibility("default"))) void **ia2_stackptr_for_pkru(uint32_t pkey);
 
@@ -22,6 +24,13 @@ void *ia2_thread_begin(void *arg) {
 
   /* Free the thunk. */
   munmap(arg, sizeof(struct ia2_thread_thunk));
+
+#if IA2_DEBUG_MEMORY
+  struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_current_thread();
+  if (thread_metadata) {
+    thread_metadata->start_fn = fn;
+  }
+#endif
 
   init_stacks_and_setup_tls();
   /* TODO: Set up alternate stack when we have per-thread shared compartment


### PR DESCRIPTION
* Fixes #567.

<details>
  <summary>An example <code>mpk_log_*</code>:</summary>

```
  start addr-end addr     perms offset  path
176260000000-176260001000 ---p 00000000 [heap:compartment 1]
176260001000-176260002000 rw-p 00000000
176260002000-176260004000 ---p 00000000
176260004000-176260008000 rw-p 00000000
176260008000-176270000000 ---p 00000000
200bfffff000-201000000000 ---p 00000000
3c1c00000000-3c2000000000 ---p 00000000
5f22d9d50000-5f22d9d5a000 r--p 00000000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
5f22d9d5a000-5f22d9d8f000 r-xp 0000a000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
5f22d9d8f000-5f22d9da4000 r--p 0003f000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
5f22d9da5000-5f22d9da6000 r--p 00054000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
5f22d9da6000-5f22d9dab000 rw-p 00055000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
5f22d9dab000-5f22d9e42000 rw-p 0005a000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/permissive_mode
5f22d9e42000-5f22da784000 rw-p 00000000
5f22e41aa000-5f22e41cb000 rw-p 00000000 [heap]
74aec0c00000-74aec1000000 rw-p 00000000 [stack:compartment 0:tid 1390230 (thread permissive_mode) (start fn start_thread)]
74aec1000000-74aec1400000 rw-p 00000000 [stack:compartment 1:tid 1390230 (thread permissive_mode) (start fn start_thread)]
74aec1400000-74aec1800000 rw-p 00000000 [stack:compartment 0:tid 1390229 (thread permissive_mode) (start fn start_thread)]
74aec1800000-74aec1c00000 rw-p 00000000 [stack:compartment 1:tid 1390229 (thread permissive_mode) (start fn start_thread)]
74aec1c00000-74aec1c01000 ---p 00000000
74aec1c01000-74aec23fc000 rw-p 00000000
74aec23fc000-74aec23fe000 rw-p 00000000 [tls:compartment 1:tid 1390230 (thread permissive_mode) (start fn start_thread)]
74aec23fe000-74aec2401000 rw-p 00000000
74aec2600000-74aec2a00000 rw-p 00000000 [stack:compartment 0:tid 1390228 (thread seven) (start fn start_thread)]
74aec2a00000-74aec2e00000 rw-p 00000000 [stack:compartment 1:tid 1390228 (thread seven) (start fn start_thread)]
74aec2e00000-74aec2e01000 ---p 00000000
74aec2e01000-74aec35fc000 rw-p 00000000
74aec35fc000-74aec35fe000 rw-p 00000000 [tls:compartment 1:tid 1390229 (thread permissive_mode) (start fn start_thread)]
74aec35fe000-74aec3601000 rw-p 00000000
74aec3800000-74aec3c00000 rw-p 00000000 [stack:compartment 0:tid 1390227 (thread permissive_mode) (start fn start_thread)]
74aec3c00000-74aec4000000 rw-p 00000000 [stack:compartment 1:tid 1390227 (thread permissive_mode) (start fn start_thread)]
74aec4000000-74aec4001000 ---p 00000000
74aec4001000-74aec47fc000 rw-p 00000000
74aec47fc000-74aec47fe000 rw-p 00000000 [tls:compartment 1:tid 1390228 (thread seven) (start fn start_thread)]
74aec47fe000-74aec4801000 rw-p 00000000
74aec4a00000-74aec4e00000 rw-p 00000000 [stack:compartment 0:tid 1390226 (thread five) (start fn start_thread)]
74aec4e00000-74aec5200000 rw-p 00000000 [stack:compartment 1:tid 1390226 (thread five) (start fn start_thread)]
74aec5200000-74aec5600000 rw-p 00000000 [stack:compartment 0:tid 1390225 (thread permissive_mode) (start fn start_thread)]
74aec5600000-74aec5601000 ---p 00000000
74aec5601000-74aec5dfc000 rw-p 00000000
74aec5dfc000-74aec5dfe000 rw-p 00000000 [tls:compartment 1:tid 1390227 (thread permissive_mode) (start fn start_thread)]
74aec5dfe000-74aec5e01000 rw-p 00000000
74aec6000000-74aec6400000 rw-p 00000000 [stack:compartment 1:tid 1390225 (thread permissive_mode) (start fn start_thread)]
74aec6400000-74aec6401000 ---p 00000000
74aec6401000-74aec6bfc000 rw-p 00000000
74aec6bfc000-74aec6bfe000 rw-p 00000000 [tls:compartment 1:tid 1390226 (thread five) (start fn start_thread)]
74aec6bfe000-74aec6c01000 rw-p 00000000
74aec6e00000-74aec7200000 rw-p 00000000 [stack:compartment 0:tid 1390224 (thread three) (start fn start_thread)]
74aec7200000-74aec7600000 rw-p 00000000 [stack:compartment 1:tid 1390224 (thread three) (start fn start_thread)]
74aec7600000-74aec7601000 ---p 00000000
74aec7601000-74aec7dfc000 rw-p 00000000
74aec7dfc000-74aec7dfe000 rw-p 00000000 [tls:compartment 1:tid 1390225 (thread permissive_mode) (start fn start_thread)]
74aec7dfe000-74aec7e01000 rw-p 00000000
74aec8000000-74aec8400000 rw-p 00000000 [stack:compartment 0:tid 1390223 (thread two) (start fn start_thread)]
74aec8400000-74aec8800000 rw-p 00000000 [stack:compartment 1:tid 1390223 (thread two) (start fn start_thread)]
74aec8800000-74aec8801000 ---p 00000000
74aec8801000-74aec8ffc000 rw-p 00000000
74aec8ffc000-74aec8ffe000 rw-p 00000000 [tls:compartment 1:tid 1390224 (thread three) (start fn start_thread)]
74aec8ffe000-74aec9001000 rw-p 00000000
74aec9200000-74aec9600000 rw-p 00000000 [stack:compartment 0:tid 1390222 (thread permissive_mode) (start fn start_thread)]
74aec9600000-74aec9a00000 rw-p 00000000 [stack:compartment 1:tid 1390222 (thread permissive_mode) (start fn start_thread)]
74aec9a00000-74aec9e00000 rw-p 00000000 [stack:compartment 0:tid 1390221 (thread permissive_mode) (start fn start_thread)]
74aec9e00000-74aec9e01000 ---p 00000000
74aec9e01000-74aeca5fc000 rw-p 00000000
74aeca5fc000-74aeca5fe000 rw-p 00000000 [tls:compartment 1:tid 1390223 (thread two) (start fn start_thread)]
74aeca5fe000-74aeca601000 rw-p 00000000
74aeca800000-74aeca801000 ---p 00000000
74aeca801000-74aecaffc000 rw-p 00000000
74aecaffc000-74aecaffe000 rw-p 00000000 [tls:compartment 1:tid 1390222 (thread permissive_mode) (start fn start_thread)]
74aecaffe000-74aecb001000 rw-p 00000000
74aecb200000-74aecb201000 ---p 00000000
74aecb201000-74aecb9fc000 rw-p 00000000
74aecb9fc000-74aecb9fe000 rw-p 00000000 [tls:compartment 1:tid 1390221 (thread permissive_mode) (start fn start_thread)]
74aecb9fe000-74aecba01000 rw-p 00000000
74aecbc00000-74aecc000000 rw-p 00000000 [stack:compartment 0:tid 1390219 (thread permissive_mode) (start fn main)]
74aecc000000-74aecc021000 rw-p 00000000
74aecc021000-74aed0000000 ---p 00000000
74aed0200000-74aed0a00000 rw-p 00000000 [stack:compartment 1:tid 1390221 (thread permissive_mode) (start fn start_thread)]
74aed0a00000-74aed0a01000 ---p 00000000
74aed0a01000-74aed1201000 rw-p 00000000
74aed1400000-74aed1500000 rw-p 00000000
74aed1600000-74aed1700000 rw-p 00000000
74aed1800000-74aed189a000 r--p 00000000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
74aed189a000-74aed19ab000 r-xp 0009a000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
74aed19ab000-74aed1a1a000 r--p 001ab000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
74aed1a1a000-74aed1a1b000 ---p 0021a000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
74aed1a1b000-74aed1a26000 r--p 0021a000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
74aed1a26000-74aed1a29000 rw-p 00225000 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
74aed1a29000-74aed1a2c000 rw-p 00000000
74aed1b19000-74aed1b27000 r--p 00000000 /usr/lib/x86_64-linux-gnu/libm.so.6
74aed1b27000-74aed1ba3000 r-xp 0000e000 /usr/lib/x86_64-linux-gnu/libm.so.6
74aed1ba3000-74aed1bfe000 r--p 0008a000 /usr/lib/x86_64-linux-gnu/libm.so.6
74aed1bfe000-74aed1bff000 r--p 000e4000 /usr/lib/x86_64-linux-gnu/libm.so.6
74aed1bff000-74aed1c00000 rw-p 000e5000 /usr/lib/x86_64-linux-gnu/libm.so.6
74aed1c00000-74aed1c28000 r--p 00000000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
74aed1c28000-74aed1dbd000 r-xp 00028000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
74aed1dbd000-74aed1e15000 r--p 001bd000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
74aed1e15000-74aed1e16000 ---p 00215000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
74aed1e16000-74aed1e1a000 r--p 00215000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
74aed1e1a000-74aed1e1c000 rw-p 00219000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/libia2/libc.so.6
74aed1e1c000-74aed1e29000 rw-p 00000000
74aed1eac000-74aed1ecf000 rw-p 00000000
74aed1ecf000-74aed1ed1000 rw-p 00000000 [tls:compartment 1:tid 1390219 (thread permissive_mode) (start fn main)]
74aed1ed1000-74aed1ed8000 rw-p 00000000
74aed1ed8000-74aed1edb000 r--p 00000000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
74aed1edb000-74aed1ef2000 r-xp 00003000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
74aed1ef2000-74aed1ef6000 r--p 0001a000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
74aed1ef6000-74aed1ef7000 r--p 0001d000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
74aed1ef7000-74aed1ef8000 rw-p 0001e000 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
74aed1ef8000-74aed1efa000 rw-p 00000000
74aed1efa000-74aed1efd000 r--p 00000000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
74aed1efd000-74aed1f07000 r-xp 00003000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
74aed1f07000-74aed1f0a000 r--p 0000d000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
74aed1f0a000-74aed1f0b000 r--p 0000f000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
74aed1f0b000-74aed1f0c000 rw-p 00010000 /usr/lib/x86_64-linux-gnu/libresolv.so.2
74aed1f0c000-74aed1f0e000 rw-p 00000000
74aed1f17000-74aed1f2c000 rw-p 00000000
74aed1f2c000-74aed1f2d000 r--p 00000000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
74aed1f2d000-74aed1f2e000 r-xp 00001000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
74aed1f2e000-74aed1f2f000 r--p 00002000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
74aed1f2f000-74aed1f30000 r--p 00002000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
74aed1f30000-74aed1f31000 rw-p 00003000 /home/kkysen/work/rust/ia2/build/x86_64/tests/permissive_mode/libpermissive_mode_call_gates.so
74aed1f31000-74aed1f32000 rw-p 00000000
74aed1f32000-74aed1f99000 r--p 00000000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
74aed1f99000-74aed1ff9000 r-xp 00067000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
74aed1ff9000-74aed2021000 r--p 000c7000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
74aed2021000-74aed2027000 r--p 000ee000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
74aed2027000-74aed202e000 rw-p 000f4000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
74aed202e000-74aed2030000 rw-p 000fb000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
74aed2030000-74aed2077000 rw-p 000fd000 /home/kkysen/work/rust/ia2/build/x86_64/runtime/partition-alloc/libpartition-alloc.so
74aed2077000-74aed2093000 rw-p 00000000
74aed2093000-74aed2094000 rw-p 00000000
74aed2094000-74aed20a9000 rw-p 00000000
74aed20a9000-74aed20ab000 r--p 00000000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
74aed20ab000-74aed20d5000 r-xp 00002000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
74aed20d5000-74aed20e0000 r--p 0002c000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
74aed20e1000-74aed20e3000 r--p 00037000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
74aed20e3000-74aed20e5000 rw-p 00039000 /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7ffe1b423000-7ffe1b445000 rw-p 00000000 [stack]
7ffe1b488000-7ffe1b48c000 r--p 00000000 [vvar]
7ffe1b48c000-7ffe1b48e000 r-xp 00000000 [vdso]
ffffffffff600000-ffffffffff601000 --xp 00000000 [vsyscall]
```

</details>