### PR TITLE
libia2: keep TCB TLS page shared across compartments

### DIFF
--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -390,6 +390,63 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
       exit(-1);
     }
 
+    // Look for the untrusted stack pointer, in case this lib defines it.
+    extern __thread void *ia2_stackptr_0;
+    uint64_t untrusted_stackptr_addr = (uint64_t)&ia2_stackptr_0;
+    if ((untrusted_stackptr_addr & 0xFFF) != 0) {
+      printf("address of ia2_stackptr_0 (%p) is not page-aligned\n",
+             (void *)untrusted_stackptr_addr);
+      exit(-1);
+    }
+#if defined(__aarch64__)
+    // Preserve the pre-existing AArch64 behavior exactly. The TCB carve-out
+    // changes are x86_64-specific and should not alter ARM TLS tagging.
+    if (untrusted_stackptr_addr >= start && untrusted_stackptr_addr < end) {
+      // The TLS region should only be split for compartment 1.
+      assert(pkey == 1);
+
+      // Protect TLS region start to the beginning of the untrusted region.
+      if (untrusted_stackptr_addr > start_round_down) {
+        int mprotect_err = ia2_mprotect_with_tag(
+            (void *)start_round_down, untrusted_stackptr_addr - start_round_down,
+            PROT_READ | PROT_WRITE, pkey);
+        if (mprotect_err != 0) {
+          printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
+          exit(-1);
+        }
+#if IA2_DEBUG_MEMORY
+        thread_metadata->tls_addr_compartment1_first = (uintptr_t)start_round_down;
+#endif
+      }
+      uint64_t after_untrusted_region_start = untrusted_stackptr_addr + PAGE_SIZE;
+      uint64_t after_untrusted_region_len = end - after_untrusted_region_start;
+      if (after_untrusted_region_len > 0) {
+        int mprotect_err = ia2_mprotect_with_tag(
+            (void *)after_untrusted_region_start,
+            after_untrusted_region_len,
+            PROT_READ | PROT_WRITE, pkey);
+        if (mprotect_err != 0) {
+          printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
+          exit(-1);
+        }
+#if IA2_DEBUG_MEMORY
+        thread_metadata->tls_addr_compartment1_second = (uintptr_t)after_untrusted_region_start;
+#endif
+      }
+    } else {
+      int mprotect_err =
+          ia2_mprotect_with_tag(
+              (void *)start_round_down, len_round_up,
+              PROT_READ | PROT_WRITE, pkey);
+      if (mprotect_err != 0) {
+        printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
+        exit(-1);
+      }
+#if IA2_DEBUG_MEMORY
+      thread_metadata->tls_addrs[pkey] = (uintptr_t)start_round_down;
+#endif
+    }
+#else
     // Default policy is "tag PT_TLS with compartment pkey".
     // We carve out ABI-sensitive TLS pages that must stay shared (pkey 0),
     // then protect the remaining ranges with the compartment pkey.
@@ -404,16 +461,8 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
     uint64_t shared_tls_pages[MAX_SHARED_TLS_PAGES] = {0};
     size_t shared_tls_page_count = 0;
     bool has_untrusted_shared_page = false;
-
-    // Look for the untrusted stack pointer, in case this lib defines it.
-    extern __thread void *ia2_stackptr_0;
-    uint64_t untrusted_stackptr_addr = (uint64_t)&ia2_stackptr_0;
-    if ((untrusted_stackptr_addr & 0xFFF) != 0) {
-      printf("address of ia2_stackptr_0 (%p) is not page-aligned\n",
-             (void *)untrusted_stackptr_addr);
-      exit(-1);
-    }
     uint64_t untrusted_stackptr_page = untrusted_stackptr_addr;
+
     // Only carve out the callgate stack pointer page when the symbol is inside
     // this module's true TLS range (not merely within the rounded-down page).
     if (untrusted_stackptr_addr >= start && untrusted_stackptr_addr < end) {
@@ -423,7 +472,6 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
       has_untrusted_shared_page = true;
     }
 
-#if defined(__x86_64__)
     uint64_t tcb_page =
         IA2_ROUND_DOWN((uint64_t)__builtin_thread_pointer(), PAGE_SIZE);
     if (tcb_page >= start_round_down && tcb_page < end &&
@@ -434,7 +482,6 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
       }
       shared_tls_pages[shared_tls_page_count++] = tcb_page;
     }
-#endif
 
     // Iterate carve-outs in ascending order so "cursor..shared_page" ranges
     // remain valid and non-overlapping.
