### PR TITLE
type-registry: use LTO for release builds

### DIFF
--- a/runtime/type-registry/Cargo.toml
+++ b/runtime/type-registry/Cargo.toml
@@ -18,3 +18,6 @@ panic = "abort"
 
 [profile.release]
 panic = "abort"
+# It's important to be small to link into call gates,
+# and LTO reduces size by an order of magnitude.
+lto = true


### PR DESCRIPTION
Pulled out #524.

This reduces the size by over an order of magnitude, and it's important not to be too large to link into the call gates.

It doesn't help with debug builds, though, and isn't worth there anyways, so we only do this for release builds.