### PR TITLE
libia2: add `-Wl,--wrap=free` for when we link `libia2` but not the `partition-alloc` shim

### DIFF
--- a/runtime/libia2/CMakeLists.txt
+++ b/runtime/libia2/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_options(libia2
         "-pthread"
         "-Wl,--wrap=pthread_create"
         "-Wl,--wrap=main"
+        "-Wl,--wrap=free" # Because we use `__real_free` in `memory_maps.c`.
 
         # Eagerly resolve GOT relocations
         "-Wl,-z,now"


### PR DESCRIPTION
We use `__real_free` in `memory_maps.c`, so we need this now.