### PR TITLE
ci: update to cmake 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
             pkg-config
             cmake
             ninja-build
+            llvm # for llvm-objdump
             llvm-15-dev
             libclang-15-dev
             zlib1g-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,6 @@ jobs:
             libc6-dev-arm64-cross
             clang-15
             pkg-config
-            cmake
-            ninja-build
             llvm # for llvm-objdump
             llvm-15-dev
             libclang-15-dev
@@ -107,6 +105,10 @@ jobs:
             libcapstone-dev
             libglib2.0-dev
           version: 1.0 # version of cache to load
+      - name: Install cmake and ninja
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "^4.0.2"
       - name: Check out code
         uses: actions/checkout@v4
       - name: Init b63 submodule # Can't use checkout@v4 because it unconditionally inits all

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 4.0)
 project(IA2Phase2)
 include(ExternalProject)
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 4.0)
 project(runtime)
 
 add_subdirectory(libia2)

--- a/runtime/libia2/CMakeLists.txt
+++ b/runtime/libia2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 4.0)
 project(libia2)
 
 add_library(libia2 ia2.c init.c threads.c main.c exit.c memory_maps.c)

--- a/runtime/partition-alloc/CMakeLists.txt
+++ b/runtime/partition-alloc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 4.0)
 project(partition-alloc)
 
 set(PA_SRCS

--- a/runtime/tracer/CMakeLists.txt
+++ b/runtime/tracer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 4.0)
 project(tracer)
 
 if (LIBIA2_AARCH64)

--- a/runtime/type-registry/CMakeLists.txt
+++ b/runtime/type-registry/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 4.0)
 project(type-registry)
 
 if (LIBIA2_AARCH64)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 4.0)
 project(tools)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/tools/pad-tls/CMakeLists.txt
+++ b/tools/pad-tls/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 4.0)
 project(PadTls)
 
 add_executable(pad-tls

--- a/tools/rewriter/CMakeLists.txt
+++ b/tools/rewriter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 4.0)
 project(rewriter)
 
 find_package(LLVM REQUIRED CONFIG)


### PR DESCRIPTION
cmake 4.0 fixes a lot of issues where `ia2-sandbox` would get stuck, including in #582, where we're unsure how else to fix the issue, but where cmake 4.0 does fix the issue.