### PR TITLE
cmake: apply 60s test timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if (LIBIA2_AARCH64)
     # On aarch64, avoid swallowing QEMU MTE check failures
     set(CMAKE_CTEST_COMMAND ${CMAKE_CTEST_COMMAND} --verbose)
 endif()
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --timeout 60 --output-on-failure)
 set_target_properties(check PROPERTIES FOLDER ".")
 
 # runtime needs to be first so it defines libia2_BINARY_DIR


### PR DESCRIPTION
Hopefully this gives us test output in the case where a test hangs, which would be really useful for debugging as I can't seem to reproduce all hangs we see locally.

CI on this PR should also give an idea of whether we see hangs on `main` to compare against some in-flight branches that touch the tracer.