@@ -498,6 +545,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
       }
 #endif
     }
+#endif
   }
 
   return 0;

--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -97,6 +97,31 @@ size_t ia2_get_compartment(void) {
   }
 }
 
+/*
+ * Keep the thread-pointer/TCB page shared on x86_64.
+ *
+ * Why this exists:
+ * - IA2 retags PT_TLS pages per compartment.
+ * - The TCB page (at __builtin_thread_pointer()) is process ABI state, not
+ *   compartment-private state.
+ * - Compiler-generated stack-protector checks load the canary via %fs:0x28 and
+ *   those loads can occur while PKRU is set for another compartment during
+ *   callgate transitions.
+ *
+ * If we leave this page compartment-tagged, code can fault in normal function
+ * prologue/epilogue paths before the intended callgate logic runs.
+ */
+void ia2_unprotect_thread_pointer_page(void) {
+  uintptr_t tcb_page =
+      IA2_ROUND_DOWN((uintptr_t)__builtin_thread_pointer(), PAGE_SIZE);
+  int err = ia2_mprotect_with_tag(
+      (void *)tcb_page, PAGE_SIZE, PROT_READ | PROT_WRITE, 0);
+  if (err != 0) {
+    printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
+    exit(-1);
+  }
+}
+
 #elif defined(__aarch64__)
 
 static size_t ia2_get_x18(void) {
@@ -110,6 +135,10 @@ size_t ia2_get_tag(void) __attribute__((alias("ia2_get_x18")));
 size_t ia2_get_compartment(void) {
   return ia2_get_tag();
 }
+
+// x18-tagged aarch64 builds do not currently use the x86_64 TCB/%fs ABI path.
+// Keep this symbol for cross-arch call-site symmetry.
+void ia2_unprotect_thread_pointer_page(void) {}
 
 // TODO: insert_tag could probably be cleaned up a bit, but I'm not sure if the
 // generated code could be simplified since addg encodes the tag as an imm field
@@ -333,6 +362,8 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
   struct ia2_thread_metadata *const thread_metadata = ia2_thread_metadata_get_for_current_thread();
 #endif
 
+  enum { MAX_SHARED_TLS_PAGES = 2 };
+
   // Protect TLS segment.
   for (size_t i = 0; i < info->dlpi_phnum; i++) {
     Elf64_Phdr phdr = info->dlpi_phdr[i];
@@ -341,8 +372,6 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
     }
 
     uint64_t start = (uint64_t)info->dlpi_tls_data;
-    size_t len = phdr.p_memsz;
-
     uint64_t start_round_down = start & ~0xFFFUL;
     uint64_t start_moved_by = start & 0xFFFUL;
     // p_memsz is 0x1000 more than the size of what we actually need to protect.
@@ -361,6 +390,20 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
       exit(-1);
     }
 
+    // Default policy is "tag PT_TLS with compartment pkey".
+    // We carve out ABI-sensitive TLS pages that must stay shared (pkey 0),
+    // then protect the remaining ranges with the compartment pkey.
+    //
+    // Shared carve-outs:
+    // 1) ia2_stackptr_0 page:
+    //    callgates switch stacks through this TLS slot and it has historically
+    //    been shared.
+    // 2) x86_64 thread-pointer/TCB page:
+    //    `%fs`-relative ABI state (including stack canary reads) may be touched
+    //    while code is running under different compartment PKRU values.
+    uint64_t shared_tls_pages[MAX_SHARED_TLS_PAGES] = {0};
+    size_t shared_tls_page_count = 0;
+
     // Look for the untrusted stack pointer, in case this lib defines it.
     extern __thread void *ia2_stackptr_0;
     uint64_t untrusted_stackptr_addr = (uint64_t)&ia2_stackptr_0;
@@ -369,54 +412,84 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
              (void *)untrusted_stackptr_addr);
       exit(-1);
     }
+    uint64_t untrusted_stackptr_page = untrusted_stackptr_addr;
+    if (untrusted_stackptr_page >= start_round_down && untrusted_stackptr_page < end) {
+      shared_tls_pages[shared_tls_page_count++] = untrusted_stackptr_page;
+    }
 
