### PR TITLE
libia2: free compartment stacks on thread termination

### DIFF
--- a/runtime/libia2/CMakeLists.txt
+++ b/runtime/libia2/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 4.0)
 project(libia2)
 
-add_library(libia2 ia2.c init.c threads.c main.c exit.c memory_maps.c)
+add_library(libia2 ia2.c init.c threads.c main.c exit.c memory_maps.c thread_name.c)
 target_compile_options(libia2 PRIVATE "-fPIC")
 
 if (LIBIA2_AARCH64)

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -415,8 +415,6 @@ __attribute__((__noreturn__)) void ia2_reinit_stack_err(int i);
 #endif
 /* clang-format on */
 
-void ia2_create_thread_keys(void);
-
 #define _IA2_INIT_RUNTIME(n)                                                   \
   __attribute__((visibility("default"))) int ia2_n_pkeys_to_alloc = n;                                                \
   __attribute__((visibility("default"))) __thread void *ia2_stackptr_0[PAGE_SIZE / sizeof(void *)]                    \

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -415,7 +415,7 @@ __attribute__((__noreturn__)) void ia2_reinit_stack_err(int i);
 #endif
 /* clang-format on */
 
-void create_thread_keys(void);
+void ia2_create_thread_keys(void);
 
 #define _IA2_INIT_RUNTIME(n)                                                   \
   __attribute__((visibility("default"))) int ia2_n_pkeys_to_alloc = n;                                                \

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -415,6 +415,8 @@ __attribute__((__noreturn__)) void ia2_reinit_stack_err(int i);
 #endif
 /* clang-format on */
 
