### PR TITLE
tracer: allow non-fixed mmap hints; add deterministic regression test

### DIFF
--- a/runtime/tracer/track_memory_map.c
+++ b/runtime/tracer/track_memory_map.c
@@ -43,8 +43,10 @@ static bool is_op_permitted(struct memory_map *map, int event,
                             union event_info *info) {
   switch (event) {
   case EVENT_MMAP:
-    // non-FIXED maps of NULL don't need to check for overlap
-    if (info->mmap.range.start == 0 && !(info->mmap.flags & MAP_FIXED)) {
+    /* Non-MAP_FIXED mmap addresses are just hints; the kernel can place the
+     * mapping elsewhere. So we must not reject them based on overlap at the
+     * hinted address (which can be spuriously in another compartment). */
+    if (!(info->mmap.flags & MAP_FIXED)) {
       return true;
     }
     if (memory_map_all_overlapping_regions_have_pkey(map, info->mmap.range,

--- a/runtime/tracer/track_memory_map.c
+++ b/runtime/tracer/track_memory_map.c
@@ -43,9 +43,9 @@ static bool is_op_permitted(struct memory_map *map, int event,
                             union event_info *info) {
   switch (event) {
   case EVENT_MMAP:
-    /* Non-MAP_FIXED mmap addresses are just hints; the kernel can place the
-     * mapping elsewhere. So we must not reject them based on overlap at the
-     * hinted address (which can be spuriously in another compartment). */
+    /* A non-MAP_FIXED mmap hint must not replace an existing mapping. Since
+     * the hinted address is not binding, we must not reject it based on
+     * overlap at that hinted location (which may be in another compartment). */
     if (!(info->mmap.flags & MAP_FIXED)) {
       return true;
     }

--- a/tests/three_keys_minimal/include/lib_2/lib_2.h
+++ b/tests/three_keys_minimal/include/lib_2/lib_2.h
@@ -3,3 +3,15 @@
 #include "lib.h"
 
 DECLARE_LIB(2, 1);
+
+/**
+ * Issue a non-MAP_FIXED anonymous mmap using an address hint from another
+ * compartment.
+ *
+ * This is used by the regression test for tracer mmap policy. The kernel may
+ * ignore a non-fixed hint and place the mapping elsewhere, so this operation
+ * should be allowed by policy.
+ *
+ * @return 0 on success, or -errno on failure.
+ */
+int lib_2_mmap_nonfixed_hint(void *hint);

--- a/tests/three_keys_minimal/include/lib_2/lib_2.h
+++ b/tests/three_keys_minimal/include/lib_2/lib_2.h
@@ -8,9 +8,9 @@ DECLARE_LIB(2, 1);
  * Issue a non-MAP_FIXED anonymous mmap using an address hint from another
  * compartment.
  *
- * This is used by the regression test for tracer mmap policy. The kernel may
- * ignore a non-fixed hint and place the mapping elsewhere, so this operation
- * should be allowed by policy.
+ * This is used by the regression test for tracer mmap policy. With MAP_FIXED
+ * unset, mmap must not replace any existing mapping, so this operation should
+ * be allowed by policy even if the hint lands in another compartment.
  *
  * @return 0 on success, or -errno on failure.
  */

--- a/tests/three_keys_minimal/lib_2.c
+++ b/tests/three_keys_minimal/lib_2.c
@@ -1,5 +1,10 @@
 #include <ia2.h>
 #include <ia2_test_runner.h>
+#include <errno.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #define IA2_COMPARTMENT 2
 #include <ia2_compartment_init.inc>
@@ -11,3 +16,26 @@
 #include <threads.h>
 
 DEFINE_LIB(2, 1);
+
+/*
+ * Regression helper for tracer mmap policy:
+ * request a non-fixed mapping with a foreign-compartment hint, then clean it
+ * up immediately.
+ */
+int lib_2_mmap_nonfixed_hint(void *hint) {
+  long page_size_l = sysconf(_SC_PAGESIZE);
+  if (page_size_l <= 0) {
+    return -EINVAL;
+  }
+  size_t page_size = (size_t)page_size_l;
+  uintptr_t aligned_hint = (uintptr_t)hint & ~(page_size - 1);
+  void *mapped = mmap((void *)aligned_hint, page_size, PROT_NONE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (mapped == MAP_FAILED) {
+    return -errno;
+  }
+  if (munmap(mapped, page_size) != 0) {
+    return -errno;
+  }
+  return 0;
+}

--- a/tests/three_keys_minimal/main.c
+++ b/tests/three_keys_minimal/main.c
@@ -85,6 +85,17 @@ Test(three_keys_minimal, direct_calls) {
   lib_2_call_loop();
 }
 
+/* Regression test for tracer mmap policy:
+ * lib_2 requests a non-MAP_FIXED anonymous mmap with a hint inside main's
+ * private mapping. Pre-fix this was denied as EPERM due overlap at the hint
+ * address, even though non-fixed hints are advisory. */
+Test(three_keys_minimal, nonfixed_mmap_hint_foreign_compartment) {
+  int *main_static = main_get_static();
+  cr_assert(main_static);
+  int rc = lib_2_mmap_nonfixed_hint(main_static);
+  cr_assert_eq(rc, 0);
+}
+
 // variant of CHECK_VIOLATION macro that works with void-valued expressions
 #define CHECK_VIOLATION_VOID(expr) \
   {                                \


### PR DESCRIPTION
## Summary

This PR fixes a flaky failure in `three_keys_minimal` #667 by correcting tracer mmap policy for non-`MAP_FIXED` mappings and adds a deterministic regression test that fails before the fix and passes after it

## Problem

`three_keys_minimal` intermittently failed in CI with tracer output like:

- `forbidden operation requested: compartment 2/3 mmap (..., prot=0, flags=22, fd=-1)`
- `region pkey: 1`
- followed by partition-alloc fatal behavior (for example `Check failed: false`) and test failure

Observed failing pattern:

- `flags=22` is `0x22` (`MAP_PRIVATE | MAP_ANONYMOUS`) and does **not** include `MAP_FIXED`
- The requested address is therefore a hint, not a strict placement requirement

## Root Cause

In `runtime/tracer/track_memory_map.c`, `EVENT_MMAP` policy only auto-allowed non-fixed mmaps when `addr == 0`:

- Non-`MAP_FIXED` + `addr==0`: allowed
- Non-`MAP_FIXED` + `addr!=0`: overlap-checked as if the hinted address were authoritative

That is incorrect for non-fixed mappings. The kernel may ignore a non-fixed hint and place the mapping elsewhere. Treating the hint as mandatory caused false denials whenever the hint overlapped memory owned by another compartment.

## Fix

In `is_op_permitted(EVENT_MMAP)`, allow all non-`MAP_FIXED` mmaps unconditionally:

- Old behavior: allow only if `start == 0` and not `MAP_FIXED`
- New behavior: allow whenever not `MAP_FIXED`

Why this remains safe in tracer implementation:

- For `mmap`, the tracer uses the returned address from syscall exit, not the entry-time hint: it runs to syscall exit (`runtime/tracer/track_memory_map.c:1175`), reads registers (`runtime/tracer/track_memory_map.c:1227`), and sets `info->range.start = reg_retval` for `EVENT_MMAP` (`runtime/tracer/track_memory_map.c:447`, `runtime/tracer/track_memory_map.c:451`)
- The tracked memory map is then updated using that returned address
- If map update cannot be represented consistently, tracer fails closed with an error

## Deterministic Regression Test

Added a deterministic regression test in `three_keys_minimal`:

- New helper in compartment 2:
  - `lib_2_mmap_nonfixed_hint(void *hint)` in `tests/three_keys_minimal/lib_2.c`
  - Declaration in `tests/three_keys_minimal/include/lib_2/lib_2.h`
- New test:
  - `nonfixed_mmap_hint_foreign_compartment` in `tests/three_keys_minimal/main.c`
  - Uses a hint address inside main compartment private mapping (`main_get_static()` page)
  - Issues non-`MAP_FIXED` anonymous mmap and expects success

This test is deterministic because the hint intentionally targets foreign-compartment-owned space, which old policy always denied and new policy always allows.
