### PR TITLE
memory_maps: various improvements from #619, #585

### DIFF
--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -323,7 +323,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
   const int pkey = search_args->pkey;
 
 #if IA2_DEBUG_MEMORY
-  struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_current_thread();
+  struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_for_current_thread();
 #endif
 
   // Protect TLS segment.

--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -381,9 +381,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
           exit(-1);
         }
 #if IA2_DEBUG_MEMORY
-        if (thread_metadata) {
-          thread_metadata->tls_addr_compartment1_first = (uintptr_t)start_round_down;
-        }
+        thread_metadata->tls_addr_compartment1_first = (uintptr_t)start_round_down;
 #endif
       }
       uint64_t after_untrusted_region_start = untrusted_stackptr_addr + 0x1000;
@@ -398,9 +396,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
           exit(-1);
         }
 #if IA2_DEBUG_MEMORY
-        if (thread_metadata) {
-          thread_metadata->tls_addr_compartment1_second = (uintptr_t)after_untrusted_region_start;
-        }
+        thread_metadata->tls_addr_compartment1_second = (uintptr_t)after_untrusted_region_start;
 #endif
       }
     } else {
@@ -413,9 +409,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
         exit(-1);
       }
 #if IA2_DEBUG_MEMORY
-      if (thread_metadata) {
-        thread_metadata->tls_addrs[pkey] = (uintptr_t)start_round_down;
-      }
+      thread_metadata->tls_addrs[pkey] = (uintptr_t)start_round_down;
 #endif
     }
   }

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -84,9 +84,7 @@ char *allocate_stack(int i) {
   ia2_log("allocating stack for compartment %d on thread %ld: %p..%p\n", i, (long)gettid(), stack, stack + STACK_SIZE);
 #if IA2_DEBUG_MEMORY
   struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_for_current_thread();
-  if (thread_metadata) {
-    thread_metadata->stack_addrs[i] = (uintptr_t)stack;
-  }
+  thread_metadata->stack_addrs[i] = (uintptr_t)stack;
 #endif
   assert(stacks[i] == NULL); // We should only be setting this once per thread compartment right after thread creation.
   stacks[i] = stack;

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -83,7 +83,7 @@ char *allocate_stack(int i) {
 
   ia2_log("allocating stack for compartment %d on thread %ld: %p..%p\n", i, (long)gettid(), stack, stack + STACK_SIZE);
 #if IA2_DEBUG_MEMORY
-  struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_current_thread();
+  struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_for_current_thread();
   if (thread_metadata) {
     thread_metadata->stack_addrs[i] = (uintptr_t)stack;
   }

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -102,18 +102,18 @@ ret:
 }
 
 // All zeroed, so this should go in `.bss` and only have pages lazily allocated.
-static struct ia2_all_threads_metadata IA2_SHARED_DATA threads = {
+static struct ia2_all_threads_metadata IA2_SHARED_DATA all_threads_metadata = {
     .lock = PTHREAD_MUTEX_INITIALIZER,
     .num_threads = 0,
     .thread_metadata = {0},
 };
 
 struct ia2_thread_metadata *ia2_thread_metadata_get_current_thread(void) {
-  return ia2_all_threads_metadata_lookup(&threads);
+  return ia2_all_threads_metadata_lookup(&all_threads_metadata);
 }
 
 struct ia2_addr_location ia2_addr_location_find(const uintptr_t addr) {
-  return ia2_all_threads_metadata_find_addr(&threads, addr);
+  return ia2_all_threads_metadata_find_addr(&all_threads_metadata, addr);
 }
 
 extern uintptr_t (*partition_alloc_thread_isolated_pool_base_address)[IA2_MAX_COMPARTMENTS];

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -69,8 +69,16 @@ struct ia2_addr_location ia2_all_threads_metadata_find_addr(struct ia2_all_threa
   }
   for (size_t thread = 0; thread < this->num_threads; thread++) {
     const pid_t tid = this->tids[thread];
+    const struct ia2_thread_metadata *const thread_metadata = &this->thread_metadata[thread];
+
+    if (addr == thread_metadata->tls_addr_compartment1_first || addr == thread_metadata->tls_addr_compartment1_second) {
+      location.name = "tls";
+      location.thread_metadata = thread_metadata;
+      location.compartment = 1;
+      goto unlock;
+    }
+
     for (int compartment = 0; compartment < IA2_MAX_COMPARTMENTS; compartment++) {
-      const struct ia2_thread_metadata *const thread_metadata = &this->thread_metadata[thread];
       if (addr == thread_metadata->stack_addrs[compartment]) {
         location.name = "stack";
         location.thread_metadata = thread_metadata;
@@ -81,12 +89,6 @@ struct ia2_addr_location ia2_all_threads_metadata_find_addr(struct ia2_all_threa
         location.name = "tls";
         location.thread_metadata = thread_metadata;
         location.compartment = compartment;
-        goto unlock;
-      }
-      if (addr == thread_metadata->tls_addr_compartment1_first || addr == thread_metadata->tls_addr_compartment1_second) {
-        location.name = "tls";
-        location.thread_metadata = thread_metadata;
-        location.compartment = 1;
         goto unlock;
       }
     }

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -20,7 +20,7 @@ struct ia2_all_threads_metadata {
 
 #define array_len(a) (sizeof(a) / sizeof(*(a)))
 
-struct ia2_thread_metadata *ia2_all_threads_metadata_lookup(struct ia2_all_threads_metadata *const this) {
+struct ia2_thread_metadata *ia2_all_threads_metadata_get_for_current_thread(struct ia2_all_threads_metadata *const this) {
   const pid_t tid = gettid();
 
   struct ia2_thread_metadata *metadata = NULL;
@@ -108,8 +108,8 @@ static struct ia2_all_threads_metadata IA2_SHARED_DATA all_threads_metadata = {
     .thread_metadata = {0},
 };
 
-struct ia2_thread_metadata *ia2_thread_metadata_get_current_thread(void) {
-  return ia2_all_threads_metadata_lookup(&all_threads_metadata);
+struct ia2_thread_metadata *ia2_thread_metadata_get_for_current_thread(void) {
+  return ia2_all_threads_metadata_get_for_current_thread(&all_threads_metadata);
 }
 
 struct ia2_addr_location ia2_addr_location_find(const uintptr_t addr) {

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -23,20 +23,22 @@ struct ia2_all_threads_metadata {
 struct ia2_thread_metadata *ia2_all_threads_metadata_get_for_current_thread(struct ia2_all_threads_metadata *const this) {
   const pid_t tid = gettid();
 
-  struct ia2_thread_metadata *metadata = NULL;
   if (pthread_mutex_lock(&this->lock) != 0) {
     perror("pthread_mutex_lock in ia2_all_threads_data_lookup failed");
-    goto ret;
+    abort();
   }
+
+  if (this->num_threads >= array_len(this->thread_metadata)) {
+    fprintf(stderr, "created %zu threads, but can't store them all (max is MAX_THREADS)\n", this->num_threads);
+    abort();
+  }
+
+  struct ia2_thread_metadata *metadata = NULL;
   for (size_t i = 0; i < this->num_threads; i++) {
     if (this->tids[i] == tid) {
       metadata = &this->thread_metadata[i];
       goto unlock;
     }
-  }
-  if (this->num_threads >= array_len(this->thread_metadata)) {
-    fprintf(stderr, "created %zu threads, but can't store them all (max is MAX_THREADS)\n", this->num_threads);
-    goto unlock;
   }
 
   metadata = &this->thread_metadata[this->num_threads];
@@ -46,13 +48,12 @@ struct ia2_thread_metadata *ia2_all_threads_metadata_get_for_current_thread(stru
   metadata->tid = tid;
   metadata->thread = pthread_self();
 
-  goto unlock;
-
 unlock:
   if (pthread_mutex_unlock(&this->lock) != 0) {
     perror("pthread_mutex_unlock in ia2_all_threads_data_lookup failed");
+    abort();
   }
-ret:
+
   return metadata;
 }
 
@@ -122,6 +123,7 @@ static void label_memory_map(FILE *log, uintptr_t start_addr) {
   const struct ia2_addr_location location = ia2_addr_location_find(start_addr);
   const struct ia2_thread_metadata *metadata = location.thread_metadata;
 
+  // If `location.name` is non-`NULL`, then `location` was found.
   if (location.name) {
     Dl_info dl_info = {0};
     const bool has_dl_info = dladdr((void *)metadata->start_fn, &dl_info);

--- a/runtime/libia2/memory_maps.c
+++ b/runtime/libia2/memory_maps.c
@@ -20,7 +20,7 @@ struct ia2_all_threads_metadata {
 
 #define array_len(a) (sizeof(a) / sizeof(*(a)))
 
-struct ia2_thread_metadata *ia2_all_threads_metadata_get_for_current_thread(struct ia2_all_threads_metadata *const this) {
+static struct ia2_thread_metadata *ia2_all_threads_metadata_get_for_current_thread(struct ia2_all_threads_metadata *const this) {
   const pid_t tid = gettid();
 
   if (pthread_mutex_lock(&this->lock) != 0) {
@@ -57,7 +57,7 @@ unlock:
   return metadata;
 }
 
-struct ia2_addr_location ia2_all_threads_metadata_find_addr(struct ia2_all_threads_metadata *const this, const uintptr_t addr) {
+static struct ia2_addr_location ia2_all_threads_metadata_find_addr(struct ia2_all_threads_metadata *const this, const uintptr_t addr) {
   struct ia2_addr_location location = {
       .name = NULL,
       .thread_metadata = NULL,

--- a/runtime/libia2/memory_maps.h
+++ b/runtime/libia2/memory_maps.h
@@ -44,7 +44,7 @@ struct ia2_thread_metadata {
 /// so the lifetime of the returned `struct ia2_thread_metadata*` is infinite,
 /// and since it's thread-specific,
 /// it is thread-safe to read and write.
-struct ia2_thread_metadata *ia2_thread_metadata_get_current_thread(void);
+struct ia2_thread_metadata *ia2_thread_metadata_get_for_current_thread(void);
 
 struct ia2_addr_location {
   /// A descriptive name of what this address points to.

--- a/runtime/libia2/memory_maps.h
+++ b/runtime/libia2/memory_maps.h
@@ -39,7 +39,8 @@ struct ia2_thread_metadata {
 
 /// Find the `struct ia2_thread_metadata*` for the current thread,
 /// adding (but not allocating) one if there isn't one yet.
-/// If there is no memory for more or an error, `NULL` is returned.
+/// If there is no memory for more or some unexpected error,
+/// it `abort`s.  `NULL` is never returned.
 /// This is a purely lookup and/or additive operation,
 /// so the lifetime of the returned `struct ia2_thread_metadata*` is infinite,
 /// and since it's thread-specific,

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -32,9 +32,7 @@ void *ia2_thread_begin(void *arg) {
 
 #if IA2_DEBUG_MEMORY
   struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_for_current_thread();
-  if (thread_metadata) {
-    thread_metadata->start_fn = fn;
-  }
+  thread_metadata->start_fn = fn;
 #endif
 
   init_stacks_and_setup_tls();

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -31,7 +31,7 @@ void *ia2_thread_begin(void *arg) {
   munmap(arg, sizeof(struct ia2_thread_thunk));
 
 #if IA2_DEBUG_MEMORY
-  struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_current_thread();
+  struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_for_current_thread();
   if (thread_metadata) {
     thread_metadata->start_fn = fn;
   }


### PR DESCRIPTION
This cherry-picks the little improvements from #619 and #585 since we're not going to merge #619 and instead make `liblibia2.a` a `.so`.  This leaves out the larger lock-free change from #585 that I think was causing the multiple definitions error (though I'll see in CI).  I also made more functions `static` where possible so `libia` isn't exporting symbols it doesn't have to.