+void create_thread_keys(void);
+
 #define _IA2_INIT_RUNTIME(n)                                                   \
   __attribute__((visibility("default"))) int ia2_n_pkeys_to_alloc = n;                                                \
   __attribute__((visibility("default"))) __thread void *ia2_stackptr_0[PAGE_SIZE / sizeof(void *)]                    \

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -58,7 +58,7 @@ static void thread_stacks_destructor(void *_unused) {
 
 /// Create `thread_stacks_key`.
 /// This should be called once per process at the very beginning, currently in `ia2_init`.
-void create_thread_keys(void) {
+void ia2_create_thread_keys(void) {
   const int result = pthread_key_create(&thread_stacks_key, thread_stacks_destructor);
   if (result != 0) {
     fprintf(stderr, "pthread_key_create failed: %s\n", strerrorname_np(result));
@@ -291,7 +291,7 @@ void ia2_start(void) {
     ia2_setup_destructors();
     /* Set up global resources. */
     ia2_set_up_tags();
-    create_thread_keys();
+    ia2_create_thread_keys();
     verify_tls_padding();
     /* allocate an unprotected stack for the untrusted compartment */
     allocate_stack_0();

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -83,6 +83,7 @@ char *allocate_stack(int i) {
     thread_metadata->stack_addrs[i] = (uintptr_t)stack;
   }
 #endif
+  assert(stacks[i] == NULL); // We should only be setting this once per thread compartment right after thread creation.
   stacks[i] = stack;
   // The value set doesn't matter here as long as it's non-`NULL`.
   // `allocate_stack` is called for each compartment

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -92,6 +92,8 @@ char *allocate_stack(int i) {
   // but it doesn't really matter what value it is,
   // since the destructor `thread_stacks_destructor`
   // just uses the TLS global `stack` directly.
+  // Moreover, this is idempotent as it doesn't matter how many times we set it,
+  // since it just matters that it's non-`NULL`.
   const int result = pthread_setspecific(thread_stacks_key, (void *)stacks);
   if (result != 0) {
     fprintf(stderr, "pthread_setspecific failed: %s\n", strerrorname_np(result));

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -24,9 +24,9 @@ extern __thread void *ia2_stackptr_0[PAGE_SIZE / sizeof(void *)]
 
 static pthread_key_t thread_stacks_key IA2_SHARED_DATA;
 
-__thread void *stacks[IA2_MAX_COMPARTMENTS] = {0};
+static __thread void *stacks[IA2_MAX_COMPARTMENTS] = {0};
 
-void thread_stacks_destructor(void *_unused) {
+static void thread_stacks_destructor(void *_unused) {
 #if IA2_VERBOSE
   char thread_name[16] = {0};
   if (pthread_getname_np(pthread_self(), thread_name, sizeof(thread_name)) != 0) {

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -51,7 +51,7 @@ static void thread_stacks_destructor(void *_unused) {
 
 /// Create `thread_stacks_key`.
 /// This should be called once per process at the very beginning, currently in `ia2_init`.
-void ia2_create_thread_keys(void) {
+static void create_thread_keys(void) {
   const int result = pthread_key_create(&thread_stacks_key, thread_stacks_destructor);
   if (result != 0) {
     fprintf(stderr, "pthread_key_create failed: %s\n", strerrorname_np(result));
@@ -287,7 +287,7 @@ void ia2_start(void) {
     ia2_setup_destructors();
     /* Set up global resources. */
     ia2_set_up_tags();
-    ia2_create_thread_keys();
+    create_thread_keys();
     verify_tls_padding();
     /* allocate an unprotected stack for the untrusted compartment */
     allocate_stack_0();

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -32,6 +32,8 @@ void thread_stacks_destructor(void *_unused) {
     if (!stack) {
       continue;
     }
+    ia2_log("deallocating stack for compartment %zu on thread %ld: %p..%p\n",
+            compartment, (long)gettid(), stack, stack + STACK_SIZE);
     if (munmap(stack, STACK_SIZE) == -1) {
       fprintf(stderr, "munmap failed\n");
       abort();
@@ -63,6 +65,7 @@ char *allocate_stack(int i) {
     }
   }
 
+  ia2_log("allocating stack for compartment %d on thread %ld: %p..%p\n", i, (long)gettid(), stack, stack + STACK_SIZE);
 #if IA2_DEBUG_MEMORY
   struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_current_thread();
   if (thread_metadata) {

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -28,7 +28,8 @@ extern __thread void *ia2_stackptr_0[PAGE_SIZE / sizeof(void *)]
 /// it just matters if it was set (to non-`NULL`) or not.
 static pthread_key_t thread_stacks_key IA2_SHARED_DATA;
 
-/// The compartment stacks for each thread.
+/// The base address of the compartment stacks for each thread.
+/// This is the address directly `mmap`ed, so there is no tagging.
 static __thread void *stacks[IA2_MAX_COMPARTMENTS] = {0};
 
 /// The destructor for `thread_stacks_key`.

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -1,5 +1,6 @@
 #include "memory_maps.h"
 #include "ia2.h"
+#include "thread_name.h"
 
 // Only enable this code that stores these addresses when debug logging is enabled.
 // This reduces the trusted codebase and avoids runtime overhead.
@@ -122,16 +123,11 @@ static void label_memory_map(FILE *log, uintptr_t start_addr) {
   const struct ia2_thread_metadata *metadata = location.thread_metadata;
 
   if (location.name) {
-    char thread_name[16] = {0};
-    const bool has_thread_name = pthread_getname_np(metadata->thread, thread_name, sizeof(thread_name)) == 0;
-
     Dl_info dl_info = {0};
     const bool has_dl_info = dladdr((void *)metadata->start_fn, &dl_info);
 
     fprintf(log, "[%s:compartment %d:tid %ld", location.name, location.compartment, (long)metadata->tid);
-    if (has_thread_name) {
-      fprintf(log, " (thread %s)", thread_name);
-    }
+    fprintf(log, " (thread %s)", thread_name_get(metadata->thread).name);
     fprintf(log, " (start fn ");
     if (!metadata->start_fn) {
       // `metadata->start_fn` is always set during `__wrap_pthread_create`/`ia2_thread_begin`,

--- a/runtime/libia2/thread_name.c
+++ b/runtime/libia2/thread_name.c
@@ -1,0 +1,17 @@
+#include "thread_name.h"
+
+#include "ia2_internal.h"
+
+#include <string.h>
+#include <unistd.h>
+
+struct thread_name thread_name_get(pthread_t thread) {
+  struct thread_name thread_name;
+  const int result = pthread_getname_np(thread, thread_name.name, sizeof(thread_name.name));
+  if (result == -1) {
+    ia2_log("pthread_getname_np failed on thread %ld: %s\n", (long)gettid(), strerrorname_np(result));
+    thread_name.name[0] = '?';
+    thread_name.name[1] = 0;
+  }
+  return thread_name;
+}

--- a/runtime/libia2/thread_name.h
+++ b/runtime/libia2/thread_name.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "ia2_internal.h"
+
+#include <pthread.h>
+#include <string.h>
+#include <unistd.h>
+
+#define THREAD_NAME_MAX_LEN 16
+
+struct thread_name {
+  char name[THREAD_NAME_MAX_LEN];
+};
+
+static inline struct thread_name thread_name_get(pthread_t thread) {
+  struct thread_name thread_name;
+  const int result = pthread_getname_np(thread, thread_name.name, sizeof(thread_name.name));
+  if (result == -1) {
+    ia2_log("pthread_getname_np failed on thread %ld: %s\n", (long)gettid(), strerrorname_np(result));
+    thread_name.name[0] = '?';
+    thread_name.name[1] = 0;
+  }
+  return thread_name;
+}

--- a/runtime/libia2/thread_name.h
+++ b/runtime/libia2/thread_name.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#include "ia2_internal.h"
-
 #include <pthread.h>
-#include <string.h>
-#include <unistd.h>
 
 #define THREAD_NAME_MAX_LEN 16
 
@@ -12,13 +8,4 @@ struct thread_name {
   char name[THREAD_NAME_MAX_LEN];
 };
 
-static inline struct thread_name thread_name_get(pthread_t thread) {
-  struct thread_name thread_name;
-  const int result = pthread_getname_np(thread, thread_name.name, sizeof(thread_name.name));
-  if (result == -1) {
-    ia2_log("pthread_getname_np failed on thread %ld: %s\n", (long)gettid(), strerrorname_np(result));
-    thread_name.name[0] = '?';
-    thread_name.name[1] = 0;
-  }
-  return thread_name;
-}
+struct thread_name thread_name_get(pthread_t thread);


### PR DESCRIPTION
* Fixes #546.

I did this with `pthread_key_create` and `pthread_setspecific`, as this makes the implementation very simple and should handle all ways thread terminate (`return`, `pthread_exit`, `pthread_cancel`).

`pthread_key_create` creates a TLS key with a destructor function that's called whenever a thread terminates (however that happens).  This is used to `munmap` all the thread stacks.  Since multiple stacks are used per thread and `pthread_key_create` can only store a single ptr as its data, the thread stacks are stored in a separate `__thread` TLS array and `pthread_setspecific` is used to simply store a non-`NULL` value as the data so that the destructor will eventually be run.