### PR TITLE
Use union PKRU for non-exit compartment destructor wrappers

### DIFF
--- a/tools/rewriter/GenCallAsm.cpp
+++ b/tools/rewriter/GenCallAsm.cpp
@@ -1053,7 +1053,8 @@ std::string emit_asm_wrapper(
     int caller_pkey,
     int target_pkey,
     Arch arch,
-    bool as_macro) {
+    bool as_macro,
+    std::optional<int> union_pkey) {
 
   // Small sanity check
   assert(caller_pkey != target_pkey);
@@ -1272,7 +1273,8 @@ std::string emit_asm_wrapper(
 
   emit_scrub_regs(aw, caller_pkey, args, kind == WrapperKind::IndirectCallsite, arch);
 
-  emit_set_pkru(aw, target_pkey, arch, std::nullopt);
+  // Use union PKRU if requested (for destructor wrappers in libc-compartment mode)
+  emit_set_pkru(aw, target_pkey, arch, union_pkey);
 
   emit_fn_call(target_name, kind, aw, arch);
 

--- a/tools/rewriter/GenCallAsm.h
+++ b/tools/rewriter/GenCallAsm.h
@@ -35,6 +35,10 @@ enum class Arch {
 // which must be valid to pass to the `PKRU` macro in ia2.h.
 // \p as_macro determines if the wrappers for direct calls is emitted as a
 // macro. Indirect calls are unconditionally emitted as macros.
+// \p union_pkey when set, causes the wrapper to use a union PKRU value that
+// allows access to both the target compartment and the union_pkey compartment.
+// This is used for destructor wrappers in libc-compartment mode so that
+// cleanup code can access both libc data (pkey 1) and compartment data.
 std::string emit_asm_wrapper(
     Context &ctx,
     FnSignature sig,
@@ -45,4 +49,5 @@ std::string emit_asm_wrapper(
     int caller_pkey,
     int target_pkey,
     Arch arch,
-    bool as_macro = false);
+    bool as_macro = false,
+    std::optional<int> union_pkey = std::nullopt);

--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -1825,10 +1825,13 @@ int main(int argc, const char **argv) {
         trivial << ");\n";
         wrapper_out << trivial.str();
       } else {
-        // Non-exit compartments need full call gates to switch from the libc compartment
+        // Non-exit compartments need full call gates to switch from the libc compartment.
+        // Use union PKRU to allow access to both libc (pkey 1) and compartment data
+        // so that __cxa_finalize can access libc internals during cleanup.
         std::string asm_wrapper =
             emit_asm_wrapper(ctx, fn_sig, std::nullopt, wrapper_name, fn_name, WrapperKind::Direct,
-                             kLibcCompartmentPkey, compartment_pkey, Target, false);
+                             kLibcCompartmentPkey, compartment_pkey, Target, false,
+                             kLibcCompartmentPkey);
         wrapper_out << asm_wrapper;
       }
     } else {


### PR DESCRIPTION
When IA2_LIBC_COMPARTMENT is enabled, destructor wrappers for compartments other than the exit compartment (pkey 1) now use a union PKRU value that allows access to both the target compartment's data and libc data.

This fixes a SIGSEGV during exit cleanup when __cxa_finalize (called from the destructor path) attempts to access libc internal data structures like __exit_funcs_lock. Without union PKRU, the destructor runs with only the target compartment's pkey enabled, blocking access to libc data (pkey 1).

The fix adds an optional union_pkey parameter to emit_asm_wrapper() which, when set, causes emit_set_pkru() to generate a PKRU value allowing access to both compartments. This is only used for destructor wrappers, not for regular cross-compartment calls, preserving strict isolation during normal execution.