### PR TITLE
type-registry: some `no_std` improvements/fixes

### DIFF
--- a/runtime/type-registry/Cargo.lock
+++ b/runtime/type-registry/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,9 +21,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7581282928bc99698341d1de7590964c28db747c164eaac9409432a3eaed098a"
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "type-registry"
 version = "0.1.0"
 dependencies = [
  "libc",
  "libc_alloc",
+ "spin",
 ]

--- a/runtime/type-registry/Cargo.lock
+++ b/runtime/type-registry/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
 name = "libc_alloc"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,5 +18,6 @@ checksum = "7581282928bc99698341d1de7590964c28db747c164eaac9409432a3eaed098a"
 name = "type-registry"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "libc_alloc",
 ]

--- a/runtime/type-registry/Cargo.toml
+++ b/runtime/type-registry/Cargo.toml
@@ -8,8 +8,8 @@ rust-version = "1.85"
 crate-type = ["staticlib"]
 
 [dependencies]
-
-libc_alloc = "1"
+libc = { version = "0.2.174", default-features = false }
+libc_alloc = "1.0.7"
 
 # We always need `panic = "abort"`,
 # as we don't want panics to cross the C/Rust boundary,

--- a/runtime/type-registry/Cargo.toml
+++ b/runtime/type-registry/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["staticlib"]
 [dependencies]
 libc = { version = "0.2.174", default-features = false }
 libc_alloc = "1.0.7"
+spin = "0.10.0"
 
 # We always need `panic = "abort"`,
 # as we don't want panics to cross the C/Rust boundary,

--- a/runtime/type-registry/src/lib.rs
+++ b/runtime/type-registry/src/lib.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(not(test), no_std)]
-/* use the C allocator; don't use libstd */
+
+// Use the C allocator; don't use libstd.
 extern crate alloc;
+
 use libc_alloc::LibcAlloc;
 
 #[global_allocator]
@@ -19,7 +21,7 @@ impl alloc::fmt::Write for StdErrWriter {
     }
 }
 
-/* print errors via libc */
+// Print errors via libc.
 macro_rules! eprintln {
     ($($items: expr),+) => {{
         use alloc::fmt::Write;

--- a/runtime/type-registry/src/lib.rs
+++ b/runtime/type-registry/src/lib.rs
@@ -30,6 +30,7 @@ struct StdErrWriter;
 
 #[cfg(not(test))]
 impl fmt::Write for StdErrWriter {
+    /// async-signal-safe
     fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
         // SAFETY: `s.as_ptr()` points to `s.len()` bytes.
         unsafe { write(STDERR_FILENO, s.as_ptr().cast(), s.len()) };

--- a/runtime/type-registry/src/lib.rs
+++ b/runtime/type-registry/src/lib.rs
@@ -11,18 +11,24 @@ use core::fmt::Formatter;
 #[cfg(not(test))]
 use core::panic::PanicInfo;
 use core::ptr;
+#[cfg(not(test))]
 use libc::STDERR_FILENO;
 #[cfg(not(test))]
 use libc::abort;
+#[cfg(not(test))]
 use libc::write;
 use libc_alloc::LibcAlloc;
 use spin::RwLock;
+#[cfg(test)]
+use std::eprintln;
 
 #[global_allocator]
 static ALLOCATOR: LibcAlloc = LibcAlloc;
 
+#[cfg(not(test))]
 struct StdErrWriter;
 
+#[cfg(not(test))]
 impl fmt::Write for StdErrWriter {
     fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
         // SAFETY: `s.as_ptr()` points to `s.len()` bytes.
@@ -32,6 +38,7 @@ impl fmt::Write for StdErrWriter {
 }
 
 // Print errors via libc.
+#[cfg(not(test))]
 macro_rules! eprintln {
     ($($items: expr),+) => {{
         use core::fmt::Write;

--- a/runtime/type-registry/src/lib.rs
+++ b/runtime/type-registry/src/lib.rs
@@ -25,6 +25,7 @@ struct StdErrWriter;
 
 impl fmt::Write for StdErrWriter {
     fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
+        // SAFETY: `s.as_ptr()` points to `s.len()` bytes.
         unsafe { write(STDERR_FILENO, s.as_ptr().cast(), s.len()) };
         Ok(())
     }
@@ -42,6 +43,7 @@ macro_rules! eprintln {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     eprintln!("{info}");
+    // SAFETY: `abort` is always safe.
     unsafe { abort() };
 }
 


### PR DESCRIPTION
This fixes some things in the `no_std` implementation of the `type-registry`, specifically:

* We use `libc` functions from the `libc` crate instead of declaring them ourselves (sometimes slightly wrong).
* We use `spin::RwLock` instead of rolling our own spin-based `Mutex`, which hasn't been checked for correctness, and is less ideal than a `RwLock`, which it originally was.
* ~~We use `hashbrown::HashMap` instead of `alloc::collections::BTreeMap`.  We would normally use `std::collections::HashMap`, but it hasn't yet been moved to `alloc`, and it internally uses `hashbrown` anyways.  Moreover, we use `fnv` as the hasher, as that's `const fn` compatible.~~
* Some other little cleanups.