### PR TITLE
Add --wrap=__cxa_finalize to rewriter-generated .ld files

### DIFF
--- a/tools/rewriter/SourceRewriter.cpp
+++ b/tools/rewriter/SourceRewriter.cpp
@@ -1843,6 +1843,17 @@ int main(int argc, const char **argv) {
                   "--wrap="s + fn_name + '\n', ".ld");
   }
 
+  // When libc compartmentalization is enabled, add --wrap=__cxa_finalize to all
+  // compartments' .ld files. The __wrap___cxa_finalize in libia2.a switches PKRU
+  // to allow pkey 1 access before calling the real __cxa_finalize, which is
+  // necessary because __cxa_finalize accesses libc's internal data structures
+  // (e.g., __exit_funcs_lock) that are tagged with pkey 1.
+  if (gLibcCompartmentEnabled) {
+    for (int pkey = 1; pkey < num_pkeys; pkey++) {
+      write_to_file(ld_args_out, pkey, "--wrap=__cxa_finalize\n", ".ld");
+    }
+  }
+
   std::cout << "Generating function pointer wrappers\n";
   std::string macros_defining_wrappers;
   /*


### PR DESCRIPTION
When libc compartmentalization is enabled, the rewriter now adds --wrap=__cxa_finalize to all compartments' .ld files. This ensures that calls to __cxa_finalize are redirected to __wrap___cxa_finalize in libia2.a, which properly switches PKRU to enable pkey 1 access.

This fixes exit-time crashes in compartmentalized applications where __cxa_finalize (called during destructor execution) needs to access libc's internal data structures (e.g., __exit_funcs_lock) that are tagged with pkey 1.

Previously, the --wrap=__cxa_finalize flag was only set via CMake's INTERFACE property on libia2, which doesn't propagate to meson-based projects like dav1d that use the rewriter-generated .ld files.