### PR TITLE
libia2: save stack ptr before tagging it on arm

### DIFF
--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -31,16 +31,17 @@ char *allocate_stack(int i) {
       exit(-1);
     }
   }
-#ifdef __aarch64__
-  /* Tag the allocated stack pointer so it is accessed with the right pkey */
-  stack = (char *)((uint64_t)stack | (uint64_t)i << 56);
-#endif
 
 #if IA2_DEBUG_MEMORY
   struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_current_thread();
   if (thread_metadata) {
     thread_metadata->stack_addrs[i] = (uintptr_t)stack;
   }
+#endif
+
+#ifdef __aarch64__
+  /* Tag the allocated stack pointer so it is accessed with the right pkey */
+  stack = (char *)((uint64_t)stack | (uint64_t)i << 56);
 #endif
 
 #ifdef __aarch64__


### PR DESCRIPTION
The tagged stack is what should be used for accesses, but the `mmap`ped untagged stack ptr is what will show up in memory maps.