### PR TITLE
tests/terminating_threads: `#if 0` out broken tests instead of using `exit(0)`, which has bugs itself

### DIFF
--- a/tests/terminating_threads/main.c
+++ b/tests/terminating_threads/main.c
@@ -15,23 +15,27 @@ void *start_return(void *_arg) {
   return NULL;
 }
 
-void *start_exit(void *_arg) {
-  _exit(0); // TODO Skip for now, as `exit` does cleanup that might have some issues.
+#if 0 // TODO Skip for now, as `exit` does cleanup that might have some issues.
 
+void *start_exit(void *_arg) {
   exit(0);
 }
+
+#endif
 
 void *start_abort(void *_arg) {
   abort();
   return NULL;
 }
 
-void *start_pthread_exit(void *_arg) {
-  _exit(0); // TODO Skip for now, as `pthread_exit` `SIGILL`s (#605).
+#if 0 // TODO Skip for now, as `pthread_exit` `SIGILL`s (#605).
 
+void *start_pthread_exit(void *_arg) {
   pthread_exit(NULL);
   return NULL;
 }
+
+#endif
 
 void *start_pause(void *_arg) {
   pause();
@@ -51,9 +55,9 @@ int end_join(pthread_t thread) {
   return pthread_join(thread, NULL);
 }
 
-int end_cancel(pthread_t thread) {
-  _exit(0); // TODO Skip for now, as `pthread_cancel` `SIGSEGV`s (#606).
+#if 0 // TODO Skip for now, as `pthread_cancel` `SIGSEGV`s (#606).
 
+int end_cancel(pthread_t thread) {
   const int result = pthread_cancel(thread) != 0;
   if (result != 0) {
     return result;
@@ -62,6 +66,8 @@ int end_cancel(pthread_t thread) {
   // join it to ensure cancellation completes.
   return pthread_join(thread, NULL);
 }
+
+#endif
 
 struct start_wrapper_args {
   start_fn start;
@@ -111,17 +117,25 @@ Test(terminating_threads, threads_1_return) {
   run_test(0, start_pause, end_none, start_return);
 }
 
+#if 0
+
 Test(terminating_threads, threads_1_exit) {
   run_test(0, start_pause, end_none, start_exit);
 }
+
+#endif
 
 Test(terminating_threads, threads_1_abort, .signal = SIGABRT) {
   run_test(0, start_pause, end_none, start_abort);
 }
 
+#if 0
+
 Test(terminating_threads, threads_1_pthread_exit) {
   run_test(0, start_pause, end_none, start_pthread_exit);
 }
+
+#endif
 
 // 2 threads, main thread
 
@@ -129,17 +143,25 @@ Test(terminating_threads, threads_2_main_thread_return) {
   run_test(1, start_pause, end_none, start_return);
 }
 
+#if 0
+
 Test(terminating_threads, threads_2_main_thread_exit) {
   run_test(1, start_pause, end_none, start_exit);
 }
+
+#endif
 
 Test(terminating_threads, threads_2_main_thread_abort, .signal = SIGABRT) {
   run_test(1, start_pause, end_none, start_abort);
 }
 
+#if 0
+
 Test(terminating_threads, threads_2_main_thread_pthread_exit) {
   run_test(1, start_pause, end_none, start_pthread_exit);
 }
+
+#endif
 
 // 11 threads, main thread
 
@@ -147,17 +169,25 @@ Test(terminating_threads, threads_11_main_thread_return) {
   run_test(10, start_pause, end_none, start_return);
 }
 
+#if 0
+
 Test(terminating_threads, threads_11_main_thread_exit) {
   run_test(10, start_pause, end_none, start_exit);
 }
+
+#endif
 
 Test(terminating_threads, threads_11_main_thread_abort, .signal = SIGABRT) {
   run_test(10, start_pause, end_none, start_abort);
 }
 
+#if 0
+
 Test(terminating_threads, threads_11_main_thread_pthread_exit) {
   run_test(10, start_pause, end_none, start_pthread_exit);
 }
+
+#endif
 
 // 2 threads, other thread
 
@@ -165,25 +195,37 @@ Test(terminating_threads, threads_2_other_thread_return) {
   run_test(1, start_return, end_join, start_return);
 }
 
+#if 0
+
 Test(terminating_threads, threads_2_other_thread_exit) {
   run_test(1, start_exit, end_join, start_return);
 }
+
+#endif
 
 Test(terminating_threads, threads_2_other_thread_abort, .signal = SIGABRT) {
   run_test(1, start_abort, end_join, start_return);
 }
 
+#if 0
+
 Test(terminating_threads, threads_2_other_thread_pthread_exit) {
   run_test(1, start_pthread_exit, end_join, start_return);
 }
+
+#endif
 
 Test(terminating_threads, threads_2_other_thread_pthread_join) {
   run_test(1, start_sleep_100_us, end_join, start_return);
 }
 
+#if 0
+
 Test(terminating_threads, threads_2_other_thread_pthread_cancel) {
   run_test(1, start_pause, end_cancel, start_return);
 }
+
+#endif
 
 // 11 threads, other threads
 
@@ -191,22 +233,34 @@ Test(terminating_threads, threads_11_other_threads_return) {
   run_test(10, start_return, end_join, start_return);
 }
 
+#if 0
+
 Test(terminating_threads, threads_11_other_threads_exit) {
   run_test(10, start_exit, end_join, start_return);
 }
+
+#endif
 
 Test(terminating_threads, threads_11_other_threads_abort, .signal = SIGABRT) {
   run_test(10, start_abort, end_join, start_return);
 }
 
+#if 0
+
 Test(terminating_threads, threads_11_other_threads_pthread_exit) {
   run_test(10, start_pthread_exit, end_join, start_return);
 }
+
+#endif
 
 Test(terminating_threads, threads_11_other_threads_pthread_join) {
   run_test(10, start_sleep_100_us, end_join, start_return);
 }
 
+#if 0
+
 Test(terminating_threads, threads_11_other_threads_pthread_cancel) {
   run_test(10, start_pause, end_cancel, start_return);
 }
+
+#endif

--- a/tests/terminating_threads/main.c
+++ b/tests/terminating_threads/main.c
@@ -16,6 +16,8 @@ void *start_return(void *_arg) {
 }
 
 void *start_exit(void *_arg) {
+  _exit(0); // TODO Skip for now, as `exit` does cleanup that might have some issues.
+
   exit(0);
 }
 
@@ -25,7 +27,7 @@ void *start_abort(void *_arg) {
 }
 
 void *start_pthread_exit(void *_arg) {
-  exit(0); // TODO Skip for now, as `pthread_exit` `SIGILL`s (#605).
+  _exit(0); // TODO Skip for now, as `pthread_exit` `SIGILL`s (#605).
 
   pthread_exit(NULL);
   return NULL;
@@ -50,7 +52,7 @@ int end_join(pthread_t thread) {
 }
 
 int end_cancel(pthread_t thread) {
-  exit(0); // TODO Skip for now, as `pthread_cancel` `SIGSEGV`s (#606).
+  _exit(0); // TODO Skip for now, as `pthread_cancel` `SIGSEGV`s (#606).
 
   const int result = pthread_cancel(thread) != 0;
   if (result != 0) {


### PR DESCRIPTION
`exit` does cleanups, so it may have some issues that may be causing some of the CI heisenbugs.  `#if 0` these tests out seems to help CI avoid errors now.  Note that `_exit` was still causing errors.