### PR TITLE
tests/terminating_threads: add a test for various combinations of ways threads can terminate

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ add_subdirectory(threads)
 add_subdirectory(protected_threads)
 add_subdirectory(memory_maps)
 add_subdirectory(signals)
+add_subdirectory(terminating_threads)
 
 # The following tests are not supported on ARM64 yet
 if (NOT LIBIA2_AARCH64)

--- a/tests/terminating_threads/CMakeLists.txt
+++ b/tests/terminating_threads/CMakeLists.txt
@@ -1,0 +1,12 @@
+define_shared_lib(
+  SRCS lib.c
+  PKEY 2
+)
+
+define_test(
+  SRCS main.c
+  PKEY 1
+  NEEDS_LD_WRAP
+  CRITERION_TEST
+  WITHOUT_SANDBOX # other thread tests require this, too
+)

--- a/tests/terminating_threads/lib.c
+++ b/tests/terminating_threads/lib.c
@@ -1,0 +1,4 @@
+#include <ia2_test_runner.h>
+
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>

--- a/tests/terminating_threads/main.c
+++ b/tests/terminating_threads/main.c
@@ -6,7 +6,7 @@ INIT_RUNTIME(2);
 #include <ia2_compartment_init.inc>
 
 #include <pthread.h>
-// #include <signal.h> // TODO 1 second delay from SIGABRT
+#include <signal.h>
 
 #if IA2_ENABLE
 
@@ -22,7 +22,7 @@ void *start_exit(void *_arg) {
 }
 
 void *start_abort(void *_arg) {
-  // abort(); // TODO 1 second delay
+  abort();
   return NULL;
 }
 
@@ -77,9 +77,7 @@ Test(terminating_threads, threads_1_exit) {
   run_test(0, start_pause, end_none, start_exit);
 }
 
