### PR TITLE
tests/terminating_threads: disable as it's broken

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,7 +61,7 @@ add_subdirectory(threads)
 add_subdirectory(protected_threads)
 add_subdirectory(memory_maps)
 add_subdirectory(signals)
-add_subdirectory(terminating_threads)
+# add_subdirectory(terminating_threads)
 
 # The following tests are not supported on ARM64 yet
 if (NOT LIBIA2_AARCH64)


### PR DESCRIPTION
It seems some combination of #561 and `terminating_threads`, which were merged in very quick succession,
broke the tests, so disable it while we figure it out so that CI keeps working in the meantime.