-    // Protect the TLS region except the page of the untrusted stack pointer.
-    // The untrusted stack pointer is page-aligned, so it starts its page, and
-    // it is followed by padding that ensures nothing else occupies the rest of
-    // its page.
-    if (untrusted_stackptr_addr >= start && untrusted_stackptr_addr < end) {
-      // The TLS region should only be split for compartment 1.
-      assert(pkey == 1);
+#if defined(__x86_64__)
+    uint64_t tcb_page =
+        IA2_ROUND_DOWN((uint64_t)__builtin_thread_pointer(), PAGE_SIZE);
+    if (tcb_page >= start_round_down && tcb_page < end &&
+        tcb_page != untrusted_stackptr_page) {
+      if (shared_tls_page_count >= MAX_SHARED_TLS_PAGES) {
+        printf("internal error: too many shared TLS pages\n");
+        exit(-1);
+      }
+      shared_tls_pages[shared_tls_page_count++] = tcb_page;
+    }
+#endif
 
-      // Protect TLS region start to the beginning of the untrusted region.
-      if (untrusted_stackptr_addr > start_round_down) {
+    // Iterate carve-outs in ascending order so "cursor..shared_page" ranges
+    // remain valid and non-overlapping.
+    if (shared_tls_page_count == 2 && shared_tls_pages[0] > shared_tls_pages[1]) {
+      uint64_t tmp = shared_tls_pages[0];
+      shared_tls_pages[0] = shared_tls_pages[1];
+      shared_tls_pages[1] = tmp;
+    }
+
+#if IA2_DEBUG_MEMORY
+    // Keep best-effort TLS start metadata for diagnostics.
+    thread_metadata->tls_addrs[pkey] = (uintptr_t)start_round_down;
+    if (pkey == 1) {
+      thread_metadata->tls_addr_compartment1_first = 0;
+      thread_metadata->tls_addr_compartment1_second = 0;
+    }
+#endif
+
+    uint64_t cursor = start_round_down;
+    for (size_t shared_i = 0; shared_i < shared_tls_page_count; shared_i++) {
+      const uint64_t shared_page = shared_tls_pages[shared_i];
+      if (shared_page > cursor) {
         int mprotect_err = ia2_mprotect_with_tag(
-            (void *)start_round_down, untrusted_stackptr_addr - start_round_down,
-            PROT_READ | PROT_WRITE, pkey);
+            (void *)cursor, shared_page - cursor, PROT_READ | PROT_WRITE, pkey);
         if (mprotect_err != 0) {
           printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
           exit(-1);
         }
 #if IA2_DEBUG_MEMORY
-        thread_metadata->tls_addr_compartment1_first = (uintptr_t)start_round_down;
-#endif
-      }
-      uint64_t after_untrusted_region_start = untrusted_stackptr_addr + 0x1000;
-      uint64_t after_untrusted_region_len = end - after_untrusted_region_start;
-      if (after_untrusted_region_len > 0) {
-        int mprotect_err = ia2_mprotect_with_tag(
-            (void *)after_untrusted_region_start,
-            after_untrusted_region_len,
-            PROT_READ | PROT_WRITE, pkey);
-        if (mprotect_err != 0) {
-          printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
-          exit(-1);
+        if (pkey == 1 && thread_metadata->tls_addr_compartment1_first == 0) {
+          thread_metadata->tls_addr_compartment1_first = (uintptr_t)cursor;
+        } else if (pkey == 1 && thread_metadata->tls_addr_compartment1_second == 0) {
+          thread_metadata->tls_addr_compartment1_second = (uintptr_t)cursor;
         }
-#if IA2_DEBUG_MEMORY
-        thread_metadata->tls_addr_compartment1_second = (uintptr_t)after_untrusted_region_start;
 #endif
       }
-    } else {
-      int mprotect_err =
-          ia2_mprotect_with_tag(
-              (void *)start_round_down, len_round_up,
-              PROT_READ | PROT_WRITE, pkey);
+
+      // Explicitly restore shared TLS ABI pages to pkey 0.
+      int shared_mprotect_err = ia2_mprotect_with_tag(
+          (void *)shared_page, PAGE_SIZE, PROT_READ | PROT_WRITE, 0);
+      if (shared_mprotect_err != 0) {
+        printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
+        exit(-1);
+      }
+
+      cursor = shared_page + PAGE_SIZE;
+    }
+
+    if (cursor < end) {
+      int mprotect_err = ia2_mprotect_with_tag(
+          (void *)cursor, end - cursor, PROT_READ | PROT_WRITE, pkey);
       if (mprotect_err != 0) {
         printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
         exit(-1);
       }
 #if IA2_DEBUG_MEMORY
-      thread_metadata->tls_addrs[pkey] = (uintptr_t)start_round_down;
+      if (pkey == 1 && thread_metadata->tls_addr_compartment1_first == 0) {
+        thread_metadata->tls_addr_compartment1_first = (uintptr_t)cursor;
+      } else if (pkey == 1 && thread_metadata->tls_addr_compartment1_second == 0) {
+        thread_metadata->tls_addr_compartment1_second = (uintptr_t)cursor;
+      }
 #endif
     }
   }

--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -501,6 +501,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
 #endif
 
     uint64_t cursor = start_round_down;
+    const bool can_retag_shared_tls_pages = (ia2_get_compartment() == 0);
     for (size_t shared_i = 0; shared_i < shared_tls_page_count; shared_i++) {
       const uint64_t shared_page = shared_tls_pages[shared_i];
       if (shared_page > cursor) {
@@ -519,12 +520,17 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
 #endif
       }
 
-      // Explicitly restore shared TLS ABI pages to pkey 0.
-      int shared_mprotect_err = ia2_mprotect_with_tag(
-          (void *)shared_page, PAGE_SIZE, PROT_READ | PROT_WRITE, 0);
-      if (shared_mprotect_err != 0) {
-        printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
-        exit(-1);
+      // Explicitly restore shared TLS ABI pages to pkey 0 during process init.
+      // For per-thread TLS setup after init, these pages are already mapped with
+      // pkey 0 by default, and redundantly re-tagging them from compartment 1
+      // violates tracer monotonicity policy.
+      if (can_retag_shared_tls_pages) {
+        int shared_mprotect_err = ia2_mprotect_with_tag(
+            (void *)shared_page, PAGE_SIZE, PROT_READ | PROT_WRITE, 0);
+        if (shared_mprotect_err != 0) {
+          printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
+          exit(-1);
+        }
       }
 
       cursor = shared_page + PAGE_SIZE;

--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -403,6 +403,7 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
     //    while code is running under different compartment PKRU values.
     uint64_t shared_tls_pages[MAX_SHARED_TLS_PAGES] = {0};
     size_t shared_tls_page_count = 0;
+    bool has_untrusted_shared_page = false;
 
     // Look for the untrusted stack pointer, in case this lib defines it.
     extern __thread void *ia2_stackptr_0;
@@ -413,15 +414,20 @@ int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data) {
       exit(-1);
     }
     uint64_t untrusted_stackptr_page = untrusted_stackptr_addr;
-    if (untrusted_stackptr_page >= start_round_down && untrusted_stackptr_page < end) {
+    // Only carve out the callgate stack pointer page when the symbol is inside
+    // this module's true TLS range (not merely within the rounded-down page).
+    if (untrusted_stackptr_addr >= start && untrusted_stackptr_addr < end) {
+      // The TLS region should only be split for compartment 1.
+      assert(pkey == 1);
       shared_tls_pages[shared_tls_page_count++] = untrusted_stackptr_page;
+      has_untrusted_shared_page = true;
     }
 
 #if defined(__x86_64__)
     uint64_t tcb_page =
         IA2_ROUND_DOWN((uint64_t)__builtin_thread_pointer(), PAGE_SIZE);
     if (tcb_page >= start_round_down && tcb_page < end &&
-        tcb_page != untrusted_stackptr_page) {
+        (!has_untrusted_shared_page || tcb_page != untrusted_stackptr_page)) {
       if (shared_tls_page_count >= MAX_SHARED_TLS_PAGES) {
         printf("internal error: too many shared TLS pages\n");
         exit(-1);

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -145,6 +145,14 @@ struct dl_phdr_info;
 /// information in the search arguments.
 IA2_EXTERN_C int protect_pages(struct dl_phdr_info *info, size_t size, void *data);
 IA2_EXTERN_C int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data);
+/// Retag the architecture thread-pointer page as shared (pkey 0).
+///
+/// On x86_64 this is the TCB page addressed through `%fs`. The page contains
+/// ABI state (for example stack canary data used by compiler-generated
+/// stack-protector checks) that may be touched while control crosses
+/// compartments. Keeping it shared prevents compartment-private TLS tagging
+/// from breaking those reads/writes.
+IA2_EXTERN_C void ia2_unprotect_thread_pointer_page(void);
 
 struct IA2SharedSection {
   const void *start;

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -320,5 +320,10 @@ void ia2_start(void) {
       exit(rc);
     }
   }
+  // Run after compartment setup so any TLS retagging done during
+  // ia2_setup_compartment/protect_tls_pages cannot leave the TCB page private.
+  // The x86_64 stack protector ABI reads the canary via %fs:0x28 and must stay
+  // valid regardless of the currently active compartment PKRU.
+  ia2_unprotect_thread_pointer_page();
   mark_init_finished();
 }

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -7,6 +7,7 @@
 
 __attribute__((visibility("default"))) void init_stacks_and_setup_tls(void);
 __attribute__((visibility("default"))) void **ia2_stackptr_for_tag(size_t tag);
+__attribute__((visibility("default"))) void ia2_unprotect_thread_pointer_page(void);
 
 struct ia2_thread_thunk {
   void *(*fn)(void *);
@@ -36,6 +37,9 @@ void *ia2_thread_begin(void *arg) {
 #endif
 
   init_stacks_and_setup_tls();
+  // New threads get their own TLS/TCB mapping; re-apply the shared TCB policy
+  // after per-thread TLS setup for the same reasons as ia2_start().
+  ia2_unprotect_thread_pointer_page();
   /* TODO: Set up alternate stack when we have per-thread shared compartment
    * data. */
   /*  sigaltstack(&alt_stack, NULL); */

--- a/runtime/libia2/threads.c
+++ b/runtime/libia2/threads.c
@@ -7,7 +7,6 @@
 
 __attribute__((visibility("default"))) void init_stacks_and_setup_tls(void);
 __attribute__((visibility("default"))) void **ia2_stackptr_for_tag(size_t tag);
-__attribute__((visibility("default"))) void ia2_unprotect_thread_pointer_page(void);
 
 struct ia2_thread_thunk {
   void *(*fn)(void *);
@@ -37,9 +36,10 @@ void *ia2_thread_begin(void *arg) {
 #endif
 
   init_stacks_and_setup_tls();
-  // New threads get their own TLS/TCB mapping; re-apply the shared TCB policy
-  // after per-thread TLS setup for the same reasons as ia2_start().
-  ia2_unprotect_thread_pointer_page();
+  // init_stacks_and_setup_tls() already runs protect_tls_pages() for this
+  // thread, including the x86_64 TCB carve-out to shared pkey 0. Avoid a
+  // redundant pkey_mprotect() here; the tracer treats post-init repeated
+  // pkey_mprotect on the same page as a policy violation.
   /* TODO: Set up alternate stack when we have per-thread shared compartment
    * data. */
   /*  sigaltstack(&alt_stack, NULL); */


### PR DESCRIPTION
### Problem

IA2 retags writable memory, including `PT_TLS`, to per-compartment pkeys. On x86_64, that model is too strict for TLS pages that hold process ABI state rather than compartment-private state.

In particular, the thread-pointer/TCB page (`__builtin_thread_pointer()`, `%fs` ABI state) can be accessed in normal execution and transition paths where current PKRU does not yet match the compartment that originally tagged the page. When that page is left compartment-tagged, this can fault in real workloads (including decode-path crashes where stack-protector canary reads use `%fs`).

### Fix

`protect_tls_pages()` now uses an x86_64 split policy:

- Default: tag module `PT_TLS` ranges with the target compartment pkey
- Shared carve-out 1: `ia2_stackptr_0` page (existing call-gate stack slot behavior)
- Shared carve-out 2: thread-pointer/TCB page (page containing `%fs` ABI state)

Implementation details:

- Maintain a bounded carve-out set (`MAX_SHARED_TLS_PAGES = 2`) and only add carve-outs that overlap the current module TLS range
- Sort carve-out pages and protect non-shared regions using a cursor walk to avoid overlap and ordering errors
- Restore shared carve-out pages to `pkey 0` during process-init path (`ia2_get_compartment() == 0`)
- Skip redundant post-init per-thread re-tagging to `pkey 0`; those pages are already shared and repeated retagging from compartment 1 can violate tracer policy
- Keep the explicit startup hardening in `ia2_start()` that re-applies TCB sharing after compartment setup
- Preserve pre-existing AArch64 behavior; TCB carve-out logic is x86_64-specific

### Similar Patterns in IA2

- Special-case shared TLS behavior already existed for `ia2_stackptr_0` in `protect_tls_pages()` (see `runtime/libia2/ia2.c`, `protect_tls_pages`, around lines 466-473)
- `protect_pages()` already uses a "protect-by-default with explicit shared carve-outs" model for writable ranges (see `runtime/libia2/ia2.c`, `protect_pages`, shared-range collection around lines 603-632, and overlap trimming before `ia2_mprotect_with_tag` around lines 685-723)
- RELRO and explicit shared sections are already handled as policy exceptions to default tagging (see `runtime/libia2/ia2.c`, explicit `shared_sections` handling around lines 605-632 and `PT_GNU_RELRO` handling around lines 634-645)