### PR TITLE
tests: Disable memory_maps test on ARM

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,7 +59,6 @@ add_subdirectory(tls_protected)
 
 add_subdirectory(threads)
 add_subdirectory(protected_threads)
-add_subdirectory(memory_maps)
 add_subdirectory(signals)
 add_subdirectory(terminating_threads)
 
@@ -84,4 +83,8 @@ if (NOT LIBIA2_AARCH64)
     add_subdirectory(post_condition)
     add_subdirectory(type_confusion)
     add_subdirectory(pre_post_condition)
+
+    # test is sporadically failing and IA2_DEBUG_MEMORY is not set in CI anyway
+    # so the test should effectively be a no-op
+    add_subdirectory(memory_maps)
 endif()


### PR DESCRIPTION
This test should effectively be a no-op since `-DIA2_DEBUG_MEMORY` is not set on ARM in CI, but it fails sporadically so I'm disabling it. I'm not entirely sure why it fails but it's likely related to how glibc defines stdio streams (see issue #405).