### PR TITLE
tests/signals: add test for signals 1..=32

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ add_subdirectory(tls_protected)
 add_subdirectory(threads)
 add_subdirectory(protected_threads)
 add_subdirectory(memory_maps)
+add_subdirectory(signals)
 
 # The following tests are not supported on ARM64 yet
 if (NOT LIBIA2_AARCH64)

--- a/tests/signals/CMakeLists.txt
+++ b/tests/signals/CMakeLists.txt
@@ -1,0 +1,12 @@
+define_shared_lib(
+  SRCS lib.c
+  PKEY 2
+)
+
+define_test(
+  SRCS main.c
+  PKEY 1
+  NEEDS_LD_WRAP
+  CRITERION_TEST
+  WITHOUT_SANDBOX # tracer can't handle unexpected signals yet (see #488)
+)

--- a/tests/signals/lib.c
+++ b/tests/signals/lib.c
@@ -1,0 +1,4 @@
+#include <ia2.h>
+
+#define IA2_COMPARTMENT 2
+#include <ia2_compartment_init.inc>

--- a/tests/signals/main.c
+++ b/tests/signals/main.c
@@ -1,0 +1,160 @@
+#include <ia2.h>
+#include <ia2_test_runner.h>
+
+INIT_RUNTIME(2);
+#define IA2_COMPARTMENT 1
+#include <ia2_compartment_init.inc>
+
+#include <signal.h>
+
+Test(signals, signal_1, .signal = SIGHUP) {
+    raise(1);
+}
+
+Test(signals, signal_2, .signal = SIGINT) {
+    raise(2);
+}
+
+Test(signals, signal_3, .signal = SIGQUIT) {
+    raise(3);
+}
+
+// TODO 1 sec delay
+// `SIGILL` core dumps.
+Test(signals, signal_4, .signal = SIGILL) {
+    raise(4);
+}
+
+// TODO 1 sec delay
+// `SIGTRAP` core dumps.
+Test(signals, signal_5, .signal = SIGTRAP) {
+    raise(5);
+}
+
+// TODO 1 sec delay
+// `SIGABRT` core dumps.
+Test(signals, signal_6, .signal = SIGABRT) {
+    raise(6);
+}
+
+// TODO CHECK_VIOLATION: unexpected seg fault
+// Test(signals, signal_7, .signal = SIGBUS) {
+//     raise(7);
+// }
+
+// TODO CHECK_VIOLATION: unexpected seg fault
+// Test(signals, signal_8, .signal = SIGFPE) {
+//     raise(8);
+// }
+
+Test(signals, signal_9, .signal = SIGKILL) {
+    raise(9);
+}
+
+Test(signals, signal_10, .signal = SIGUSR1) {
+    raise(10);
+}
+
+// TODO CHECK_VIOLATION: unexpected seg fault
+// Test(signals, signal_11, .signal = SIGSEGV) {
+//     raise(11);
+// }
+
+Test(signals, signal_12, .signal = SIGUSR2) {
+    raise(12);
+}
+
+Test(signals, signal_13, .signal = SIGPIPE) {
+    raise(13);
+}
+
+Test(signals, signal_14, .signal = SIGALRM) {
+    raise(14);
+}
+
+Test(signals, signal_15, .signal = SIGTERM) {
+    raise(15);
+}
+
+Test(signals, signal_16, .signal = SIGSTKFLT) {
+    raise(16);
+}
+
+// `SIGCHLD` ignored.
+Test(signals, signal_17) {
+    raise(SIGCHLD);
+}
+
+// `SIGCONT` ignored.
+Test(signals, signal_18) {
+    raise(SIGCONT);
+}
+
+// `SIGSTOP` stops.
+Test(signals, signal_19) {
+    // raise(SIGSTOP);
+}
+
+// `SIGTSTP` stops.
+Test(signals, signal_20) {
+    // raise(SIGTSTP);
+}
+
+// `SIGTTIN` stops.
+Test(signals, signal_21) {
+    // raise(SIGTTIN);
+}
+
+// `SIGTTOU` stops.
+Test(signals, signal_22) {
+    // raise(SIGTTOU);
+}
+
+// `SIGURG` ignored.
+Test(signals, signal_23) {
+    raise(SIGURG);
+}
+
+// TODO 1 sec delay
+// `SIGXCPU` core dumps.
+Test(signals, signal_24, .signal = SIGXCPU) {
+    raise(24);
+}
+
+// TODO 1 sec delay
+// `SIGXFSZ` core dumps.
+Test(signals, signal_25, .signal = SIGXFSZ) {
+    raise(25);
+}
+
+Test(signals, signal_26, .signal = SIGVTALRM) {
+    raise(26);
+}
+
+Test(signals, signal_27, .signal = SIGPROF) {
+    raise(27);
+}
+
+// `SIGWINCH` ignored.
+Test(signals, signal_28) {
+    raise(SIGWINCH);
+}
+
+Test(signals, signal_29, .signal = SIGIO) {
+    raise(29);
+}
+
+Test(signals, signal_30, .signal = SIGPWR) {
+    raise(30);
+}
+
+// TODO 1 sec delay
+// `SIGSYS` core dumps.
+Test(signals, signal_31, .signal = SIGSYS) {
+    raise(31);
+}
+
+// Realtime signals ignored.
+Test(signals, signal_32) {
+    raise(32);
+}


### PR DESCRIPTION
* Testing #601.

This tests all signals from 1 to 32, covering all non-realtime signals and one realtime signal (32).

Some signals cause a ~1 second delay:
* `SIGILL` (4)
* `SIGTRAP` (5)
* `SIGABRT` (6)
* `SIGXCPU` (24)
* `SIGXFSZ` (25)
* `SIGSYS` (31)

These all core dump by default, but `ulimit -c 0` doesn't help, and `SIGQUIT` (3) also core dumps, but has no delay.

Some other signals also cause `CHECK_VIOLATION: unexpected seg fault`s:
* `SIGBUS` (7)
* `SIGFPE` (8)
* `SIGSEGV` (11)