### PR TITLE
tests/terminating_threads: test that stacks are freed upon thread termination

### DIFF
--- a/misc/test_runner/include/ia2_test_runner.h
+++ b/misc/test_runner/include/ia2_test_runner.h
@@ -52,8 +52,8 @@ extern struct fake_criterion_test *fake_criterion_tests;
   }                                                                                         \
   void fake_criterion_##suite_##_##name_(void)
 
-#define cr_log_info(f, ...) printf(f "\n", ##__VA_ARGS__)
-#define cr_log_error(f, ...) fprintf(stderr, f "\n", ##__VA_ARGS__)
+#define cr_log_info(fmt, ...) fprintf(stdout, fmt "\n", ##__VA_ARGS__)
+#define cr_log_error(fmt, ...) fprintf(stderr, fmt "\n", ##__VA_ARGS__)
 
 #if NDEBUG
 #define cr_assert(x) (x || (abort(), true))
@@ -64,10 +64,10 @@ extern struct fake_criterion_test *fake_criterion_tests;
 
 #define cr_assert_eq(a, b) cr_assert((a) == (b))
 #define cr_assert_lt(a, b) cr_assert((a) < (b))
-#define cr_fatal(s)          \
-  do {                       \
-    fprintf(stderr, s "\n"); \
-    exit(1);                 \
+#define cr_fatal(fmt, ...)            \
+  do {                                \
+    cr_log_error(fmt, ##__VA_ARGS__); \
+    exit(1);                          \
   } while (0)
 
 /*

--- a/tests/terminating_threads/main.c
+++ b/tests/terminating_threads/main.c
@@ -102,6 +102,15 @@ struct start_wrapper_args {
   size_t index;
 };
 
+/// Run some pre-thread start code in the new thread.
+///
+/// `arg` should be a `struct start_wrapper_args`.
+///
+/// The wrapper:
+/// * saves `args->start` in case it's deallocated in the parent thread.
+/// * stores a stack ptr from the new thread.
+/// * names the thread to help with debugging.
+/// * waits on `args->barrier` so that all thread wrappers finish before the parent thread finishes.
 static void *start_wrapper(void *arg) {
   struct start_wrapper_args *const args = (struct start_wrapper_args *)arg;
 

--- a/tests/terminating_threads/main.c
+++ b/tests/terminating_threads/main.c
@@ -146,10 +146,12 @@ void run_test(size_t num_threads, start_fn start, end_fn end, start_fn main) {
     cr_assert(pthread_barrier_init(&barrier, NULL, (unsigned)num_threads + 1) == 0);
 
     for (size_t i = 0; i < num_threads; i++) {
-      args[i].start = start;
-      args[i].barrier = &barrier;
-      args[i].stack_ptr = NULL;
-      args[i].index = i;
+      args[i] = (struct start_wrapper_args){
+          .start = start,
+          .barrier = &barrier,
+          .stack_ptr = NULL,
+          .index = i,
+      };
 #if IA2_ENABLE
       pthread_create(&threads[i], NULL, start_wrapper, (void *)&args[i]);
 #endif

--- a/tests/terminating_threads/main.c
+++ b/tests/terminating_threads/main.c
@@ -14,8 +14,8 @@ static bool addr_is_mapped(void *const ptr) {
   const uintptr_t page_mask = ~(PAGE_SIZE - 1);
   void *const aligned_ptr = (void *)((uintptr_t)ptr & page_mask);
 
-  unsigned char vec = 0;
-  const int result = mincore(aligned_ptr, PAGE_SIZE, &vec);
+  unsigned char vec[1] = {0}; // We're only checking 1 page.
+  const int result = mincore(aligned_ptr, PAGE_SIZE, vec);
   if (result == -1) {
     if (errno == ENOMEM) {
       // `ENOMEM` for `mincore` means that the page `aligned_ptr..aligned_ptr + PAGE_SIZE`,

--- a/tests/terminating_threads/main.c
+++ b/tests/terminating_threads/main.c
@@ -111,8 +111,23 @@ static void *start_wrapper(void *arg) {
   int stack_arg;
   args->stack_ptr = (void *)&stack_arg;
 
+  const char *start_name = "?";
+  if (start == start_return) {
+    start_name = "return";
+  } else if (false /* start == start_exit */) {
+    start_name = "exit";
+  } else if (start == start_abort) {
+    start_name = "abort";
+  } else if (false /* start == start_pthread_exit */) {
+    start_name = "pthread_exit";
+  } else if (start == start_pause) {
+    start_name = "pause";
+  } else if (start == start_sleep_100_us) {
+    start_name = "sleep_100_us";
+  }
+
   char thread_name[16] = {0};
-  snprintf(thread_name, sizeof(thread_name), "%zu", args->index);
+  snprintf(thread_name, sizeof(thread_name), "%zu, %s", args->index, start_name);
   const int result = pthread_setname_np(pthread_self(), thread_name);
   if (result != 0) {
     cr_fatal("pthread_setname_np failed: %s", strerrorname_np(result));

--- a/tests/terminating_threads/main.c
+++ b/tests/terminating_threads/main.c
@@ -37,53 +37,53 @@ void ia2_main(void) {
 typedef void *(*start_fn)(void *arg);
 typedef int (*end_fn)(pthread_t thread);
 
-void *start_return(void *_arg) {
+static void *start_return(void *_arg) {
   return NULL;
 }
 
 #if 0 // TODO Skip for now, as `exit` does cleanup that might have some issues.
 
-void *start_exit(void *_arg) {
+static void *start_exit(void *_arg) {
   exit(0);
 }
 
 #endif
 
-void *start_abort(void *_arg) {
+static void *start_abort(void *_arg) {
   abort();
   return NULL;
 }
 
 #if 0 // TODO Skip for now, as `pthread_exit` `SIGILL`s (#605).
 
-void *start_pthread_exit(void *_arg) {
+static void *start_pthread_exit(void *_arg) {
   pthread_exit(NULL);
   return NULL;
 }
 
 #endif
 
-void *start_pause(void *_arg) {
+static void *start_pause(void *_arg) {
   pause();
   return NULL;
 }
 
-void *start_sleep_100_us(void *_arg) {
+static void *start_sleep_100_us(void *_arg) {
   usleep(100);
   return NULL;
 }
 
-int end_none(pthread_t _thread) {
+static int end_none(pthread_t _thread) {
   return 0;
 }
 
-int end_join(pthread_t thread) {
+static int end_join(pthread_t thread) {
   return pthread_join(thread, NULL);
 }
 
 #if 0 // TODO Skip for now, as `pthread_cancel` `SIGSEGV`s (#606).
 
-int end_cancel(pthread_t thread) {
+static int end_cancel(pthread_t thread) {
   const int result = pthread_cancel(thread) != 0;
   if (result != 0) {
     return result;
@@ -147,7 +147,7 @@ static void *start_wrapper(void *arg) {
   return start(NULL);
 }
 
-void run_test(size_t num_threads, start_fn start, end_fn end, start_fn main) {
+static void run_test(size_t num_threads, start_fn start, end_fn end, start_fn main) {
   if (num_threads > 0) {
     pthread_t threads[num_threads];
     struct start_wrapper_args args[num_threads];

--- a/tests/terminating_threads/main.c
+++ b/tests/terminating_threads/main.c
@@ -174,6 +174,7 @@ static void run_test(size_t num_threads, start_fn start, end_fn end, start_fn ma
       const int result = end(threads[i]);
       cr_assert(result == 0);
 
+      // NOTE: This only checks that compartment 1 (`main.c`)'s stacks are freed.
       const bool stack_is_mapped = addr_is_mapped(args[i].stack_ptr);
       if (start == start_pause && end == end_none) {
         // Threads are still alive, so their stack ptrs should still be mapped.


### PR DESCRIPTION
This uses `mincore` to test that thread stacks are freed upon thread termination.  Note that this only checks that compartment 1 (`main.c`)'s stacks are freed.