### PR TITLE
tests/memory_maps: add a memory maps test with multiple compartments and threads

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,8 @@ add_subdirectory(tls_protected)
 
 add_subdirectory(threads)
 add_subdirectory(protected_threads)
+add_subdirectory(memory_maps)
+
 # The following tests are not supported on ARM64 yet
 if (NOT LIBIA2_AARCH64)
     # Expected to have compartment violations, but we aren't enforcing yet:

--- a/tests/memory_maps/2.c
+++ b/tests/memory_maps/2.c
@@ -1,0 +1,2 @@
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>

--- a/tests/memory_maps/3.c
+++ b/tests/memory_maps/3.c
@@ -1,0 +1,2 @@
+#define IA2_COMPARTMENT 3
+#include <ia2_compartment_init.inc>

--- a/tests/memory_maps/4.c
+++ b/tests/memory_maps/4.c
@@ -1,0 +1,2 @@
+#define IA2_COMPARTMENT 4
+#include <ia2_compartment_init.inc>

--- a/tests/memory_maps/CMakeLists.txt
+++ b/tests/memory_maps/CMakeLists.txt
@@ -1,0 +1,26 @@
+define_shared_lib(
+  LIBNAME 2
+  SRCS 2.c
+  PKEY 2
+)
+
+define_shared_lib(
+  LIBNAME 3
+  SRCS 3.c
+  PKEY 3
+)
+
+define_shared_lib(
+  LIBNAME 4
+  SRCS 4.c
+  PKEY 4
+)
+
+define_test(
+  SRCS main.c
+  PKEY 1
+  LIBS 2 3 4
+  NEEDS_LD_WRAP
+  CRITERION_TEST
+  WITHOUT_SANDBOX # tracer forbids reading `/proc/self/maps`
+)

--- a/tests/memory_maps/main.c
+++ b/tests/memory_maps/main.c
@@ -1,0 +1,66 @@
+#include <ia2.h>
+#include <ia2_memory_maps.h>
+#include <ia2_test_runner.h>
+
+#include <pthread.h>
+
+INIT_RUNTIME(4);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
+
+Test(memory_maps, alloc) {
+  // Alloc and free so that partition-alloc allocates its compartment heaps.
+  free(malloc(1024));
+
+  ia2_log_memory_maps(stdout);
+}
+
+__thread int tls;
+
+void *start_thread(void *const arg) {
+  // Mostly bogus stuff.
+  // Just want to use stack, heap, and TLS.
+  int a[4096] = {0};
+  malloc(10);
+
+  // We want to inspect the labeled memory map with all of the threads,
+  // so if we joined them first then we wouldn't be able to see them.
+  pause();
+  return (void *)((void *)a - (void *)&tls);
+}
+
+// `open_memstream` calls `malloc` inside of `libc`,
+// but we wrap `malloc` with `__wrap_malloc`,
+// so we need to free what `getline` allocated with `__real_free`.
+typeof(IA2_IGNORE(free)) __real_free;
+
+Test(memory_maps, multithreaded) {
+  pthread_t threads[10];
+  for (size_t i = 0; i < 10; i++) {
+#if IA2_ENABLE
+    pthread_create(&threads[i], NULL, start_thread, NULL);
+#endif
+  }
+
+  // Name some (but not all) of them to see how we print them.
+  pthread_setname_np(threads[2], "two");
+  pthread_setname_np(threads[3], "three");
+  pthread_setname_np(threads[5], "five");
+  pthread_setname_np(threads[7], "seven");
+
+  // Don't write to stdout/stderr directly,
+  // since it interleaves with other concurrent output.
+  char *buf = NULL;
+  size_t buf_len = 0;
+  FILE* const log = open_memstream(&buf, &buf_len);
+
+  // Log before joining threads.
+  // We want to inspect the labeled memory map with all of the threads,
+  // so if we joined them first then we wouldn't be able to see them.
+  ia2_log_memory_maps(log);
+
+  fclose(log);
+  fflush(stdout);
+  write(STDOUT_FILENO, buf, buf_len);
+  __real_free(buf);
+}


### PR DESCRIPTION
This differs from the existing permissive mode test in that it just prints the labeled memory maps to `stdout` instead of saving them to a log file. This is more convenient during testing.
It also tests more compartments.