### PR TITLE
Revert "tracer: allow non-fixed mmap hints; add deterministic regression test

### DIFF
--- a/runtime/tracer/track_memory_map.c
+++ b/runtime/tracer/track_memory_map.c
@@ -43,10 +43,8 @@ static bool is_op_permitted(struct memory_map *map, int event,
                             union event_info *info) {
   switch (event) {
   case EVENT_MMAP:
-    /* Non-MAP_FIXED mmap addresses are just hints; the kernel can place the
-     * mapping elsewhere. So we must not reject them based on overlap at the
-     * hinted address (which can be spuriously in another compartment). */
-    if (!(info->mmap.flags & MAP_FIXED)) {
+    // non-FIXED maps of NULL don't need to check for overlap
+    if (info->mmap.range.start == 0 && !(info->mmap.flags & MAP_FIXED)) {
       return true;
     }
     if (memory_map_all_overlapping_regions_have_pkey(map, info->mmap.range,

--- a/tests/three_keys_minimal/include/lib_2/lib_2.h
+++ b/tests/three_keys_minimal/include/lib_2/lib_2.h
@@ -3,15 +3,3 @@
 #include "lib.h"
 
 DECLARE_LIB(2, 1);
-
-/**
- * Issue a non-MAP_FIXED anonymous mmap using an address hint from another
- * compartment.
- *
- * This is used by the regression test for tracer mmap policy. The kernel may
- * ignore a non-fixed hint and place the mapping elsewhere, so this operation
- * should be allowed by policy.
- *
- * @return 0 on success, or -errno on failure.
- */
-int lib_2_mmap_nonfixed_hint(void *hint);

--- a/tests/three_keys_minimal/lib_2.c
+++ b/tests/three_keys_minimal/lib_2.c
@@ -1,10 +1,5 @@
 #include <ia2.h>
 #include <ia2_test_runner.h>
-#include <errno.h>
-#include <stdint.h>
-#include <sys/mman.h>
-#include <sys/types.h>
-#include <unistd.h>
 
 #define IA2_COMPARTMENT 2
 #include <ia2_compartment_init.inc>
@@ -16,26 +11,3 @@
 #include <threads.h>
 
 DEFINE_LIB(2, 1);
-
-/*
- * Regression helper for tracer mmap policy:
- * request a non-fixed mapping with a foreign-compartment hint, then clean it
- * up immediately.
- */
-int lib_2_mmap_nonfixed_hint(void *hint) {
-  long page_size_l = sysconf(_SC_PAGESIZE);
-  if (page_size_l <= 0) {
-    return -EINVAL;
-  }
-  size_t page_size = (size_t)page_size_l;
-  uintptr_t aligned_hint = (uintptr_t)hint & ~(page_size - 1);
-  void *mapped = mmap((void *)aligned_hint, page_size, PROT_NONE,
-                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-  if (mapped == MAP_FAILED) {
-    return -errno;
-  }
-  if (munmap(mapped, page_size) != 0) {
-    return -errno;
-  }
-  return 0;
-}

--- a/tests/three_keys_minimal/main.c
+++ b/tests/three_keys_minimal/main.c
@@ -85,17 +85,6 @@ Test(three_keys_minimal, direct_calls) {
   lib_2_call_loop();
 }
 
-/* Regression test for tracer mmap policy:
- * lib_2 requests a non-MAP_FIXED anonymous mmap with a hint inside main's
- * private mapping. Pre-fix this was denied as EPERM due overlap at the hint
- * address, even though non-fixed hints are advisory. */
-Test(three_keys_minimal, nonfixed_mmap_hint_foreign_compartment) {
-  int *main_static = main_get_static();
-  cr_assert(main_static);
-  int rc = lib_2_mmap_nonfixed_hint(main_static);
-  cr_assert_eq(rc, 0);
-}
-
 // variant of CHECK_VIOLATION macro that works with void-valued expressions
 #define CHECK_VIOLATION_VOID(expr) \
   {                                \


### PR DESCRIPTION
This reverts commit a98fecc909c1cd96411ee5c3e66dfbf75a7e12f0.