### PR TITLE
Mark shared allocation functions with visibility("default") in header

### DIFF
--- a/runtime/partition-alloc/include/ia2_allocator.h
+++ b/runtime/partition-alloc/include/ia2_allocator.h
@@ -1,10 +1,21 @@
 #pragma once
 #include <stddef.h>
 
+__attribute__((visibility("default"), noinline))
 void *shared_malloc(size_t bytes);
+
+__attribute__((visibility("default"), noinline))
 void shared_free(void *ptr);
+
+__attribute__((visibility("default"), noinline))
 void *shared_realloc(void *ptr, size_t size);
+
+__attribute__((visibility("default"), noinline))
 void *shared_calloc(size_t num, size_t size);
+
+__attribute__((visibility("default"), noinline))
 void *shared_memalign(size_t algin, size_t size);
+
+__attribute__((visibility("default"), noinline))
 int shared_posix_memalign(void **res, size_t align, size_t size);
 char* shared_strdup(const char* str);

--- a/runtime/partition-alloc/include/ia2_allocator.h
+++ b/runtime/partition-alloc/include/ia2_allocator.h
@@ -1,6 +1,10 @@
 #pragma once
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 __attribute__((visibility("default"), noinline))
 void *shared_malloc(size_t bytes);
 
@@ -18,4 +22,10 @@ void *shared_memalign(size_t algin, size_t size);
 
 __attribute__((visibility("default"), noinline))
 int shared_posix_memalign(void **res, size_t align, size_t size);
+
+__attribute__((visibility("default"), noinline))
 char* shared_strdup(const char* str);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif


### PR DESCRIPTION
In the Firefox demo I ran into the issue that the shared allocation functions were showing up as undefined hidden symbols, causing linker errors:

```
0:06.53 ld.lld: error: undefined hidden symbol: shared_strdup
```

I think this is fixed by adding the `visibility("default")` attribute in the headers (or at least that's how we solved similar symbol visibility issues that we ran into on ff). In `shared_allocator.cc`, where these functions are defined, we're using `SHIM_ALWAYS_EXPORT` to mark visibility, but we're not using that define when declaring these functions `ia2_allocator.h`. In theory we'd just want to add `SHIM_ALWAYS_EXPORT` to the header, however it comes from a header in partition-alloc that we probably don't want to expose as part of the public API of IA2 (e.g. because we don't want users to have to add the PA include path as part of their build process).

As a first-pass solution I've added `__attribute__((visibility("default"), noinline))` to all of the declarations, since that's what [`SHIM_ALWAY_EXPORT` will be](https://github.com/immunant/IA2-Phase2/blob/7dd567f7acfa31af314d434f6c462215ef84fba7/external/chromium/src/base/allocator/partition_allocator/shim/allocator_shim_internals.h#L44) on Linux. There's almost definitely a better way to achieve this, I just don't know what's appropriate in this case.

We also need `extern "C"` when this is used from C++, as it is in Firefox. I added the extern block with `__cplusplus` guards, lmk if there's some better way to do this.