### PR TITLE
Targeted TCB Carveout 

### DIFF
--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -129,8 +129,6 @@ size_t ia2_get_compartment(void) {
   return ia2_get_tag();
 }
 
-void ia2_unprotect_thread_pointer_page(void) {}
-
 // TODO: insert_tag could probably be cleaned up a bit, but I'm not sure if the
 // generated code could be simplified since addg encodes the tag as an imm field
 #define _addg(out_ptr, in_ptr, tag) \

--- a/runtime/libia2/ia2.c
+++ b/runtime/libia2/ia2.c
@@ -97,6 +97,24 @@ size_t ia2_get_compartment(void) {
   }
 }
 
+/*
+ * Keep the page containing the x86_64 thread pointer shared.
+ *
+ * Stack-protector and other ABI-sensitive accesses read %fs-relative data
+ * (for example, %fs:0x28) and must remain valid across compartment PKRU
+ * transitions.
+ */
+void ia2_unprotect_thread_pointer_page(void) {
+  uintptr_t tcb_page =
+      IA2_ROUND_DOWN((uintptr_t)__builtin_thread_pointer(), PAGE_SIZE);
+  int err = ia2_mprotect_with_tag(
+      (void *)tcb_page, PAGE_SIZE, PROT_READ | PROT_WRITE, 0);
+  if (err != 0) {
+    printf("ia2_mprotect_with_tag failed: %s\n", strerror(errno));
+    exit(-1);
+  }
+}
+
 #elif defined(__aarch64__)
 
 static size_t ia2_get_x18(void) {
@@ -110,6 +128,8 @@ size_t ia2_get_tag(void) __attribute__((alias("ia2_get_x18")));
 size_t ia2_get_compartment(void) {
   return ia2_get_tag();
 }
+
+void ia2_unprotect_thread_pointer_page(void) {}
 
 // TODO: insert_tag could probably be cleaned up a bit, but I'm not sure if the
 // generated code could be simplified since addg encodes the tag as an imm field

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -145,6 +145,7 @@ struct dl_phdr_info;
 /// information in the search arguments.
 IA2_EXTERN_C int protect_pages(struct dl_phdr_info *info, size_t size, void *data);
 IA2_EXTERN_C int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data);
+IA2_EXTERN_C void ia2_unprotect_thread_pointer_page(void);
 
 struct IA2SharedSection {
   const void *start;

--- a/runtime/libia2/include/ia2_internal.h
+++ b/runtime/libia2/include/ia2_internal.h
@@ -145,7 +145,9 @@ struct dl_phdr_info;
 /// information in the search arguments.
 IA2_EXTERN_C int protect_pages(struct dl_phdr_info *info, size_t size, void *data);
 IA2_EXTERN_C int protect_tls_pages(struct dl_phdr_info *info, size_t size, void *data);
+#if defined(__x86_64__)
 IA2_EXTERN_C void ia2_unprotect_thread_pointer_page(void);
+#endif
 
 struct IA2SharedSection {
   const void *start;

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -320,6 +320,8 @@ void ia2_start(void) {
       exit(rc);
     }
   }
+#if defined(__x86_64__)
   ia2_unprotect_thread_pointer_page();
+#endif
   mark_init_finished();
 }

--- a/runtime/libia2/init.c
+++ b/runtime/libia2/init.c
@@ -320,5 +320,6 @@ void ia2_start(void) {
       exit(rc);
     }
   }
+  ia2_unprotect_thread_pointer_page();
   mark_init_finished();
 }


### PR DESCRIPTION
# Problem
IA2 retags writable memory (including PT_TLS-backed TLS pages) to compartment pkeys.
On x86_64, the page containing `__builtin_thread_pointer()` (the TCB page addressed through `%fs`) holds process ABI state that can be accessed while different compartment PKRU values are active.

That ABI state includes stack-protector canary reads such as `%fs:0x28`, which occur in normal function prologues/epilogues and are not tied to a single compartment's policy boundary.
If this page remains compartment-tagged, code can fault when execution reaches one of these ABI reads under a PKRU that cannot access that page.

Observed on `main` during single-thread dav1d decode:
- crash site: `dav1d_ref_create+16`
- faulting instruction: `mov %fs:0x28,%rax`
- fault class: PKRU permission failure on `%fs`-relative TCB access

# Fix In This Branch
This branch applies a minimal x86_64-only startup hardening change (and replaces #671):
- Keep existing `protect_tls_pages()` logic unchanged.
- Add `ia2_unprotect_thread_pointer_page()` that:
  - computes `tcb_page = round_down(__builtin_thread_pointer(), PAGE_SIZE)`
  - retags exactly that one page to shared pkey 0 via `ia2_mprotect_with_tag()`
- Call that helper in `ia2_start()` after compartment setup/TLS retagging has run, before init completion.
- Keep AArch64 behavior unchanged (no-op stub for symbol parity).

# What This Branch Accomplishes
- Removes the first strict-mode `dav1d` decode blocker on `main` (the `%fs:0x28` TCB access fault).
- Demonstrates forward progress to the next independent blocker (`__tls_get_addr` / `_rtld_local`).

# How This Differs From #671 
#671 widened runtime TLS policy in `protect_tls_pages()` (bounded multi-page carveout set, sorted carveout walk, per-thread carveout handling, redundant-retag avoidance).

This branch intentionally does **not** do that.
It is a narrower replacement branch that changes only startup TP-page treatment and leaves `protect_tls_pages()` as in `main`.

Practical effect:
- broader branch: attempts a generalized shared-TLS carveout policy
- this branch: fixes only the x86_64 TP-page visibility blocker from first principles
