### PR TITLE
type-registry: use `panic_abort!` instead of `panic!`

### DIFF
--- a/runtime/type-registry/src/panic.rs
+++ b/runtime/type-registry/src/panic.rs
@@ -1,0 +1,38 @@
+#[cfg(not(test))]
+pub mod panic_abort_impl {
+    use std::backtrace::Backtrace;
+    use std::fmt::Arguments;
+    use std::panic::Location;
+    use std::process::abort;
+    use std::thread;
+
+    #[cfg(not(test))]
+    #[track_caller]
+    pub fn panic_abort_args(args: Arguments) -> ! {
+        let thread = thread::current();
+        let thread_name = thread.name().unwrap_or("<unnamed>");
+        let caller = Location::caller();
+        let file = caller.file();
+        let line = caller.line();
+        let col = caller.column();
+        let backtrace = Backtrace::capture();
+        eprintln!("thread '{thread_name}' panicked at {file}:{line}:{col}:\n{args}\n{backtrace}");
+
+        abort();
+    }
+}
+
+#[cfg(not(test))]
+macro_rules! panic_abort {
+    ($($arg:tt)*) => {{
+        $crate::panic::panic_abort_impl::panic_abort_args(format_args!($($arg)*));
+    }};
+}
+
+#[cfg(not(test))]
+pub(crate) use panic_abort;
+
+// Tests use `#[should_panic]` and this behavior is difficult to maintain with `abort()`s instead,
+// so just use normal `panic!`s when testing.
+#[cfg(test)]
+pub(crate) use panic as panic_abort;


### PR DESCRIPTION
`panic!`, even with `panic = "abort"`, still goes through the panic handler machinery, which unfortunately uses TLS, which doesn't work with IA2 correctly.

This changes all panics to use `panic_abort!` instead, which behaves like `panic!`, printing the panic message, location info, and backtrace, but then immediately and directly `abort()`s instead of going through the panic machinery.

The alternative is to make `type-registry` `#![no_std]` and define our own `#[panic_handler]`, which can work well, and is more thorough, but then we can't use a ton of things from `std`, like locks.

Thus, we'd have to implement our own locks, and this is tricky. The simplest is a spin lock (there's a `spin` crate already, too), but that's not ideal in userspace.  Wrapping `pthread` is an option, but this is annoyingly difficult since `pthread_mutex_t` and `pthread_rwlock_t` can't be moved, so we'd need to `Box` them, which means we can't `const` initialize them. And existing implementations like `std` and `parking_lot` are in `std` or depend on it, so we can't use them even if they could've just depended only on `futex` and `park`.