### PR TITLE
Increase the size of the thread-isolated address pools

### DIFF
--- a/external/chromium/src/base/allocator/partition_allocator/partition_address_space.h
+++ b/external/chromium/src/base/allocator/partition_allocator/partition_address_space.h
@@ -309,7 +309,7 @@ class PA_COMPONENT_EXPORT(PARTITION_ALLOC) PartitionAddressSpace {
 #if BUILDFLAG(ENABLE_THREAD_ISOLATION)
   // IA2: Increase size of thread isolated pool since those are our main pools
   // when compartmentalized.
-  static constexpr size_t kThreadIsolatedPoolSize = kPoolMaxSize; // kGiB / 4; 
+  static constexpr size_t kThreadIsolatedPoolSize = kPoolMaxSize;
   static_assert(base::bits::IsPowerOfTwo(kThreadIsolatedPoolSize));
 #endif
   static constexpr size_t kConfigurablePoolMaxSize = kPoolMaxSize;

--- a/external/chromium/src/base/allocator/partition_allocator/partition_address_space.h
+++ b/external/chromium/src/base/allocator/partition_allocator/partition_address_space.h
@@ -307,7 +307,9 @@ class PA_COMPONENT_EXPORT(PARTITION_ALLOC) PartitionAddressSpace {
   static_assert(base::bits::IsPowerOfTwo(kRegularPoolSize));
   static_assert(base::bits::IsPowerOfTwo(kBRPPoolSize));
 #if BUILDFLAG(ENABLE_THREAD_ISOLATION)
-  static constexpr size_t kThreadIsolatedPoolSize = kGiB / 4;
+  // IA2: Increase size of thread isolated pool since those are our main pools
+  // when compartmentalized.
+  static constexpr size_t kThreadIsolatedPoolSize = kPoolMaxSize; // kGiB / 4; 
   static_assert(base::bits::IsPowerOfTwo(kThreadIsolatedPoolSize));
 #endif
   static constexpr size_t kConfigurablePoolMaxSize = kPoolMaxSize;

--- a/runtime/partition-alloc/README.md
+++ b/runtime/partition-alloc/README.md
@@ -4,7 +4,7 @@ This directory contains the partition allocator sources and a simplified shim fo
 symbols using [`ld --wrap`][wrap] based off of the [existing chromium shim][shim]. See the
 [Unified malloc shim layer doc][design-doc] for more info. To replace malloc & friends with partition
 allocator, first build `libpartition_alloc.so` with the CMake `partition-alloc` target. Then link
-your program against `libpartition_alloc.so` with the following linker flags.
+your program against `libpartition_alloc.so` with the following linker flags:
 
 ```
 -Wl,--wrap=calloc
@@ -24,6 +24,14 @@ your program against `libpartition_alloc.so` with the following linker flags.
 -Wl,--wrap=vasprintf
 ```
 
+## Partition Address Spaces
+
+This version of partition-alloc makes use of the thread-isolated address pools
+in order to isolate allocations for different compartments. See [the
+partition-alloc docs][glossary] for information about address pools and how they
+are used.
+
 [wrap]: https://chromium.googlesource.com/chromium/src/base/+/refs/heads/main/allocator/allocator_shim_override_libc_symbols.h
 [shim]: https://chromium.googlesource.com/chromium/src/base/+/refs/heads/main/allocator/allocator_shim_default_dispatch_to_partition_alloc.cc
 [design-doc]: https://docs.google.com/document/d/1yKlO1AO4XjpDad9rjcBOI15EKdAGsuGO_IeZy0g0kxo/edit
+[glossary]: https://chromium.googlesource.com/chromium/src/+/refs/heads/main/base/allocator/partition_allocator/glossary.md#pool


### PR DESCRIPTION
This was something I encountered when working on Firefox. With our changes to partition-alloc, all of our allocations go through their thread-isolated address pools, which only have 256 MB of address space, causing OOM issues when running Firefox. Since we only use the thread-isolated pools, I think giving them the max pool size is reasonable.