-Test(terminating_threads, threads_1_abort,
-     // .signal = SIGABRT
-) {
+Test(terminating_threads, threads_1_abort, .signal = SIGABRT) {
   run_test(0, start_pause, end_none, start_abort);
 }
 
@@ -97,9 +95,7 @@ Test(terminating_threads, threads_2_main_thread_exit) {
   run_test(1, start_pause, end_none, start_exit);
 }
 
-Test(terminating_threads, threads_2_main_thread_abort,
-     // .signal = SIGABRT
-) {
+Test(terminating_threads, threads_2_main_thread_abort, .signal = SIGABRT) {
   run_test(1, start_pause, end_none, start_abort);
 }
 
@@ -117,9 +113,7 @@ Test(terminating_threads, threads_11_main_thread_exit) {
   run_test(10, start_pause, end_none, start_exit);
 }
 
-Test(terminating_threads, threads_11_main_thread_abort,
-     // .signal = SIGABRT
-) {
+Test(terminating_threads, threads_11_main_thread_abort, .signal = SIGABRT) {
   run_test(10, start_pause, end_none, start_abort);
 }
 
@@ -137,9 +131,7 @@ Test(terminating_threads, threads_2_other_thread_exit) {
   run_test(1, start_exit, end_join, start_return);
 }
 
-Test(terminating_threads, threads_2_other_thread_abort,
-     // .signal = SIGABRT
-) {
+Test(terminating_threads, threads_2_other_thread_abort, .signal = SIGABRT) {
   run_test(1, start_abort, end_join, start_return);
 }
 
@@ -165,9 +157,7 @@ Test(terminating_threads, threads_11_other_threads_exit) {
   run_test(10, start_exit, end_join, start_return);
 }
 
-Test(terminating_threads, threads_11_other_threads_abort,
-     // .signal = SIGABRT
-) {
+Test(terminating_threads, threads_11_other_threads_abort, .signal = SIGABRT) {
   run_test(10, start_abort, end_join, start_return);
 }
 

--- a/tests/terminating_threads/main.c
+++ b/tests/terminating_threads/main.c
@@ -1,0 +1,186 @@
+#include <ia2.h>
+#include <ia2_test_runner.h>
+
+INIT_RUNTIME(2);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
+
+#include <pthread.h>
+// #include <signal.h> // TODO 1 second delay from SIGABRT
+
+#if IA2_ENABLE
+
+typedef void *(*start_fn)(void *arg);
+typedef int (*end_fn)(pthread_t thread);
+
+void *start_return(void *_arg) {
+  return NULL;
+}
+
+void *start_exit(void *_arg) {
+  exit(0);
+}
+
+void *start_abort(void *_arg) {
+  // abort(); // TODO 1 second delay
+  return NULL;
+}
+
+void *start_pthread_exit(void *_arg) {
+  // pthread_exit(NULL); // TODO `SIGILL`s.
+  return NULL;
+}
+
+void *start_pause(void *_arg) {
+  pause();
+  return NULL;
+}
+
+void *start_sleep_100_us(void *_arg) {
+  usleep(100);
+  return NULL;
+}
+
+int end_none(pthread_t _thread) {
+  return 0;
+}
+
+int end_join(pthread_t thread) {
+  return pthread_join(thread, NULL);
+}
+
+int end_cancel(pthread_t thread) {
+  // return pthread_cancel(thread); // TODO `SIGSEGV`s.
+  exit(0);
+}
+
+void run_test(size_t num_threads, start_fn start, end_fn end, start_fn main) {
+  if (num_threads > 0) {
+    pthread_t threads[num_threads];
+    for (size_t i = 0; i < num_threads; i++) {
+      pthread_create(&threads[i], NULL, start, NULL);
+    }
+    for (size_t i = 0; i < num_threads; i++) {
+      cr_assert(end(threads[i]) == 0);
+    }
+  }
+  main(NULL);
+}
+
+// 1 thread
+
+Test(terminating_threads, threads_1_return) {
+  run_test(0, start_pause, end_none, start_return);
+}
+
+Test(terminating_threads, threads_1_exit) {
+  run_test(0, start_pause, end_none, start_exit);
+}
+
+Test(terminating_threads, threads_1_abort,
+     // .signal = SIGABRT
+) {
+  run_test(0, start_pause, end_none, start_abort);
+}
+
+Test(terminating_threads, threads_1_pthread_exit) {
+  run_test(0, start_pause, end_none, start_pthread_exit);
+}
+
+// 2 threads, main thread
+
+Test(terminating_threads, threads_2_main_thread_return) {
+  run_test(1, start_pause, end_none, start_return);
+}
+
+Test(terminating_threads, threads_2_main_thread_exit) {
+  run_test(1, start_pause, end_none, start_exit);
+}
+
+Test(terminating_threads, threads_2_main_thread_abort,
+     // .signal = SIGABRT
+) {
+  run_test(1, start_pause, end_none, start_abort);
+}
+
+Test(terminating_threads, threads_2_main_thread_pthread_exit) {
+  run_test(1, start_pause, end_none, start_pthread_exit);
+}
+
+// 11 threads, main thread
+
+Test(terminating_threads, threads_11_main_thread_return) {
+  run_test(10, start_pause, end_none, start_return);
+}
+
+Test(terminating_threads, threads_11_main_thread_exit) {
+  run_test(10, start_pause, end_none, start_exit);
+}
+
+Test(terminating_threads, threads_11_main_thread_abort,
+     // .signal = SIGABRT
+) {
+  run_test(10, start_pause, end_none, start_abort);
+}
+
+Test(terminating_threads, threads_11_main_thread_pthread_exit) {
+  run_test(10, start_pause, end_none, start_pthread_exit);
+}
+
+// 2 threads, other thread
+
+Test(terminating_threads, threads_2_other_thread_return) {
+  run_test(1, start_return, end_join, start_return);
+}
+
+Test(terminating_threads, threads_2_other_thread_exit) {
+  run_test(1, start_exit, end_join, start_return);
+}
+
+Test(terminating_threads, threads_2_other_thread_abort,
+     // .signal = SIGABRT
+) {
+  run_test(1, start_abort, end_join, start_return);
+}
+
+Test(terminating_threads, threads_2_other_thread_pthread_exit) {
+  run_test(1, start_pthread_exit, end_join, start_return);
+}
+
+Test(terminating_threads, threads_2_other_thread_pthread_join) {
+  run_test(1, start_sleep_100_us, end_join, start_return);
+}
+
+Test(terminating_threads, threads_2_other_thread_pthread_cancel) {
+  run_test(1, start_pause, end_cancel, start_return);
+}
+
+// 11 threads, other threads
+
+Test(terminating_threads, threads_11_other_threads_return) {
+  run_test(10, start_return, end_join, start_return);
+}
+
+Test(terminating_threads, threads_11_other_threads_exit) {
+  run_test(10, start_exit, end_join, start_return);
+}
+
+Test(terminating_threads, threads_11_other_threads_abort,
+     // .signal = SIGABRT
+) {
+  run_test(10, start_abort, end_join, start_return);
+}
+
+Test(terminating_threads, threads_11_other_threads_pthread_exit) {
+  run_test(10, start_pthread_exit, end_join, start_return);
+}
+
+Test(terminating_threads, threads_11_other_threads_pthread_join) {
+  run_test(10, start_sleep_100_us, end_join, start_return);
+}
+
+Test(terminating_threads, threads_11_other_threads_pthread_cancel) {
+  run_test(10, start_pause, end_cancel, start_return);
+}
+
+#endif

--- a/tests/terminating_threads/main.c
+++ b/tests/terminating_threads/main.c
@@ -52,8 +52,15 @@ int end_join(pthread_t thread) {
 }
 
 int end_cancel(pthread_t thread) {
-  // return pthread_cancel(thread); // TODO `SIGSEGV`s.
-  exit(0);
+  exit(0); // TODO Skip for now, as `pthread_cancel` `SIGSEGV`s (#606).
+
+  const int result = pthread_cancel(thread) != 0;
+  if (result != 0) {
+    return result;
+  }
+  // Cancellation is asynchronous, so we still need to
+  // join it to ensure cancellation completes.
+  return pthread_join(thread, NULL);
 }
 
 void run_test(size_t num_threads, start_fn start, end_fn end, start_fn main) {

--- a/tests/terminating_threads/main.c
+++ b/tests/terminating_threads/main.c
@@ -27,7 +27,9 @@ void *start_abort(void *_arg) {
 }
 
 void *start_pthread_exit(void *_arg) {
-  // pthread_exit(NULL); // TODO `SIGILL`s.
+  exit(0); // TODO Skip for now, as `pthread_exit` `SIGILL`s (#605).
+
+  pthread_exit(NULL);
   return NULL;
 }
 


### PR DESCRIPTION
This tests various combinations of threads terminating, including a matrix of:
* 1, 2, and 11 threads (including the main thread)
* threads terminating by `return`, `exit(0)`, `abort()`, `pthread_exit(0)` (including the main thread) or `pause()`ing or `sleep`ing
* threads being `pthread_join`ed, `pthread_cancel`ed, or through process termination

However, `abort()` currently incurs a ~1 second penalty for some reason, so that's disabled. Moreover, `pthread_exit` causes `SIGILL` and `pthread_cancel` causes `SIGSEGV`, so these are disabled, too.

Furthermore, just like the other existing thread tests (`threads` and `protected_threads`), `terminating_threads` runs `WITHOUT_SANDBOX`, as the tracer fails on all of them.

I'll add tests covering `atexit`, `pthread_cleanup_push`, `pthread_key_create`, and other process/thread termination cleanup functions next in a subsequent PR.