### PR TITLE
test_runner: make `cr_assert` unconditional and use instead of `assert`

### DIFF
--- a/misc/test_runner/include/ia2_test_runner.h
+++ b/misc/test_runner/include/ia2_test_runner.h
@@ -56,7 +56,7 @@ extern struct fake_criterion_test *fake_criterion_tests;
 #define cr_log_info(f, ...) printf(f "\n", ##__VA_ARGS__)
 #define cr_log_error(f, ...) fprintf(stderr, f "\n", ##__VA_ARGS__)
 
-#define cr_assert assert
+#define cr_assert(x) (x || (abort(), true))
 #define cr_assert_eq(a, b) cr_assert((a) == (b))
 #define cr_assert_lt(a, b) cr_assert((a) < (b))
 #define cr_fatal(s)          \

--- a/misc/test_runner/include/ia2_test_runner.h
+++ b/misc/test_runner/include/ia2_test_runner.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <assert.h>
 #include <ia2.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/misc/test_runner/test_runner.c
+++ b/misc/test_runner/test_runner.c
@@ -102,7 +102,7 @@ int main() {
     struct fake_criterion_test *test = &tests[i];
     if (test->signal != 0) {
       // If an expected signal was set, check if it was valid.
-      assert(test->signal > 0 && test->signal < _NSIG);
+      cr_assert(test->signal > 0 && test->signal < _NSIG);
       if (test->exit_code != 0) {
         fprintf(stderr, "can't expect both signal %d (SIG%s) and exit status %d\n",
                 test->signal, sigabbrev_np(test->signal), test->exit_code);
@@ -169,7 +169,7 @@ int main() {
       return 2;
     }
 
-    assert(WIFEXITED(status) ^ WIFSIGNALED(status));
+    cr_assert(WIFEXITED(status) ^ WIFSIGNALED(status));
     if (WIFSIGNALED(status)) {
       fprintf(stderr, "killed by signal %d (SIG%s)",
               WTERMSIG(status), sigabbrev_np(WTERMSIG(status)));


### PR DESCRIPTION
Pulled out of #524.

@fw-immunant, this is done instead of `assert` since `assert` sometimes is more like `debug_assert!`, right?