### PR TITLE
runtime/libia2: Simplify use of IA2_VERBOSE

### DIFF
--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -386,9 +386,7 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
     search_args->found_library_count++;
   }
 
-#if IA2_VERBOSE
-  printf("protecting library: %s\n", basename(info->dlpi_name));
-#endif
+  ia2_log("protecting library: %s\n", basename(info->dlpi_name));
 
   struct AddressRange shared_ranges[NUM_SHARED_RANGES] = {0};
   size_t shared_range_count = 0;
@@ -416,9 +414,7 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
              search_args->shared_sections[i].end);
       exit(-1);
     }
-#if IA2_VERBOSE
-    printf("Shared range %zu: 0x%" PRIx64 "-0x%" PRIx64 "\n", shared_range_count, cur_range->start, cur_range->end);
-#endif
+    ia2_log("Shared range %zu: 0x%" PRIx64 "-0x%" PRIx64 "\n", shared_range_count, cur_range->start, cur_range->end);
 
     shared_range_count++;
   }
@@ -470,9 +466,7 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
 
     Elf64_Addr start = (info->dlpi_addr + phdr.p_vaddr) & ~0xFFFUL;
     Elf64_Addr seg_end = (info->dlpi_addr + phdr.p_vaddr + phdr.p_memsz + 0xFFFUL) & ~0xFFFUL;
-#if IA2_VERBOSE
-    printf("Segment %zu: 0x%" PRIx64 "-0x%" PRIx64 "\n", i, start, seg_end);
-#endif
+    ia2_log("Segment %zu: 0x%" PRIx64 "-0x%" PRIx64 "\n", i, start, seg_end);
     while (start < seg_end) {
       Elf64_Addr cur_end = seg_end;
 
@@ -483,9 +477,7 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
         // and remove the overlapping portion.
         if (shared_ranges[j].start <= start && shared_ranges[j].end > start) {
           start = shared_ranges[j].end;
-#if IA2_VERBOSE
-          printf("Shared range %zu overlaps start of segment %zu, adjusting start to 0x%" PRIx64 "\n", j, i, start);
-#endif
+          ia2_log("Shared range %zu overlaps start of segment %zu, adjusting start to 0x%" PRIx64 "\n", j, i, start);
         }
 
         // Look for a shared range overlapping any of the rest of the current
@@ -494,9 +486,7 @@ int protect_pages(struct dl_phdr_info *info, size_t size, void *data) {
         if (shared_ranges[j].start > start &&
             shared_ranges[j].start < cur_end) {
           cur_end = shared_ranges[j].start;
-#if IA2_VERBOSE
-          printf("Shared range %zu overlaps end of segment %zu, adjusting end to 0x%" PRIx64 "\n", j, i, cur_end);
-#endif
+          ia2_log("Shared range %zu overlaps end of segment %zu, adjusting end to 0x%" PRIx64 "\n", j, i, cur_end);
         }
       }
 

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -442,3 +442,9 @@ __attribute__((__noreturn__)) void ia2_reinit_stack_err(int i);
     REPEATB##n(setup_destructors_for_compartment, nop_macro);                  \
     mark_init_finished();                                                      \
   }
+
+#if IA2_VERBOSE
+#define ia2_log(fmt, ...) fprintf(stdout, "%s:" fmt, __func__, __VA_ARGS__)
+#else
+#define ia2_log(...)
+#endif


### PR DESCRIPTION
This simplifies most uses of IA2_VERBOSE to make logging easier and more uniform. This commit intentionally ignores the existing use of IA2_VERBOSE in ia2_internal.h since (ideally) the static function defined in that header should be move to a source file at some point.