### PR TITLE
rewriter: fix segfault from iterator invalidation

### DIFF
--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -1280,9 +1280,7 @@ int main(int argc, const char **argv) {
   tool.appendArgumentsAdjuster([&](const CommandLineArguments &args, llvm::StringRef filename) {
     CommandLineArguments new_args(args);
     // Try to remove existing definition from command line to avoid warnings.
-    new_args.erase(std::remove_if(new_args.begin(), new_args.end(),
-                                  [](std::string &x) { return x.starts_with("-DIA2_ENABLE="); }),
-                   new_args.end());
+    std::erase_if(new_args, [](const std::string &arg) { return arg.starts_with("-DIA2_ENABLE="); });
     // Insert prior to the "end of flags" double hyphen; if not present, append
     auto double_hyphen_pos = std::find(new_args.begin(), new_args.end(), "--");
     double_hyphen_pos = new_args.insert(double_hyphen_pos, "-DIA2_ENABLE=0"s) + 1;

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -1285,12 +1285,12 @@ int main(int argc, const char **argv) {
                    new_args.end());
     // Insert prior to the "end of flags" double hyphen; if not present, append
     auto double_hyphen_pos = std::find(new_args.begin(), new_args.end(), "--");
-    new_args.insert(double_hyphen_pos, "-DIA2_ENABLE=0"s);
+    double_hyphen_pos = new_args.insert(double_hyphen_pos, "-DIA2_ENABLE=0"s);
     if (Target == Arch::Aarch64) {
-      new_args.insert(double_hyphen_pos, "--target=aarch64-linux-gnu"s);
+      double_hyphen_pos = new_args.insert(double_hyphen_pos, "--target=aarch64-linux-gnu"s);
     }
     // Insert extra args from command line
-    new_args.insert(double_hyphen_pos, ExtraArgs.begin(), ExtraArgs.end());
+    double_hyphen_pos = new_args.insert(double_hyphen_pos, ExtraArgs.begin(), ExtraArgs.end());
     return new_args;
   });
 

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -1285,12 +1285,12 @@ int main(int argc, const char **argv) {
                    new_args.end());
     // Insert prior to the "end of flags" double hyphen; if not present, append
     auto double_hyphen_pos = std::find(new_args.begin(), new_args.end(), "--");
-    double_hyphen_pos = new_args.insert(double_hyphen_pos, "-DIA2_ENABLE=0"s);
+    double_hyphen_pos = new_args.insert(double_hyphen_pos, "-DIA2_ENABLE=0"s) + 1;
     if (Target == Arch::Aarch64) {
-      double_hyphen_pos = new_args.insert(double_hyphen_pos, "--target=aarch64-linux-gnu"s);
+      double_hyphen_pos = new_args.insert(double_hyphen_pos, "--target=aarch64-linux-gnu"s) + 1;
     }
     // Insert extra args from command line
-    double_hyphen_pos = new_args.insert(double_hyphen_pos, ExtraArgs.begin(), ExtraArgs.end());
+    double_hyphen_pos = new_args.insert(double_hyphen_pos, ExtraArgs.begin(), ExtraArgs.end()) + ExtraArgs.size();
     return new_args;
   });
 


### PR DESCRIPTION
This was causing `ninja all` to segfault locally.